### PR TITLE
fix: 修复多屏环境下语音输入栏显示在错误屏幕的问题

### DIFF
--- a/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
@@ -31,7 +31,9 @@ final class FloatingBarPanel: NSPanel {
     override var canBecomeMain: Bool { false }
 
     func positionAtBottomCenter() {
-        guard let screen = NSScreen.main else { return }
+        let mouseLocation = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first(where: { $0.frame.contains(mouseLocation) }) ?? NSScreen.main ?? NSScreen.screens.first
+        guard let screen else { return }
         let visible = screen.visibleFrame
         let x = visible.midX - frame.width / 2
         let y = visible.origin.y + TF.barBottomOffset - 16  // compensate for shadow inset


### PR DESCRIPTION
## 问题 / Problem

多屏环境下，语音输入浮动栏始终显示在 app 窗口所在的屏幕，而非用户鼠标所在的屏幕。

In multi-monitor setups, the floating voice input bar always appeared on the screen containing the app's key window, not the screen where the mouse cursor is.

## 原因 / Root Cause

`FloatingBarPanel.positionAtBottomCenter()` 使用了 `NSScreen.main`，该属性返回包含 key window 的屏幕，而非鼠标所在屏幕。

`NSScreen.main` returns the screen containing the key window, not the screen with the mouse cursor.

## 修复 / Fix

改为通过 `NSEvent.mouseLocation` 获取鼠标坐标，遍历 `NSScreen.screens` 找到鼠标所在屏幕进行定位。

Uses `NSEvent.mouseLocation` to find which screen the cursor is on, then positions the bar on that screen.

## 测试 / Test Plan

- [x] 在多屏环境下，将鼠标移到副屏，触发语音输入，浮动栏显示在副屏底部中央
- [x] 单屏环境下行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)
