### PR TITLE
Strip think tags from LLM responses before injection

### DIFF
--- a/Type4Me/LLM/ClaudeChatClient.swift
+++ b/Type4Me/LLM/ClaudeChatClient.swift
@@ -74,7 +74,11 @@ actor ClaudeChatClient: LLMClient {
         }
 
         logger.info("Claude result: \(result.count) chars")
-        return result
+
+        let stripped = result
+            .replacingOccurrences(of: "<think>[\\s\\S]*?<\\/think>", with: "", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return stripped
     }
 }
 

--- a/Type4Me/LLM/DoubaoChatClient.swift
+++ b/Type4Me/LLM/DoubaoChatClient.swift
@@ -65,7 +65,11 @@ actor DoubaoChatClient: LLMClient {
         }
 
         logger.info("LLM result: \(result.count) chars")
-        return result
+
+        let stripped = result
+            .replacingOccurrences(of: "<think>[\\s\\S]*?<\\/think>", with: "", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return stripped
     }
 }
 


### PR DESCRIPTION
部分LLM翻译的时候会返回<think>思维链，需要删除。