### PR TITLE
feat: Bailian ASR + think-tag 修复 + review fixes

### DIFF
--- a/Type4Me/ASR/ASRProvider.swift
+++ b/Type4Me/ASR/ASRProvider.swift
@@ -14,6 +14,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
     // China
     case volcano
     case aliyun
+    case bailian
     case tencent
     case iflytek
     // Fallback
@@ -29,6 +30,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
         case .deepgram: return "Deepgram"
         case .volcano:  return L("火山引擎 (Doubao)", "Volcano (Doubao)")
         case .aliyun:   return L("阿里云", "Alibaba Cloud")
+        case .bailian:  return L("阿里云百炼", "Alibaba Cloud Bailian")
         case .tencent:  return L("腾讯云", "Tencent Cloud")
         case .iflytek:  return L("讯飞", "iFLYTEK")
         case .custom:   return L("自定义", "Custom")

--- a/Type4Me/ASR/ASRProvider.swift
+++ b/Type4Me/ASR/ASRProvider.swift
@@ -12,6 +12,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
     // China
     case volcano
     case aliyun
+    case bailian
     case tencent
     case iflytek
     // Fallback
@@ -26,6 +27,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
         case .deepgram: return "Deepgram"
         case .volcano:  return L("火山引擎 (Doubao)", "Volcano (Doubao)")
         case .aliyun:   return L("阿里云", "Alibaba Cloud")
+        case .bailian:  return L("阿里云百炼", "Alibaba Cloud Bailian")
         case .tencent:  return L("腾讯云", "Tencent Cloud")
         case .iflytek:  return L("讯飞", "iFLYTEK")
         case .custom:   return L("自定义", "Custom")

--- a/Type4Me/ASR/ASRProviderRegistry.swift
+++ b/Type4Me/ASR/ASRProviderRegistry.swift
@@ -1,25 +1,101 @@
 import Foundation
 
+struct ASRProviderCapabilities: Sendable, Equatable {
+    let supportsQuickMode: Bool
+    let supportsPerformanceMode: Bool
+    let performanceModeReason: String?
+
+    static let full = ASRProviderCapabilities(
+        supportsQuickMode: true,
+        supportsPerformanceMode: true,
+        performanceModeReason: nil
+    )
+
+    static let quickOnly = ASRProviderCapabilities(
+        supportsQuickMode: true,
+        supportsPerformanceMode: false,
+        performanceModeReason: L(
+            "当前引擎仅支持实时识别，不支持整段识别。",
+            "This engine only supports real-time recognition, not full-audio recognition."
+        )
+    )
+
+    static let unavailable = ASRProviderCapabilities(
+        supportsQuickMode: false,
+        supportsPerformanceMode: false,
+        performanceModeReason: L(
+            "当前引擎尚未提供可用的语音识别实现。",
+            "This engine does not currently provide an available speech recognition implementation."
+        )
+    )
+}
+
 enum ASRProviderRegistry {
 
     struct ProviderEntry: Sendable {
         let configType: any ASRProviderConfig.Type
         let createClient: (@Sendable () -> any SpeechRecognizer)?
+        let capabilities: ASRProviderCapabilities
 
         var isAvailable: Bool { createClient != nil }
     }
 
     static let all: [ASRProvider: ProviderEntry] = [
-        .volcano: ProviderEntry(configType: VolcanoASRConfig.self, createClient: { VolcASRClient() }),
-        .openai:  ProviderEntry(configType: OpenAIASRConfig.self,  createClient: nil),
-        .azure:   ProviderEntry(configType: AzureASRConfig.self,   createClient: nil),
-        .google:  ProviderEntry(configType: GoogleASRConfig.self,  createClient: nil),
-        .aws:     ProviderEntry(configType: AWSASRConfig.self,     createClient: nil),
-        .deepgram: ProviderEntry(configType: DeepgramASRConfig.self, createClient: { DeepgramASRClient() }),
-        .aliyun:  ProviderEntry(configType: AliyunASRConfig.self,  createClient: nil),
-        .tencent: ProviderEntry(configType: TencentASRConfig.self, createClient: nil),
-        .iflytek: ProviderEntry(configType: IflytekASRConfig.self, createClient: nil),
-        .custom:  ProviderEntry(configType: CustomASRConfig.self,  createClient: nil),
+        .volcano: ProviderEntry(
+            configType: VolcanoASRConfig.self,
+            createClient: { VolcASRClient() },
+            capabilities: .full
+        ),
+        .openai: ProviderEntry(
+            configType: OpenAIASRConfig.self,
+            createClient: nil,
+            capabilities: .unavailable
+        ),
+        .azure: ProviderEntry(
+            configType: AzureASRConfig.self,
+            createClient: nil,
+            capabilities: .unavailable
+        ),
+        .google: ProviderEntry(
+            configType: GoogleASRConfig.self,
+            createClient: nil,
+            capabilities: .unavailable
+        ),
+        .aws: ProviderEntry(
+            configType: AWSASRConfig.self,
+            createClient: nil,
+            capabilities: .unavailable
+        ),
+        .deepgram: ProviderEntry(
+            configType: DeepgramASRConfig.self,
+            createClient: { DeepgramASRClient() },
+            capabilities: .quickOnly
+        ),
+        .aliyun: ProviderEntry(
+            configType: AliyunASRConfig.self,
+            createClient: nil,
+            capabilities: .unavailable
+        ),
+        .bailian: ProviderEntry(
+            configType: BailianASRConfig.self,
+            createClient: { BailianASRClient() },
+            capabilities: .quickOnly
+        ),
+        .tencent: ProviderEntry(
+            configType: TencentASRConfig.self,
+            createClient: nil,
+            capabilities: .unavailable
+        ),
+        .iflytek: ProviderEntry(
+            configType: IflytekASRConfig.self,
+            createClient: nil,
+            capabilities: .unavailable
+        ),
+        .custom: ProviderEntry(
+            configType: CustomASRConfig.self,
+            createClient: nil,
+            capabilities: .unavailable
+        ),
     ]
 
     static func entry(for provider: ASRProvider) -> ProviderEntry? {
@@ -32,5 +108,55 @@ enum ASRProviderRegistry {
 
     static func createClient(for provider: ASRProvider) -> (any SpeechRecognizer)? {
         all[provider]?.createClient?()
+    }
+
+    static func capabilities(for provider: ASRProvider) -> ASRProviderCapabilities {
+        all[provider]?.capabilities ?? .unavailable
+    }
+
+    static func supports(_ mode: ProcessingMode, for provider: ASRProvider) -> Bool {
+        let capabilities = capabilities(for: provider)
+
+        guard capabilities.supportsQuickMode else { return false }
+        if mode.id == ProcessingMode.performanceId {
+            return capabilities.supportsPerformanceMode
+        }
+        if mode.id == ProcessingMode.directId {
+            return capabilities.supportsQuickMode
+        }
+        return true
+    }
+
+    static func supportedModes(from modes: [ProcessingMode], for provider: ASRProvider) -> [ProcessingMode] {
+        modes.filter { supports($0, for: provider) }
+    }
+
+    static func resolvedMode(for mode: ProcessingMode, provider: ASRProvider) -> ProcessingMode {
+        supports(mode, for: provider) ? mode : .direct
+    }
+
+    static func unsupportedReason(for mode: ProcessingMode, provider: ASRProvider) -> String? {
+        guard !supports(mode, for: provider) else { return nil }
+
+        if mode.id == ProcessingMode.performanceId {
+            return capabilities(for: provider).performanceModeReason
+        }
+
+        return L(
+            "当前引擎不可用于此模式。",
+            "This engine is not available for this mode."
+        )
+    }
+
+    static func supportedModesSummary(for provider: ASRProvider) -> String {
+        let capabilities = capabilities(for: provider)
+        switch (capabilities.supportsQuickMode, capabilities.supportsPerformanceMode) {
+        case (true, true):
+            return L("支持：快速模式、性能模式", "Supports: Quick Mode, Performance Mode")
+        case (true, false):
+            return L("支持：快速模式", "Supports: Quick Mode")
+        default:
+            return L("支持：无", "Supports: None")
+        }
     }
 }

--- a/Type4Me/ASR/ASRProviderRegistry.swift
+++ b/Type4Me/ASR/ASRProviderRegistry.swift
@@ -1,27 +1,57 @@
 import Foundation
 
+struct ASRProviderCapabilities: Sendable, Equatable {
+    let supportsQuickMode: Bool
+    let supportsPerformanceMode: Bool
+    let performanceModeReason: String?
+
+    static let full = ASRProviderCapabilities(
+        supportsQuickMode: true,
+        supportsPerformanceMode: true,
+        performanceModeReason: nil
+    )
+
+    static let quickOnly = ASRProviderCapabilities(
+        supportsQuickMode: true,
+        supportsPerformanceMode: false,
+        performanceModeReason: L(
+            "当前引擎仅支持实时识别，不支持整段识别。",
+            "This engine only supports real-time recognition, not full-audio recognition."
+        )
+    )
+
+    static let unavailable = ASRProviderCapabilities(
+        supportsQuickMode: false,
+        supportsPerformanceMode: false,
+        performanceModeReason: L(
+            "当前引擎尚未提供可用的语音识别实现。",
+            "This engine does not currently provide an available speech recognition implementation."
+        )
+    )
+}
+
 enum ASRProviderRegistry {
 
     struct ProviderEntry: Sendable {
         let configType: any ASRProviderConfig.Type
         let createClient: (@Sendable () -> any SpeechRecognizer)?
+        let capabilities: ASRProviderCapabilities
 
         /// Factory for creating an offline (one-shot) recognizer for dual-channel mode.
-        /// Providers that support dual-channel return a non-nil closure.
         let offlineRecognize: (@Sendable (Data, any ASRProviderConfig) async throws -> String)?
 
         var isAvailable: Bool { createClient != nil }
-
-        /// Whether this provider supports dual-channel (streaming + offline) mode.
         var supportsDualChannel: Bool { offlineRecognize != nil }
 
         init(
             configType: any ASRProviderConfig.Type,
             createClient: (@Sendable () -> any SpeechRecognizer)?,
+            capabilities: ASRProviderCapabilities = .unavailable,
             offlineRecognize: (@Sendable (Data, any ASRProviderConfig) async throws -> String)? = nil
         ) {
             self.configType = configType
             self.createClient = createClient
+            self.capabilities = capabilities
             self.offlineRecognize = offlineRecognize
         }
     }
@@ -31,6 +61,7 @@ enum ASRProviderRegistry {
             .volcano: ProviderEntry(
                 configType: VolcanoASRConfig.self,
                 createClient: { VolcASRClient() },
+                capabilities: .full,
                 offlineRecognize: { pcmData, config in
                     guard let volcConfig = config as? VolcanoASRConfig else {
                         throw VolcFlashASRError.missingCredentials
@@ -38,11 +69,20 @@ enum ASRProviderRegistry {
                     return try await VolcFlashASRClient.recognize(pcmData: pcmData, config: volcConfig)
                 }
             ),
+            .deepgram: ProviderEntry(
+                configType: DeepgramASRConfig.self,
+                createClient: { DeepgramASRClient() },
+                capabilities: .quickOnly
+            ),
+            .bailian: ProviderEntry(
+                configType: BailianASRConfig.self,
+                createClient: { BailianASRClient() },
+                capabilities: .quickOnly
+            ),
             .openai:  ProviderEntry(configType: OpenAIASRConfig.self,  createClient: nil),
             .azure:   ProviderEntry(configType: AzureASRConfig.self,   createClient: nil),
             .google:  ProviderEntry(configType: GoogleASRConfig.self,  createClient: nil),
             .aws:     ProviderEntry(configType: AWSASRConfig.self,     createClient: nil),
-            .deepgram: ProviderEntry(configType: DeepgramASRConfig.self, createClient: { DeepgramASRClient() }),
             .aliyun:  ProviderEntry(configType: AliyunASRConfig.self,  createClient: nil),
             .tencent: ProviderEntry(configType: TencentASRConfig.self, createClient: nil),
             .iflytek: ProviderEntry(configType: IflytekASRConfig.self, createClient: nil),
@@ -52,6 +92,7 @@ enum ASRProviderRegistry {
         dict[.sherpa] = ProviderEntry(
             configType: SherpaASRConfig.self,
             createClient: { SherpaASRClient() },
+            capabilities: .full,
             offlineRecognize: { pcmData, config in
                 guard let sherpaConfig = config as? SherpaASRConfig else {
                     throw SherpaOfflineASRError.modelNotFound("Invalid config type")
@@ -75,5 +116,54 @@ enum ASRProviderRegistry {
 
     static func createClient(for provider: ASRProvider) -> (any SpeechRecognizer)? {
         all[provider]?.createClient?()
+    }
+
+    static func capabilities(for provider: ASRProvider) -> ASRProviderCapabilities {
+        all[provider]?.capabilities ?? .unavailable
+    }
+
+    static func supports(_ mode: ProcessingMode, for provider: ASRProvider) -> Bool {
+        let capabilities = capabilities(for: provider)
+        if mode.id == ProcessingMode.performanceId {
+            return capabilities.supportsPerformanceMode
+        }
+        if mode.id == ProcessingMode.directId {
+            return capabilities.supportsQuickMode
+        }
+        // Custom/LLM modes are always allowed regardless of provider capabilities
+        return true
+    }
+
+    static func supportedModes(from modes: [ProcessingMode], for provider: ASRProvider) -> [ProcessingMode] {
+        modes.filter { supports($0, for: provider) }
+    }
+
+    static func resolvedMode(for mode: ProcessingMode, provider: ASRProvider) -> ProcessingMode {
+        supports(mode, for: provider) ? mode : .direct
+    }
+
+    static func unsupportedReason(for mode: ProcessingMode, provider: ASRProvider) -> String? {
+        guard !supports(mode, for: provider) else { return nil }
+
+        if mode.id == ProcessingMode.performanceId {
+            return capabilities(for: provider).performanceModeReason
+        }
+
+        return L(
+            "当前引擎不可用于此模式。",
+            "This engine is not available for this mode."
+        )
+    }
+
+    static func supportedModesSummary(for provider: ASRProvider) -> String {
+        let capabilities = capabilities(for: provider)
+        switch (capabilities.supportsQuickMode, capabilities.supportsPerformanceMode) {
+        case (true, true):
+            return L("支持：快速模式、性能模式", "Supports: Quick Mode, Performance Mode")
+        case (true, false):
+            return L("支持：快速模式", "Supports: Quick Mode")
+        default:
+            return L("支持：无", "Supports: None")
+        }
     }
 }

--- a/Type4Me/ASR/BailianASRClient.swift
+++ b/Type4Me/ASR/BailianASRClient.swift
@@ -1,0 +1,291 @@
+import Foundation
+import os
+
+enum BailianASRError: Error, LocalizedError {
+    case unsupportedProvider
+    case handshakeTimedOut
+    case closedBeforeTaskStart(code: Int, reason: String?)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedProvider:
+            return "BailianASRClient requires BailianASRConfig"
+        case .handshakeTimedOut:
+            return "Alibaba Cloud Bailian task-start handshake timed out"
+        case .closedBeforeTaskStart(let code, let reason):
+            if let reason, !reason.isEmpty {
+                return "Alibaba Cloud Bailian socket closed before task-started (\(code)): \(reason)"
+            }
+            return "Alibaba Cloud Bailian socket closed before task-started (\(code))"
+        }
+    }
+}
+
+actor BailianASRClient: SpeechRecognizer {
+
+    private let logger = Logger(
+        subsystem: "com.type4me.asr",
+        category: "BailianASRClient"
+    )
+
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var receiveTask: Task<Void, Never>?
+    private var session: URLSession?
+    private var sessionDelegate: BailianWebSocketDelegate?
+    private var taskStartGate: BailianTaskStartGate?
+
+    private var eventContinuation: AsyncStream<RecognitionEvent>.Continuation?
+    private var _events: AsyncStream<RecognitionEvent>?
+
+    private var confirmedSegments: [String] = []
+    private var lastTranscript: RecognitionTranscript = .empty
+    private var audioPacketCount = 0
+    private var didRequestFinish = false
+    private var currentTaskID: String?
+
+    var events: AsyncStream<RecognitionEvent> {
+        if let existing = _events {
+            return existing
+        }
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        eventContinuation = continuation
+        _events = stream
+        return stream
+    }
+
+    func connect(config: any ASRProviderConfig, options: ASRRequestOptions = ASRRequestOptions()) async throws {
+        guard let bailianConfig = config as? BailianASRConfig else {
+            throw BailianASRError.unsupportedProvider
+        }
+
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        eventContinuation = continuation
+        _events = stream
+
+        var request = URLRequest(url: BailianProtocol.endpoint)
+        request.setValue("Bearer \(bailianConfig.apiKey)", forHTTPHeaderField: "Authorization")
+
+        let taskID = UUID().uuidString.lowercased()
+        let gate = BailianTaskStartGate()
+        let delegate = BailianWebSocketDelegate(taskStartGate: gate)
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        let task = session.webSocketTask(with: request)
+        task.resume()
+
+        sessionDelegate = delegate
+        self.session = session
+        webSocketTask = task
+        taskStartGate = gate
+        confirmedSegments = []
+        lastTranscript = .empty
+        audioPacketCount = 0
+        didRequestFinish = false
+        currentTaskID = taskID
+
+        startReceiveLoop()
+
+        let runTaskMessage = BailianProtocol.buildRunTaskMessage(
+            config: bailianConfig,
+            options: options,
+            taskID: taskID
+        )
+        try await task.send(.string(runTaskMessage))
+        try await gate.waitUntilStarted(timeout: .seconds(5))
+        logger.info("Alibaba Cloud Bailian ASR task started")
+    }
+
+    func sendAudio(_ data: Data) async throws {
+        guard let task = webSocketTask else { return }
+        audioPacketCount += 1
+        try await task.send(.data(data))
+    }
+
+    func endAudio() async throws {
+        guard let task = webSocketTask,
+              let taskID = currentTaskID
+        else { return }
+
+        didRequestFinish = true
+        try await task.send(.string(BailianProtocol.buildFinishTaskMessage(taskID: taskID)))
+    }
+
+    func disconnect() {
+        receiveTask?.cancel()
+        receiveTask = nil
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        webSocketTask = nil
+        session?.invalidateAndCancel()
+        session = nil
+        sessionDelegate = nil
+        taskStartGate = nil
+        eventContinuation?.finish()
+        eventContinuation = nil
+        _events = nil
+        confirmedSegments = []
+        lastTranscript = .empty
+        audioPacketCount = 0
+        didRequestFinish = false
+        currentTaskID = nil
+        logger.info("Alibaba Cloud Bailian disconnected")
+    }
+
+    private func startReceiveLoop() {
+        receiveTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                do {
+                    guard let task = await self.webSocketTask else { break }
+                    let message = try await task.receive()
+                    await self.handleMessage(message)
+                } catch {
+                    if Task.isCancelled {
+                        break
+                    }
+
+                    let gate = await self.taskStartGate
+                    let gateStarted = await gate?.hasStarted ?? false
+                    let didRequestFinish = await self.didRequestFinish
+                    let audioPacketCount = await self.audioPacketCount
+
+                    if let gate, !gateStarted {
+                        await gate.markFailure(error)
+                    } else if didRequestFinish || audioPacketCount > 0 {
+                        await self.emitEvent(.completed)
+                    } else {
+                        await self.emitEvent(.error(error))
+                        await self.emitEvent(.completed)
+                    }
+                    break
+                }
+            }
+
+            let continuation = await self.eventContinuation
+            continuation?.finish()
+        }
+    }
+
+    private func handleMessage(_ message: URLSessionWebSocketTask.Message) async {
+        do {
+            let data: Data
+            switch message {
+            case .data(let payload):
+                data = payload
+            case .string(let text):
+                data = Data(text.utf8)
+            @unknown default:
+                return
+            }
+
+            guard let event = try BailianProtocol.parseServerEvent(
+                from: data,
+                confirmedSegments: confirmedSegments
+            ) else {
+                return
+            }
+
+            switch event {
+            case .taskStarted:
+                if let gate = taskStartGate {
+                    await gate.markStarted()
+                }
+
+            case .transcript(let update):
+                confirmedSegments = update.confirmedSegments
+                guard update.transcript != lastTranscript else { return }
+                lastTranscript = update.transcript
+                emitEvent(.transcript(update.transcript))
+
+            case .taskFinished:
+                emitEvent(.completed)
+
+            case .taskFailed(let code, let message):
+                let error = BailianProtocolError.taskFailed(code: code, message: message)
+                if let gate = taskStartGate {
+                    await gate.markFailure(error)
+                }
+                emitEvent(.error(error))
+                emitEvent(.completed)
+                webSocketTask?.cancel(with: .normalClosure, reason: nil)
+                webSocketTask = nil
+            }
+        } catch {
+            if let gate = taskStartGate {
+                await gate.markFailure(error)
+            }
+            emitEvent(.error(error))
+        }
+    }
+
+    private func emitEvent(_ event: RecognitionEvent) {
+        eventContinuation?.yield(event)
+    }
+}
+
+private actor BailianTaskStartGate {
+
+    private var continuation: CheckedContinuation<Void, Error>?
+    private(set) var isStarted = false
+    private var failure: Error?
+
+    var hasStarted: Bool { isStarted }
+
+    func waitUntilStarted(timeout: Duration) async throws {
+        let timeoutTask = Task {
+            try? await Task.sleep(for: timeout)
+            self.markFailure(BailianASRError.handshakeTimedOut)
+        }
+
+        defer { timeoutTask.cancel() }
+        try await wait()
+    }
+
+    func markStarted() {
+        guard !isStarted else { return }
+        isStarted = true
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func markFailure(_ error: Error) {
+        guard !isStarted, failure == nil else { return }
+        failure = error
+        continuation?.resume(throwing: error)
+        continuation = nil
+    }
+
+    private func wait() async throws {
+        if isStarted { return }
+        if let failure { throw failure }
+
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+}
+
+private final class BailianWebSocketDelegate: NSObject, URLSessionWebSocketDelegate {
+
+    private let taskStartGate: BailianTaskStartGate
+
+    init(taskStartGate: BailianTaskStartGate) {
+        self.taskStartGate = taskStartGate
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
+        reason: Data?
+    ) {
+        let reasonText = reason.flatMap { String(data: $0, encoding: .utf8) }
+        Task {
+            guard await !taskStartGate.hasStarted else { return }
+            await taskStartGate.markFailure(
+                BailianASRError.closedBeforeTaskStart(
+                    code: Int(closeCode.rawValue),
+                    reason: reasonText
+                )
+            )
+        }
+    }
+}

--- a/Type4Me/ASR/BailianASRClient.swift
+++ b/Type4Me/ASR/BailianASRClient.swift
@@ -1,0 +1,291 @@
+import Foundation
+import os
+
+enum BailianASRError: Error, LocalizedError {
+    case unsupportedProvider
+    case handshakeTimedOut
+    case closedBeforeTaskStart(code: Int, reason: String?)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedProvider:
+            return "BailianASRClient requires BailianASRConfig"
+        case .handshakeTimedOut:
+            return "Alibaba Cloud Bailian task-start handshake timed out"
+        case .closedBeforeTaskStart(let code, let reason):
+            if let reason, !reason.isEmpty {
+                return "Alibaba Cloud Bailian socket closed before task-started (\(code)): \(reason)"
+            }
+            return "Alibaba Cloud Bailian socket closed before task-started (\(code))"
+        }
+    }
+}
+
+actor BailianASRClient: SpeechRecognizer {
+
+    private let logger = Logger(
+        subsystem: "com.type4me.asr",
+        category: "BailianASRClient"
+    )
+
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var receiveTask: Task<Void, Never>?
+    private var session: URLSession?
+    private var sessionDelegate: BailianWebSocketDelegate?
+    private var taskStartGate: BailianTaskStartGate?
+
+    private var eventContinuation: AsyncStream<RecognitionEvent>.Continuation?
+    private var _events: AsyncStream<RecognitionEvent>?
+
+    private var confirmedSegments: [String] = []
+    private var lastTranscript: RecognitionTranscript = .empty
+    private var audioPacketCount = 0
+    private var didRequestFinish = false
+    private var currentTaskID: String?
+
+    var events: AsyncStream<RecognitionEvent> {
+        if let existing = _events {
+            return existing
+        }
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        eventContinuation = continuation
+        _events = stream
+        return stream
+    }
+
+    func connect(config: any ASRProviderConfig, options: ASRRequestOptions = ASRRequestOptions()) async throws {
+        guard let bailianConfig = config as? BailianASRConfig else {
+            throw BailianASRError.unsupportedProvider
+        }
+
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        eventContinuation = continuation
+        _events = stream
+
+        var request = URLRequest(url: BailianProtocol.endpoint)
+        request.setValue("Bearer \(bailianConfig.apiKey)", forHTTPHeaderField: "Authorization")
+
+        let taskID = UUID().uuidString.lowercased()
+        let gate = BailianTaskStartGate()
+        let delegate = BailianWebSocketDelegate(taskStartGate: gate)
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        let task = session.webSocketTask(with: request)
+        task.resume()
+
+        sessionDelegate = delegate
+        self.session = session
+        webSocketTask = task
+        taskStartGate = gate
+        confirmedSegments = []
+        lastTranscript = .empty
+        audioPacketCount = 0
+        didRequestFinish = false
+        currentTaskID = taskID
+
+        startReceiveLoop()
+
+        let runTaskMessage = BailianProtocol.buildRunTaskMessage(
+            config: bailianConfig,
+            options: options,
+            taskID: taskID
+        )
+        try await task.send(.string(runTaskMessage))
+        try await gate.waitUntilStarted(timeout: .seconds(5))
+        logger.info("Alibaba Cloud Bailian ASR task started")
+    }
+
+    func sendAudio(_ data: Data) async throws {
+        guard let task = webSocketTask else { return }
+        audioPacketCount += 1
+        try await task.send(.data(data))
+    }
+
+    func endAudio() async throws {
+        guard let task = webSocketTask,
+              let taskID = currentTaskID
+        else { return }
+
+        didRequestFinish = true
+        try await task.send(.string(BailianProtocol.buildFinishTaskMessage(taskID: taskID)))
+    }
+
+    func disconnect() {
+        receiveTask?.cancel()
+        receiveTask = nil
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        webSocketTask = nil
+        session?.invalidateAndCancel()
+        session = nil
+        sessionDelegate = nil
+        taskStartGate = nil
+        eventContinuation?.finish()
+        eventContinuation = nil
+        _events = nil
+        confirmedSegments = []
+        lastTranscript = .empty
+        audioPacketCount = 0
+        didRequestFinish = false
+        currentTaskID = nil
+        logger.info("Alibaba Cloud Bailian disconnected")
+    }
+
+    private func startReceiveLoop() {
+        receiveTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                do {
+                    guard let task = await self.webSocketTask else { break }
+                    let message = try await task.receive()
+                    await self.handleMessage(message)
+                } catch {
+                    if Task.isCancelled {
+                        break
+                    }
+
+                    let gate = await self.taskStartGate
+                    let gateStarted = await gate?.hasStarted ?? false
+                    let didRequestFinish = await self.didRequestFinish
+                    let audioPacketCount = await self.audioPacketCount
+
+                    if let gate, !gateStarted {
+                        await gate.markFailure(error)
+                    } else if didRequestFinish || audioPacketCount > 0 {
+                        await self.emitEvent(.completed)
+                    } else {
+                        await self.emitEvent(.error(error))
+                        await self.emitEvent(.completed)
+                    }
+                    break
+                }
+            }
+
+            let continuation = await self.eventContinuation
+            continuation?.finish()
+        }
+    }
+
+    private func handleMessage(_ message: URLSessionWebSocketTask.Message) async {
+        do {
+            let data: Data
+            switch message {
+            case .data(let payload):
+                data = payload
+            case .string(let text):
+                data = Data(text.utf8)
+            @unknown default:
+                return
+            }
+
+            guard let event = try BailianProtocol.parseServerEvent(
+                from: data,
+                confirmedSegments: confirmedSegments
+            ) else {
+                return
+            }
+
+            switch event {
+            case .taskStarted:
+                if let gate = taskStartGate {
+                    await gate.markStarted()
+                }
+
+            case .transcript(let update):
+                confirmedSegments = update.confirmedSegments
+                guard update.transcript != lastTranscript else { return }
+                lastTranscript = update.transcript
+                emitEvent(.transcript(update.transcript))
+
+            case .taskFinished:
+                emitEvent(.completed)
+
+            case .taskFailed(let code, let message):
+                let error = BailianProtocolError.taskFailed(code: code, message: message)
+                if let gate = taskStartGate {
+                    await gate.markFailure(error)
+                }
+                emitEvent(.error(error))
+                emitEvent(.completed)
+                webSocketTask?.cancel(with: .normalClosure, reason: nil)
+                webSocketTask = nil
+            }
+        } catch {
+            if let gate = taskStartGate {
+                await gate.markFailure(error)
+            }
+            emitEvent(.error(error))
+        }
+    }
+
+    private func emitEvent(_ event: RecognitionEvent) {
+        eventContinuation?.yield(event)
+    }
+}
+
+private actor BailianTaskStartGate {
+
+    private var continuation: CheckedContinuation<Void, Error>?
+    private(set) var isStarted = false
+    private var failure: Error?
+
+    var hasStarted: Bool { isStarted }
+
+    func waitUntilStarted(timeout: Duration) async throws {
+        let timeoutTask = Task {
+            try? await Task.sleep(for: timeout)
+            await self.markFailure(BailianASRError.handshakeTimedOut)
+        }
+
+        defer { timeoutTask.cancel() }
+        try await wait()
+    }
+
+    func markStarted() {
+        guard !isStarted else { return }
+        isStarted = true
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func markFailure(_ error: Error) {
+        guard !isStarted, failure == nil else { return }
+        failure = error
+        continuation?.resume(throwing: error)
+        continuation = nil
+    }
+
+    private func wait() async throws {
+        if isStarted { return }
+        if let failure { throw failure }
+
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+}
+
+private final class BailianWebSocketDelegate: NSObject, URLSessionWebSocketDelegate {
+
+    private let taskStartGate: BailianTaskStartGate
+
+    init(taskStartGate: BailianTaskStartGate) {
+        self.taskStartGate = taskStartGate
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
+        reason: Data?
+    ) {
+        let reasonText = reason.flatMap { String(data: $0, encoding: .utf8) }
+        Task {
+            guard await !taskStartGate.hasStarted else { return }
+            await taskStartGate.markFailure(
+                BailianASRError.closedBeforeTaskStart(
+                    code: Int(closeCode.rawValue),
+                    reason: reasonText
+                )
+            )
+        }
+    }
+}

--- a/Type4Me/ASR/Providers/BailianASRConfig.swift
+++ b/Type4Me/ASR/Providers/BailianASRConfig.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+struct BailianASRConfig: ASRProviderConfig, Sendable {
+
+    static let provider = ASRProvider.bailian
+    static let displayName = L("阿里云百炼", "Alibaba Cloud Bailian")
+    static let defaultModel = "fun-asr-realtime"
+    static let supportedLanguageHints = ["zh", "en", "ja"]
+
+    static var credentialFields: [CredentialField] {[
+        CredentialField(
+            key: "apiKey",
+            label: "API Key",
+            placeholder: "sk-...",
+            isSecure: true,
+            isOptional: false,
+            defaultValue: ""
+        ),
+        CredentialField(
+            key: "model",
+            label: "Model",
+            placeholder: defaultModel,
+            isSecure: false,
+            isOptional: false,
+            defaultValue: defaultModel
+        ),
+        CredentialField(
+            key: "deviceId",
+            label: "Device ID",
+            placeholder: L("客户端唯一标识", "Stable client identifier"),
+            isSecure: false,
+            isOptional: true,
+            defaultValue: ASRIdentityStore.loadOrCreateUID()
+        ),
+        CredentialField(
+            key: "languageHint",
+            label: "Language Hint",
+            placeholder: "zh / en / ja",
+            isSecure: false,
+            isOptional: true,
+            defaultValue: ""
+        ),
+        CredentialField(
+            key: "vocabularyId",
+            label: "Vocabulary ID",
+            placeholder: L("热词词表 ID", "Hotword vocabulary ID"),
+            isSecure: false,
+            isOptional: true,
+            defaultValue: ""
+        ),
+    ]}
+
+    let apiKey: String
+    let model: String
+    let deviceId: String
+    let languageHint: String
+    let vocabularyId: String
+
+    init?(credentials: [String: String]) {
+        guard let apiKey = Self.sanitized(credentials["apiKey"]),
+              !apiKey.isEmpty
+        else { return nil }
+
+        self.apiKey = apiKey
+        self.model = Self.sanitized(credentials["model"]) ?? Self.defaultModel
+        self.deviceId = Self.sanitized(credentials["deviceId"]) ?? ASRIdentityStore.loadOrCreateUID()
+
+        let rawLanguageHint = Self.sanitized(credentials["languageHint"])?.lowercased() ?? ""
+        self.languageHint = Self.supportedLanguageHints.contains(rawLanguageHint) ? rawLanguageHint : ""
+        self.vocabularyId = Self.sanitized(credentials["vocabularyId"]) ?? ""
+    }
+
+    func toCredentials() -> [String: String] {
+        [
+            "apiKey": apiKey,
+            "model": model,
+            "deviceId": deviceId,
+            "languageHint": languageHint,
+            "vocabularyId": vocabularyId,
+        ]
+    }
+
+    var isValid: Bool {
+        !apiKey.isEmpty && !model.isEmpty && !deviceId.isEmpty
+    }
+
+    private static func sanitized(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Type4Me/LLM/ClaudeChatClient.swift
+++ b/Type4Me/LLM/ClaudeChatClient.swift
@@ -75,10 +75,7 @@ actor ClaudeChatClient: LLMClient {
 
         logger.info("Claude result: \(result.count) chars")
 
-        let stripped = result
-            .replacingOccurrences(of: "<think>[\\s\\S]*?<\\/think>", with: "", options: .regularExpression)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return stripped
+        return result.strippingThinkTags()
     }
 }
 

--- a/Type4Me/LLM/DoubaoChatClient.swift
+++ b/Type4Me/LLM/DoubaoChatClient.swift
@@ -71,10 +71,7 @@ actor DoubaoChatClient: LLMClient {
 
         logger.info("LLM result: \(result.count) chars")
 
-        let stripped = result
-            .replacingOccurrences(of: "<think>[\\s\\S]*?<\\/think>", with: "", options: .regularExpression)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return stripped
+        return result.strippingThinkTags()
     }
 }
 

--- a/Type4Me/LLM/LLMClient.swift
+++ b/Type4Me/LLM/LLMClient.swift
@@ -5,3 +5,14 @@ protocol LLMClient: Sendable {
     func process(text: String, prompt: String, config: LLMConfig) async throws -> String
     func warmUp(baseURL: String) async
 }
+
+extension String {
+    /// Remove `<think>...</think>` reasoning blocks emitted by models like DeepSeek.
+    /// Handles both closed tags and unclosed/truncated tags.
+    func strippingThinkTags() -> String {
+        self
+            .replacingOccurrences(of: "<think>[\\s\\S]*?</think>", with: "", options: .regularExpression)
+            .replacingOccurrences(of: "<think>[\\s\\S]*$", with: "", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Type4Me/Protocol/BailianProtocol.swift
+++ b/Type4Me/Protocol/BailianProtocol.swift
@@ -1,0 +1,259 @@
+import Foundation
+
+enum BailianProtocolError: Error, LocalizedError, Equatable {
+    case invalidMessage
+    case taskFailed(code: String?, message: String?)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidMessage:
+            return "Invalid Alibaba Cloud Bailian ASR message"
+        case .taskFailed(let code, let message):
+            let codePart = code?.isEmpty == false ? "[\(code!)] " : ""
+            let messagePart = message?.isEmpty == false ? message! : "Task failed"
+            return "Alibaba Cloud Bailian ASR failed: \(codePart)\(messagePart)"
+        }
+    }
+}
+
+struct BailianTranscriptUpdate: Sendable, Equatable {
+    let transcript: RecognitionTranscript
+    let confirmedSegments: [String]
+}
+
+enum BailianServerEvent: Sendable, Equatable {
+    case taskStarted(taskID: String?)
+    case transcript(BailianTranscriptUpdate)
+    case taskFinished(taskID: String?)
+    case taskFailed(code: String?, message: String?)
+}
+
+enum BailianProtocol {
+
+    static let endpoint = URL(string: "wss://dashscope.aliyuncs.com/api-ws/v1/inference")!
+
+    static func buildRunTaskMessage(
+        config: BailianASRConfig,
+        options: ASRRequestOptions,
+        taskID: String
+    ) -> String {
+        var parameters: [String: Any] = [
+            "format": "pcm",
+            "sample_rate": 16000,
+            "semantic_punctuation_enabled": false,
+            "max_sentence_silence": 800,
+            "multi_threshold_mode_enabled": false,
+            "heartbeat": false,
+        ]
+
+        if let vocabularyID = sanitized(options.boostingTableID) ?? sanitized(config.vocabularyId) {
+            parameters["vocabulary_id"] = vocabularyID
+        }
+
+        if let languageHint = sanitized(config.languageHint) {
+            parameters["language_hints"] = [languageHint]
+        }
+
+        let payload: [String: Any] = [
+            "header": [
+                "action": "run-task",
+                "task_id": taskID,
+                "streaming": "duplex",
+            ],
+            "payload": [
+                "task_group": "audio",
+                "task": "asr",
+                "function": "recognition",
+                "model": config.model,
+                "parameters": parameters,
+                "input": [:],
+            ],
+        ]
+
+        return jsonString(from: payload)
+    }
+
+    static func buildFinishTaskMessage(taskID: String) -> String {
+        let payload: [String: Any] = [
+            "header": [
+                "action": "finish-task",
+                "task_id": taskID,
+                "streaming": "duplex",
+            ],
+            "payload": [
+                "input": [:],
+            ],
+        ]
+
+        return jsonString(from: payload)
+    }
+
+    static func parseServerEvent(
+        from data: Data,
+        confirmedSegments: [String]
+    ) throws -> BailianServerEvent? {
+        let decoder = JSONDecoder()
+        let envelope = try decoder.decode(Envelope.self, from: data)
+
+        switch envelope.header.event {
+        case "task-started":
+            return .taskStarted(taskID: envelope.header.taskID)
+
+        case "result-generated":
+            let message = try decoder.decode(ResultMessage.self, from: data)
+            guard let update = makeTranscriptUpdate(
+                sentence: message.payload.output?.sentence,
+                confirmedSegments: confirmedSegments
+            ) else {
+                return nil
+            }
+            return .transcript(update)
+
+        case "task-finished":
+            return .taskFinished(taskID: envelope.header.taskID)
+
+        case "task-failed":
+            return .taskFailed(
+                code: envelope.header.errorCode,
+                message: envelope.header.errorMessage
+            )
+
+        default:
+            return nil
+        }
+    }
+
+    static func makeTranscriptUpdate(
+        sentence: BailianSentence?,
+        confirmedSegments: [String]
+    ) -> BailianTranscriptUpdate? {
+        guard let sentence else { return nil }
+        if sentence.heartbeat == true { return nil }
+
+        let trimmedText = sentence.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let isFinal = sentence.sentenceEnd
+
+        var nextConfirmed = confirmedSegments
+        var partialText = ""
+
+        if !trimmedText.isEmpty {
+            let normalized = normalize(segment: trimmedText, after: confirmedSegments.joined())
+            if isFinal {
+                nextConfirmed.append(normalized)
+            } else {
+                partialText = normalized
+            }
+        } else if !isFinal || confirmedSegments.isEmpty {
+            return nil
+        }
+
+        let authoritativeText = (nextConfirmed + (partialText.isEmpty ? [] : [partialText])).joined()
+        let transcript = RecognitionTranscript(
+            confirmedSegments: nextConfirmed,
+            partialText: partialText,
+            authoritativeText: authoritativeText,
+            isFinal: isFinal
+        )
+        return BailianTranscriptUpdate(
+            transcript: transcript,
+            confirmedSegments: nextConfirmed
+        )
+    }
+
+    private static func jsonString(from object: [String: Any]) -> String {
+        let data = try! JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        return String(data: data, encoding: .utf8)!
+    }
+
+    private static func sanitized(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func normalize(segment: String, after existingText: String) -> String {
+        guard !segment.isEmpty else { return "" }
+        guard let last = existingText.last else { return segment }
+        guard let first = segment.first else { return segment }
+
+        if last.isWhitespace || first.isWhitespace {
+            return segment
+        }
+
+        if first.isClosingPunctuation || last.isOpeningPunctuation {
+            return segment
+        }
+
+        if last.isCJKUnifiedIdeograph || first.isCJKUnifiedIdeograph {
+            return segment
+        }
+
+        return " " + segment
+    }
+
+    private struct Envelope: Decodable {
+        let header: Header
+    }
+
+    private struct Header: Decodable {
+        let event: String
+        let taskID: String?
+        let errorCode: String?
+        let errorMessage: String?
+
+        enum CodingKeys: String, CodingKey {
+            case event
+            case taskID = "task_id"
+            case errorCode = "error_code"
+            case errorMessage = "error_message"
+        }
+    }
+
+    private struct ResultMessage: Decodable {
+        let payload: ResultPayload
+    }
+
+    private struct ResultPayload: Decodable {
+        let output: ResultOutput?
+    }
+
+    private struct ResultOutput: Decodable {
+        let sentence: BailianSentence?
+    }
+}
+
+struct BailianSentence: Decodable, Sendable, Equatable {
+    let text: String
+    let heartbeat: Bool?
+    let sentenceEnd: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case text
+        case heartbeat
+        case sentenceEnd = "sentence_end"
+    }
+}
+
+private extension Character {
+    var isClosingPunctuation: Bool {
+        ",.!?;:)]}\"'".contains(self)
+    }
+
+    var isOpeningPunctuation: Bool {
+        "([{/\"'".contains(self)
+    }
+
+    var isCJKUnifiedIdeograph: Bool {
+        unicodeScalars.contains { scalar in
+            switch scalar.value {
+            case 0x3400...0x4DBF, 0x4E00...0x9FFF, 0xF900...0xFAFF:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+}

--- a/Type4Me/Protocol/VolcProtocol.swift
+++ b/Type4Me/Protocol/VolcProtocol.swift
@@ -84,7 +84,7 @@ enum VolcProtocol: Sendable {
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
         if !cleanedHotwords.isEmpty {
-            contextObject["hotwords"] = cleanedHotwords.map { ["word": $0, "scale": 3.0] as [String: Any] }
+            contextObject["hotwords"] = cleanedHotwords.map { ["word": $0, "scale": 5.0] as [String: Any] }
         }
 
         guard !contextObject.isEmpty,

--- a/Type4Me/Services/KeychainService.swift
+++ b/Type4Me/Services/KeychainService.swift
@@ -58,7 +58,10 @@ enum KeychainService {
             return provider
         }
         set {
+            let previous = selectedASRProvider
             UserDefaults.standard.set(newValue.rawValue, forKey: selectedProviderKey)
+            guard previous != newValue else { return }
+            NotificationCenter.default.post(name: .asrProviderDidChange, object: newValue)
         }
     }
 
@@ -191,6 +194,19 @@ enum KeychainService {
             mutableDict.removeValue(forKey: "tf_resourceId")
             migrated = true
             NSLog("[KeychainService] Migrated legacy ASR credentials to tf_asr_volcano")
+        }
+
+        // Migrate mistakenly stored Bailian ASR credentials from tf_asr_aliyun → tf_asr_bailian
+        if let aliyunValues = dict[asrStorageKey(for: .aliyun)] as? [String: String],
+           let apiKey = aliyunValues["apiKey"], !apiKey.isEmpty,
+           dict[asrStorageKey(for: .bailian)] == nil {
+            mutableDict[asrStorageKey(for: .bailian)] = aliyunValues
+            mutableDict.removeValue(forKey: asrStorageKey(for: .aliyun))
+            if selectedASRProvider == .aliyun {
+                selectedASRProvider = .bailian
+            }
+            migrated = true
+            NSLog("[KeychainService] Migrated Bailian ASR credentials from tf_asr_aliyun → tf_asr_bailian")
         }
 
         // Migrate LLM: tf_llmEndpointId → tf_llmModel

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -23,6 +23,11 @@ actor RecognitionSession {
         state = newState
     }
 
+    /// Exposed for testing; production code should resolve modes through startRecording / switchMode.
+    func currentModeForTesting() -> ProcessingMode {
+        currentMode
+    }
+
     // MARK: - Dependencies
 
     private let audioEngine = AudioCaptureEngine()
@@ -109,13 +114,14 @@ actor RecognitionSession {
             await forceReset()
         }
 
-        self.currentMode = mode
+        let provider = KeychainService.selectedASRProvider
+        let effectiveMode = ASRProviderRegistry.resolvedMode(for: mode, provider: provider)
+        self.currentMode = effectiveMode
         self.recordingStartTime = nil
         hasEmittedReadyForCurrentSession = false
         state = .starting
 
-        // Load credentials / config for selected provider
-        let provider = KeychainService.selectedASRProvider
+        // Load credentials for selected provider
         let config: any ASRProviderConfig
 
         if provider.isLocal {
@@ -181,7 +187,7 @@ actor RecognitionSession {
         // Load hotwords
         let hotwords = HotwordStorage.load()
         let biasSettings = ASRBiasSettingsStorage.load()
-        let needsLLM = !mode.prompt.isEmpty
+        let needsLLM = !effectiveMode.prompt.isEmpty
         let requestOptions = ASRRequestOptions(
             enablePunc: !needsLLM,
             hotwords: hotwords,
@@ -276,7 +282,7 @@ actor RecognitionSession {
 
     /// Switch the processing mode before stopping. Used for cross-mode hotkey stops.
     func switchMode(to mode: ProcessingMode) {
-        currentMode = mode
+        currentMode = ASRProviderRegistry.resolvedMode(for: mode, provider: KeychainService.selectedASRProvider)
     }
 
     // MARK: - Stop

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -23,6 +23,11 @@ actor RecognitionSession {
         state = newState
     }
 
+    /// Exposed for testing; production code should resolve modes through startRecording / switchMode.
+    func currentModeForTesting() -> ProcessingMode {
+        currentMode
+    }
+
     // MARK: - Dependencies
 
     private let audioEngine = AudioCaptureEngine()
@@ -105,13 +110,14 @@ actor RecognitionSession {
             await forceReset()
         }
 
-        self.currentMode = mode
+        let provider = KeychainService.selectedASRProvider
+        let effectiveMode = ASRProviderRegistry.resolvedMode(for: mode, provider: provider)
+        self.currentMode = effectiveMode
         self.recordingStartTime = nil
         hasEmittedReadyForCurrentSession = false
         state = .starting
 
         // Load credentials for selected provider
-        let provider = KeychainService.selectedASRProvider
         let config: any ASRProviderConfig
 
         if let savedConfig = KeychainService.loadASRConfig(for: provider) {
@@ -152,7 +158,7 @@ actor RecognitionSession {
         // Load hotwords
         let hotwords = HotwordStorage.load()
         let biasSettings = ASRBiasSettingsStorage.load()
-        let needsLLM = !mode.prompt.isEmpty
+        let needsLLM = !effectiveMode.prompt.isEmpty
         let requestOptions = ASRRequestOptions(
             enablePunc: !needsLLM,
             hotwords: hotwords,
@@ -242,7 +248,7 @@ actor RecognitionSession {
 
     /// Switch the processing mode before stopping. Used for cross-mode hotkey stops.
     func switchMode(to mode: ProcessingMode) {
-        currentMode = mode
+        currentMode = ASRProviderRegistry.resolvedMode(for: mode, provider: KeychainService.selectedASRProvider)
     }
 
     // MARK: - Stop

--- a/Type4Me/Type4MeApp.swift
+++ b/Type4Me/Type4MeApp.swift
@@ -108,8 +108,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Start periodic update checking
         UpdateChecker.shared.startPeriodicChecking(appState: appState)
 
-        // Register per-mode hotkeys
-        registerHotkeys()
+        // Reconcile current mode against the active provider before hotkeys are registered.
+        refreshModeAvailability()
 
         // Re-register when modes change in Settings
         NotificationCenter.default.addObserver(
@@ -118,7 +118,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated { [weak self] in
-                self?.registerHotkeys()
+                self?.refreshModeAvailability()
+            }
+        }
+
+        NotificationCenter.default.addObserver(
+            forName: .asrProviderDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { [weak self] in
+                self?.refreshModeAvailability()
             }
         }
 
@@ -172,8 +182,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
     }
 
-    private func registerHotkeys() {
-        let modes = appState.availableModes
+    private func refreshModeAvailability() {
+        let provider = KeychainService.selectedASRProvider
+        appState.reconcileCurrentMode(for: provider)
+        registerHotkeys(for: provider)
+    }
+
+    private func registerHotkeys(for provider: ASRProvider) {
+        let availableModes = appState.availableModes
+        let modes = ASRProviderRegistry.supportedModes(from: availableModes, for: provider)
         let bindings: [ModeBinding] = modes.compactMap { mode in
             guard let code = mode.hotkeyCode else { return nil }
             let modifiers = CGEventFlags(rawValue: mode.hotkeyModifiers ?? 0)
@@ -185,13 +202,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 style: capturedMode.hotkeyStyle,
                 onStart: { [weak self] in
                     guard let self else { return }
-                    NSLog("[Type4Me] >>> HOTKEY: Record START (mode: %@)", capturedMode.name)
-                    DebugFileLogger.log("hotkey record start mode=\(capturedMode.name)")
+                    let selectedProvider = KeychainService.selectedASRProvider
+                    let resolvedMode = ASRProviderRegistry.resolvedMode(for: capturedMode, provider: selectedProvider)
+                    let effectiveMode = availableModes.first(where: { $0.id == resolvedMode.id }) ?? resolvedMode
+                    NSLog("[Type4Me] >>> HOTKEY: Record START (mode: %@)", effectiveMode.name)
+                    DebugFileLogger.log("hotkey record start mode=\(effectiveMode.name)")
                     Task { @MainActor in
-                        self.appState.currentMode = capturedMode
+                        self.appState.currentMode = effectiveMode
                         self.appState.startRecording()
                     }
-                    Task { await self.session.startRecording(mode: capturedMode) }
+                    Task { await self.session.startRecording(mode: effectiveMode) }
                 },
                 onStop: { [weak self] in
                     guard let self else { return }
@@ -208,15 +228,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Switch to mode B and stop, so the recording is processed with mode B.
         hotkeyManager.onCrossModeStop = { [weak self] newModeId in
             guard let self else { return }
-            guard let newMode = self.appState.availableModes.first(where: { $0.id == newModeId }) else { return }
-            NSLog("[Type4Me] >>> HOTKEY: Cross-mode stop → %@", newMode.name)
-            DebugFileLogger.log("hotkey cross-mode stop → \(newMode.name)")
+            guard let newMode = availableModes.first(where: { $0.id == newModeId }) else { return }
+            let selectedProvider = KeychainService.selectedASRProvider
+            let resolvedMode = ASRProviderRegistry.resolvedMode(for: newMode, provider: selectedProvider)
+            let effectiveMode = availableModes.first(where: { $0.id == resolvedMode.id }) ?? resolvedMode
+            NSLog("[Type4Me] >>> HOTKEY: Cross-mode stop → %@", effectiveMode.name)
+            DebugFileLogger.log("hotkey cross-mode stop → \(effectiveMode.name)")
             Task { @MainActor in
-                self.appState.currentMode = newMode
+                self.appState.currentMode = effectiveMode
                 self.appState.stopRecording()
             }
             Task {
-                await self.session.switchMode(to: newMode)
+                await self.session.switchMode(to: effectiveMode)
                 await self.session.stopRecording()
             }
         }

--- a/Type4Me/UI/AppState.swift
+++ b/Type4Me/UI/AppState.swift
@@ -332,6 +332,12 @@ final class AppState {
         segments.map(\.text).joined()
     }
 
+    func reconcileCurrentMode(for provider: ASRProvider) {
+        let resolved = ASRProviderRegistry.resolvedMode(for: currentMode, provider: provider)
+        guard resolved.id != currentMode.id else { return }
+        currentMode = availableModes.first(where: { $0.id == resolved.id }) ?? resolved
+    }
+
     // MARK: Private
 
     private func showDone(message: String = L("已完成", "Done")) {
@@ -356,6 +362,7 @@ extension AppState: FloatingBarState {}
 
 extension Notification.Name {
     static let modesDidChange = Notification.Name("Type4MeModesDidChange")
+    static let asrProviderDidChange = Notification.Name("Type4MeASRProviderDidChange")
     static let hotkeyRecordingDidStart = Notification.Name("Type4MeHotkeyRecordingDidStart")
     static let hotkeyRecordingDidEnd = Notification.Name("Type4MeHotkeyRecordingDidEnd")
     static let navigateToMode = Notification.Name("Type4MeNavigateToMode")

--- a/Type4Me/UI/AppState.swift
+++ b/Type4Me/UI/AppState.swift
@@ -320,6 +320,12 @@ final class AppState {
         segments.map(\.text).joined()
     }
 
+    func reconcileCurrentMode(for provider: ASRProvider) {
+        let resolved = ASRProviderRegistry.resolvedMode(for: currentMode, provider: provider)
+        guard resolved.id != currentMode.id else { return }
+        currentMode = availableModes.first(where: { $0.id == resolved.id }) ?? resolved
+    }
+
     // MARK: Private
 
     private func showDone(message: String = L("已完成", "Done")) {
@@ -344,6 +350,7 @@ extension AppState: FloatingBarState {}
 
 extension Notification.Name {
     static let modesDidChange = Notification.Name("Type4MeModesDidChange")
+    static let asrProviderDidChange = Notification.Name("Type4MeASRProviderDidChange")
     static let hotkeyRecordingDidStart = Notification.Name("Type4MeHotkeyRecordingDidStart")
     static let hotkeyRecordingDidEnd = Notification.Name("Type4MeHotkeyRecordingDidEnd")
     static let navigateToMode = Notification.Name("Type4MeNavigateToMode")

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -197,6 +197,10 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
         ASRProviderRegistry.entry(for: selectedASRProvider)?.isAvailable ?? false
     }
 
+    private var asrCapabilitySummary: String {
+        ASRProviderRegistry.supportedModesSummary(for: selectedASRProvider)
+    }
+
     // MARK: Body
 
     var body: some View {
@@ -206,6 +210,11 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
                 .foregroundStyle(TF.settingsTextTertiary)
                 .padding(.bottom, 6)
             asrProviderPicker
+            Text(asrCapabilitySummary)
+                .font(.system(size: 11))
+                .foregroundStyle(TF.settingsTextTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, 2)
             SettingsDivider()
 
             if hasASRCredentials && !isEditingASR {

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -205,6 +205,10 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
         ASRProviderRegistry.entry(for: selectedASRProvider)?.isAvailable ?? false
     }
 
+    private var asrCapabilitySummary: String {
+        ASRProviderRegistry.supportedModesSummary(for: selectedASRProvider)
+    }
+
     // MARK: Body
 
     var body: some View {
@@ -214,6 +218,11 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
                 .foregroundStyle(TF.settingsTextTertiary)
                 .padding(.bottom, 6)
             asrProviderPicker
+            Text(asrCapabilitySummary)
+                .font(.system(size: 11))
+                .foregroundStyle(TF.settingsTextTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, 2)
             SettingsDivider()
 
             if selectedASRProvider.isLocal {

--- a/Type4Me/UI/Settings/ModesSettingsTab.swift
+++ b/Type4Me/UI/Settings/ModesSettingsTab.swift
@@ -18,6 +18,7 @@ struct ModesSettingsTab: View {
     @State private var recordingTarget: RecordingTarget?
     @State private var deletingModeId: UUID?
     @State private var draggingModeId: UUID?
+    @State private var selectedASRProvider: ASRProvider = KeychainService.selectedASRProvider
 
     private var builtinModes: [ProcessingMode] {
         modes.filter { $0.isBuiltin }
@@ -32,7 +33,7 @@ struct ModesSettingsTab: View {
             SettingsSectionHeader(
                 label: "MODES",
                 title: L("处理模式", "Modes"),
-                description: L("配置语音转写后的文本处理流水线。快速模式输出原文，其他模式经 LLM 加工。", "Configure text processing pipelines after speech-to-text. Quick mode outputs raw text; others use LLM processing.")
+                description: L("配置语音转写与后处理流水线。快速模式实时输出，性能模式优先整段识别，自定义模式可经 LLM 加工。", "Configure speech-to-text and post-processing pipelines. Quick Mode outputs live text, Performance Mode prefers full-audio recognition, and custom modes can use LLM processing.")
             )
 
             // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -102,8 +103,16 @@ struct ModesSettingsTab: View {
             .frame(maxWidth: .infinity)
         }
         .onAppear {
+            selectedASRProvider = KeychainService.selectedASRProvider
             if selectedModeId == nil {
                 selectedModeId = customModes.first?.id
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .asrProviderDidChange)) { note in
+            if let provider = note.object as? ASRProvider {
+                selectedASRProvider = provider
+            } else {
+                selectedASRProvider = KeychainService.selectedASRProvider
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .selectMode)) { note in
@@ -183,32 +192,45 @@ struct ModesSettingsTab: View {
 
     // MARK: - Builtin Mode Card
 
-    private var builtinMeta: [UUID: (icon: String, desc: String, badge: String)] {
-        [
-            ProcessingMode.directId: (
+    private func builtinMeta(for mode: ProcessingMode) -> (icon: String, desc: String, badge: String) {
+        let isSupported = ASRProviderRegistry.supports(mode, for: selectedASRProvider)
+
+        if mode.id == ProcessingMode.directId {
+            return (
                 icon: "bolt.fill",
                 desc: L("流式语音识别，边说边出字。松开快捷键后立即将文本粘贴到光标位置，响应最快。适合日常短句、即时通讯和快速笔记。",
                          "Streaming ASR, text appears as you speak. Pastes to cursor immediately on key release. Best for short phrases, messaging and quick notes."),
                 badge: L("低延迟，边说边出", "Low latency, real-time")
-            ),
-            ProcessingMode.performanceId: (
+            )
+        }
+
+        if mode.id == ProcessingMode.performanceId, !isSupported {
+            return (
                 icon: "waveform.badge.magnifyingglass",
-                desc: L("录音结束后将完整音频提交识别引擎，获得更准确的全文结果。适合长段落口述、正式文档和需要高准确率的场景。",
-                         "Submits full audio after recording for more accurate results. Best for long dictation, formal documents and high-accuracy scenarios."),
-                badge: L("高准确率，整段识别", "High accuracy, full-segment")
-            ),
-        ]
+                desc: ASRProviderRegistry.unsupportedReason(for: mode, provider: selectedASRProvider)
+                    ?? L("当前引擎不支持该模式。", "This engine does not support this mode."),
+                badge: L("当前引擎不支持", "Unsupported for current engine")
+            )
+        }
+
+        return (
+            icon: "waveform.badge.magnifyingglass",
+            desc: L("录音结束后将完整音频提交识别引擎，获得更准确的全文结果。适合长段落口述、正式文档和需要高准确率的场景。",
+                     "Submits full audio after recording for more accurate results. Best for long dictation, formal documents and high-accuracy scenarios."),
+            badge: L("高准确率，整段识别", "High accuracy, full-segment")
+        )
     }
 
     private func builtinModeCard(_ mode: ProcessingMode) -> some View {
-        let meta = builtinMeta[mode.id] ?? (icon: "mic.fill", desc: "", badge: "")
+        let meta = builtinMeta(for: mode)
+        let isSupported = ASRProviderRegistry.supports(mode, for: selectedASRProvider)
 
         return VStack(alignment: .leading, spacing: 0) {
             // Header: icon + name + badge
             HStack(spacing: 6) {
                 Image(systemName: meta.icon)
                     .font(.system(size: 13))
-                    .foregroundStyle(TF.settingsAccentGreen)
+                    .foregroundStyle(isSupported ? TF.settingsAccentGreen : TF.settingsTextTertiary)
                 Text(mode.name)
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(TF.settingsText)
@@ -233,16 +255,16 @@ struct ModesSettingsTab: View {
             HStack(spacing: 5) {
                 Image(systemName: meta.icon)
                     .font(.system(size: 9))
-                    .foregroundStyle(TF.settingsAccentGreen)
+                    .foregroundStyle(isSupported ? TF.settingsAccentGreen : TF.settingsTextTertiary)
                 Text(meta.badge)
                     .font(.system(size: 9, weight: .medium))
-                    .foregroundStyle(TF.settingsAccentGreen)
+                    .foregroundStyle(isSupported ? TF.settingsAccentGreen : TF.settingsTextTertiary)
             }
             .padding(.horizontal, 7)
             .padding(.vertical, 3)
             .background(
                 RoundedRectangle(cornerRadius: 4)
-                    .fill(TF.settingsAccentGreen.opacity(0.1))
+                    .fill((isSupported ? TF.settingsAccentGreen : TF.settingsTextTertiary).opacity(0.1))
             )
 
             Spacer(minLength: 8)
@@ -277,6 +299,7 @@ struct ModesSettingsTab: View {
                     }
                     .buttonStyle(.plain)
                     .help(L("删除快捷键", "Remove hotkey"))
+                    .disabled(!isSupported)
                 } else {
                     Text(L("未设置快捷键", "No hotkey"))
                         .font(.system(size: 9))
@@ -305,6 +328,7 @@ struct ModesSettingsTab: View {
                     )
                 }
                 .buttonStyle(.plain)
+                .disabled(!isSupported)
             }
         }
         .padding(14)
@@ -312,6 +336,7 @@ struct ModesSettingsTab: View {
             RoundedRectangle(cornerRadius: 8)
                 .fill(TF.settingsBg)
         )
+        .opacity(isSupported ? 1 : 0.7)
     }
 
     // MARK: - Custom Mode Row

--- a/Type4Me/UI/Setup/SetupWizardView.swift
+++ b/Type4Me/UI/Setup/SetupWizardView.swift
@@ -168,6 +168,10 @@ struct SetupWizardView: View {
         }
     }
 
+    private var providerCapabilitySummary: String {
+        ASRProviderRegistry.supportedModesSummary(for: selectedProvider)
+    }
+
     private var providerStep: some View {
         VStack(spacing: 24) {
             Spacer()
@@ -201,6 +205,11 @@ struct SetupWizardView: View {
                     credentialValues = defaults
                 }
 
+                Text(providerCapabilitySummary)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 300, alignment: .leading)
+
                 // Dynamic credential fields
                 ForEach(currentFields) { field in
                     if field.isSecure {
@@ -229,10 +238,10 @@ struct SetupWizardView: View {
                 Spacer()
                 Button(L("下一步", "Next")) {
                     if hasRequiredFields {
-                        KeychainService.selectedASRProvider = selectedProvider
                         try? KeychainService.saveASRCredentials(
                             for: selectedProvider, values: credentialValues
                         )
+                        KeychainService.selectedASRProvider = selectedProvider
                     }
                     step = 5
                 }

--- a/Type4MeTests/ASRProviderRegistryTests.swift
+++ b/Type4MeTests/ASRProviderRegistryTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import Type4Me
+
+final class ASRProviderRegistryTests: XCTestCase {
+
+    func testVolcanoSupportsQuickAndPerformanceModes() {
+        XCTAssertTrue(ASRProviderRegistry.supports(.direct, for: .volcano))
+        XCTAssertTrue(ASRProviderRegistry.supports(.performance, for: .volcano))
+        XCTAssertNil(ASRProviderRegistry.unsupportedReason(for: .performance, provider: .volcano))
+    }
+
+    func testBailianAndDeepgramOnlySupportQuickMode() {
+        for provider in [ASRProvider.bailian, .deepgram] {
+            XCTAssertTrue(ASRProviderRegistry.supports(.direct, for: provider))
+            XCTAssertFalse(ASRProviderRegistry.supports(.performance, for: provider))
+            XCTAssertEqual(
+                ASRProviderRegistry.unsupportedReason(for: .performance, provider: provider),
+                L(
+                    "当前引擎仅支持实时识别，不支持整段识别。",
+                    "This engine only supports real-time recognition, not full-audio recognition."
+                )
+            )
+        }
+    }
+
+    func testResolvedModeFallsBackToDirectForUnsupportedPerformanceMode() {
+        XCTAssertEqual(
+            ASRProviderRegistry.resolvedMode(for: .performance, provider: .bailian).id,
+            ProcessingMode.directId
+        )
+        XCTAssertEqual(
+            ASRProviderRegistry.resolvedMode(for: .performance, provider: .deepgram).id,
+            ProcessingMode.directId
+        )
+    }
+
+    func testSupportedModesFilterOnlyRemovesPerformanceModeForQuickOnlyProviders() {
+        let customMode = ProcessingMode(
+            id: UUID(),
+            name: "Custom",
+            prompt: "Rewrite: {text}",
+            isBuiltin: false
+        )
+        let modes = [ProcessingMode.direct, ProcessingMode.performance, customMode]
+
+        let bailianModes = ASRProviderRegistry.supportedModes(from: modes, for: .bailian)
+        XCTAssertEqual(bailianModes.map(\.id), [ProcessingMode.directId, customMode.id])
+
+        let volcanoModes = ASRProviderRegistry.supportedModes(from: modes, for: .volcano)
+        XCTAssertEqual(volcanoModes.map(\.id), [ProcessingMode.directId, ProcessingMode.performanceId, customMode.id])
+    }
+}

--- a/Type4MeTests/AppStateTests.swift
+++ b/Type4MeTests/AppStateTests.swift
@@ -109,4 +109,30 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(appState.barPhase, .error)
         XCTAssertEqual(appState.feedbackMessage, "找不到麦克风")
     }
+
+    func testReconcileCurrentModeFallsBackToDirectForUnsupportedPerformanceProvider() {
+        let appState = AppState()
+        let direct = appState.availableModes.first(where: { $0.id == ProcessingMode.directId }) ?? .direct
+        appState.currentMode = .performance
+
+        appState.reconcileCurrentMode(for: .bailian)
+
+        XCTAssertEqual(appState.currentMode.id, direct.id)
+    }
+
+    func testReconcileCurrentModeKeepsSupportedCustomModeForQuickOnlyProvider() {
+        let appState = AppState()
+        let customMode = ProcessingMode(
+            id: UUID(),
+            name: "结构化",
+            prompt: "Rewrite {text}",
+            isBuiltin: false
+        )
+        appState.availableModes.append(customMode)
+        appState.currentMode = customMode
+
+        appState.reconcileCurrentMode(for: .bailian)
+
+        XCTAssertEqual(appState.currentMode.id, customMode.id)
+    }
 }

--- a/Type4MeTests/BailianASRConfigTests.swift
+++ b/Type4MeTests/BailianASRConfigTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import Type4Me
+
+final class BailianASRConfigTests: XCTestCase {
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "tf_asrUID")
+        super.tearDown()
+    }
+
+    func testInit_acceptsAPIKeyAndDefaultsModelAndDeviceID() throws {
+        let config = try XCTUnwrap(BailianASRConfig(credentials: [
+            "apiKey": "sk-test-key"
+        ]))
+
+        XCTAssertEqual(config.apiKey, "sk-test-key")
+        XCTAssertEqual(config.model, BailianASRConfig.defaultModel)
+        XCTAssertTrue(config.deviceId.hasPrefix("type4me-"))
+        XCTAssertEqual(config.languageHint, "")
+        XCTAssertEqual(config.vocabularyId, "")
+        XCTAssertTrue(config.isValid)
+    }
+
+    func testInit_rejectsMissingAPIKey() {
+        XCTAssertNil(BailianASRConfig(credentials: [:]))
+    }
+
+    func testToCredentials_roundTripsConfiguredValues() throws {
+        let config = try XCTUnwrap(BailianASRConfig(credentials: [
+            "apiKey": "sk-test-key",
+            "model": "fun-asr-realtime-2025-11-07",
+            "deviceId": "custom-device",
+            "languageHint": "ja",
+            "vocabularyId": "vocab-123",
+        ]))
+
+        XCTAssertEqual(config.toCredentials()["apiKey"], "sk-test-key")
+        XCTAssertEqual(config.toCredentials()["model"], "fun-asr-realtime-2025-11-07")
+        XCTAssertEqual(config.toCredentials()["deviceId"], "custom-device")
+        XCTAssertEqual(config.toCredentials()["languageHint"], "ja")
+        XCTAssertEqual(config.toCredentials()["vocabularyId"], "vocab-123")
+    }
+
+    func testRegistry_exposesAliyunProvider() {
+        let entry = ASRProviderRegistry.entry(for: .bailian)
+
+        XCTAssertNotNil(entry)
+        XCTAssertTrue(entry?.isAvailable ?? false)
+        XCTAssertTrue(ASRProviderRegistry.configType(for: .bailian) == BailianASRConfig.self)
+        XCTAssertNotNil(ASRProviderRegistry.createClient(for: .bailian))
+    }
+}

--- a/Type4MeTests/BailianProtocolTests.swift
+++ b/Type4MeTests/BailianProtocolTests.swift
@@ -1,0 +1,212 @@
+import XCTest
+@testable import Type4Me
+
+final class BailianProtocolTests: XCTestCase {
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "tf_asrUID")
+        super.tearDown()
+    }
+
+    func testBuildRunTaskMessage_usesExpectedParameters() throws {
+        let config = try XCTUnwrap(BailianASRConfig(credentials: [
+            "apiKey": "sk-test-key",
+            "model": "fun-asr-realtime",
+            "deviceId": "device-123",
+            "languageHint": "zh",
+            "vocabularyId": "vocab-from-config",
+        ]))
+
+        let message = BailianProtocol.buildRunTaskMessage(
+            config: config,
+            options: ASRRequestOptions(
+                enablePunc: true,
+                hotwords: ["Type4Me"],
+                boostingTableID: "vocab-from-options",
+                contextHistoryLength: 8
+            ),
+            taskID: "task-123"
+        )
+        let json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(message.utf8)) as? [String: Any]
+        )
+
+        let header = try XCTUnwrap(json["header"] as? [String: Any])
+        let payload = try XCTUnwrap(json["payload"] as? [String: Any])
+        let parameters = try XCTUnwrap(payload["parameters"] as? [String: Any])
+
+        XCTAssertEqual(header["action"] as? String, "run-task")
+        XCTAssertEqual(header["task_id"] as? String, "task-123")
+        XCTAssertEqual(header["streaming"] as? String, "duplex")
+        XCTAssertEqual(payload["task_group"] as? String, "audio")
+        XCTAssertEqual(payload["task"] as? String, "asr")
+        XCTAssertEqual(payload["function"] as? String, "recognition")
+        XCTAssertEqual(payload["model"] as? String, "fun-asr-realtime")
+        XCTAssertEqual(parameters["format"] as? String, "pcm")
+        XCTAssertEqual(parameters["sample_rate"] as? Int, 16000)
+        XCTAssertEqual(parameters["semantic_punctuation_enabled"] as? Bool, false)
+        XCTAssertEqual(parameters["max_sentence_silence"] as? Int, 800)
+        XCTAssertEqual(parameters["multi_threshold_mode_enabled"] as? Bool, false)
+        XCTAssertEqual(parameters["heartbeat"] as? Bool, false)
+        XCTAssertEqual(parameters["vocabulary_id"] as? String, "vocab-from-options")
+        XCTAssertEqual(parameters["language_hints"] as? [String], ["zh"])
+    }
+
+    func testBuildRunTaskMessage_omitsEmptyLanguageHints() throws {
+        let config = try XCTUnwrap(BailianASRConfig(credentials: [
+            "apiKey": "sk-test-key",
+            "deviceId": "device-123",
+        ]))
+
+        let message = BailianProtocol.buildRunTaskMessage(
+            config: config,
+            options: ASRRequestOptions(),
+            taskID: "task-123"
+        )
+        let json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(message.utf8)) as? [String: Any]
+        )
+        let payload = try XCTUnwrap(json["payload"] as? [String: Any])
+        let parameters = try XCTUnwrap(payload["parameters"] as? [String: Any])
+
+        XCTAssertNil(parameters["language_hints"])
+        XCTAssertNil(parameters["vocabulary_id"])
+    }
+
+    func testParseServerEvent_buildsPartialTranscript() throws {
+        let message = """
+        {
+          "header": {
+            "task_id": "task-123",
+            "event": "result-generated",
+            "attributes": {}
+          },
+          "payload": {
+            "output": {
+              "sentence": {
+                "text": "world",
+                "heartbeat": false,
+                "sentence_end": false
+              }
+            }
+          }
+        }
+        """
+
+        let event = try XCTUnwrap(
+            BailianProtocol.parseServerEvent(
+                from: Data(message.utf8),
+                confirmedSegments: ["Hello"]
+            )
+        )
+
+        guard case .transcript(let update) = event else {
+            return XCTFail("Expected transcript event")
+        }
+
+        XCTAssertEqual(update.confirmedSegments, ["Hello"])
+        XCTAssertEqual(update.transcript.partialText, " world")
+        XCTAssertEqual(update.transcript.authoritativeText, "Hello world")
+        XCTAssertFalse(update.transcript.isFinal)
+    }
+
+    func testParseServerEvent_promotesSentenceEndToConfirmedSegments() throws {
+        let message = """
+        {
+          "header": {
+            "task_id": "task-123",
+            "event": "result-generated",
+            "attributes": {}
+          },
+          "payload": {
+            "output": {
+              "sentence": {
+                "text": "world",
+                "heartbeat": false,
+                "sentence_end": true
+              }
+            }
+          }
+        }
+        """
+
+        let event = try XCTUnwrap(
+            BailianProtocol.parseServerEvent(
+                from: Data(message.utf8),
+                confirmedSegments: ["Hello"]
+            )
+        )
+
+        guard case .transcript(let update) = event else {
+            return XCTFail("Expected transcript event")
+        }
+
+        XCTAssertEqual(update.confirmedSegments, ["Hello", " world"])
+        XCTAssertEqual(update.transcript.partialText, "")
+        XCTAssertEqual(update.transcript.authoritativeText, "Hello world")
+        XCTAssertTrue(update.transcript.isFinal)
+    }
+
+    func testParseServerEvent_ignoresHeartbeatResults() throws {
+        let message = """
+        {
+          "header": {
+            "task_id": "task-123",
+            "event": "result-generated",
+            "attributes": {}
+          },
+          "payload": {
+            "output": {
+              "sentence": {
+                "text": "",
+                "heartbeat": true,
+                "sentence_end": false
+              }
+            }
+          }
+        }
+        """
+
+        let event = try BailianProtocol.parseServerEvent(
+            from: Data(message.utf8),
+            confirmedSegments: []
+        )
+
+        XCTAssertNil(event)
+    }
+
+    func testParseServerEvent_mapsTaskFailed() throws {
+        let message = """
+        {
+          "header": {
+            "task_id": "task-123",
+            "event": "task-failed",
+            "error_code": "CLIENT_ERROR",
+            "error_message": "request timeout"
+          },
+          "payload": {}
+        }
+        """
+
+        let event = try XCTUnwrap(
+            BailianProtocol.parseServerEvent(
+                from: Data(message.utf8),
+                confirmedSegments: []
+            )
+        )
+
+        XCTAssertEqual(
+            event,
+            .taskFailed(code: "CLIENT_ERROR", message: "request timeout")
+        )
+    }
+
+    func testParseServerEvent_throwsForInvalidJSON() {
+        XCTAssertThrowsError(
+            try BailianProtocol.parseServerEvent(
+                from: Data("{".utf8),
+                confirmedSegments: []
+            )
+        )
+    }
+}

--- a/Type4MeTests/KeychainServiceTests.swift
+++ b/Type4MeTests/KeychainServiceTests.swift
@@ -3,8 +3,17 @@ import XCTest
 
 final class KeychainServiceTests: XCTestCase {
 
+    private var originalProvider: ASRProvider!
+
+    override func setUp() {
+        super.setUp()
+        originalProvider = KeychainService.selectedASRProvider
+    }
+
     override func tearDown() {
         KeychainService.delete(key: "test_key")
+        KeychainService.selectedASRProvider = originalProvider
+        super.tearDown()
     }
 
     func testSaveAndLoad() throws {
@@ -51,5 +60,23 @@ final class KeychainServiceTests: XCTestCase {
         XCTAssertEqual(config?.appKey, "myAppKey")
         XCTAssertEqual(config?.accessKey, "myAccessKey")
         XCTAssertEqual(config?.resourceId, "myResource")
+    }
+
+    func testSelectedASRProviderPostsNotificationOnChange() {
+        let targetProvider: ASRProvider = originalProvider == .bailian ? .volcano : .bailian
+        let expectation = expectation(description: "provider change notification")
+        let token = NotificationCenter.default.addObserver(
+            forName: .asrProviderDidChange,
+            object: nil,
+            queue: .main
+        ) { note in
+            XCTAssertEqual(note.object as? ASRProvider, targetProvider)
+            expectation.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        KeychainService.selectedASRProvider = targetProvider
+
+        wait(for: [expectation], timeout: 1.0)
     }
 }

--- a/Type4MeTests/RecognitionSessionTests.swift
+++ b/Type4MeTests/RecognitionSessionTests.swift
@@ -2,6 +2,10 @@ import XCTest
 @testable import Type4Me
 
 final class RecognitionSessionTests: XCTestCase {
+    override func tearDown() {
+        KeychainService.selectedASRProvider = .volcano
+    }
+
     func testInitialStateIsIdle() async {
         let session = RecognitionSession()
         let state = await session.state
@@ -25,5 +29,25 @@ final class RecognitionSessionTests: XCTestCase {
         canStart = await session.canStartRecording
         XCTAssertFalse(canStart)
         await session.setState(.idle)
+    }
+
+    func testSwitchModeFallsBackToDirectWhenPerformanceModeIsUnsupported() async {
+        KeychainService.selectedASRProvider = .bailian
+        let session = RecognitionSession()
+
+        await session.switchMode(to: .performance)
+
+        let mode = await session.currentModeForTesting()
+        XCTAssertEqual(mode.id, ProcessingMode.directId)
+    }
+
+    func testSwitchModeKeepsPerformanceModeForVolcano() async {
+        KeychainService.selectedASRProvider = .volcano
+        let session = RecognitionSession()
+
+        await session.switchMode(to: .performance)
+
+        let mode = await session.currentModeForTesting()
+        XCTAssertEqual(mode.id, ProcessingMode.performanceId)
     }
 }


### PR DESCRIPTION
## Summary

合并 PR #14 (Bailian ASR) 和 PR #11 修复，解决冲突和代码质量问题。

### PR #14 (Bailian ASR) 合并 + 修复
- 解决 ASRProviderRegistry 冲突：保留 closure + `#if canImport` 条件编译
- `ProviderEntry` 新增 `capabilities` 字段，同时保留 `offlineRecognize`（Performance Mode 不受影响）
- 百炼 provider 注册为 `quickOnly` capabilities
- **fix**: `supports()` 移除 guard 逻辑，自定义模式不受 provider 能力限制
- **fix**: `BailianTaskStartGate.waitUntilStarted` 添加缺失的 `await`

### PR #11 (think-tag) 修复
- 提取 `String.strippingThinkTags()` 到 `LLMClient.swift`，消除重复代码
- 添加未闭合 `<think>` 标签的 fallback regex

## Test plan
- [ ] `swift build` 编译通过（无 SherpaOnnx framework）
- [ ] 百炼 ASR 识别正常
- [ ] 火山 Performance Mode 正常（offlineRecognize 保留）
- [ ] 自定义模式热键在所有 provider 上可用
- [ ] DeepSeek 模型 think 标签正确过滤（含截断场景）

🤖 Generated with [Claude Code](https://claude.com/claude-code)