### PR TITLE
feat: 录音时自动降低系统音量

### DIFF
--- a/Type4Me/Services/SystemVolumeManager.swift
+++ b/Type4Me/Services/SystemVolumeManager.swift
@@ -1,0 +1,81 @@
+import AudioToolbox
+import CoreAudio
+import Foundation
+import os
+
+/// Manages system output volume: save, lower, and restore.
+/// Uses CoreAudio directly — no private APIs.
+enum SystemVolumeManager {
+
+    private static let logger = Logger(subsystem: "com.type4me.volume", category: "SystemVolumeManager")
+
+    /// The volume level saved before lowering.
+    private static var savedVolume: Float?
+
+    /// Lower system volume to a fraction of the current level.
+    /// Saves the current volume so it can be restored later.
+    /// - Parameter fraction: Target fraction (e.g. 0.2 = 20% of current volume).
+    static func lower(to fraction: Float) {
+        guard let deviceID = defaultOutputDevice() else { return }
+        guard let current = getVolume(device: deviceID) else { return }
+
+        // Don't lower if already very quiet
+        guard current > 0.05 else { return }
+
+        savedVolume = current
+        let target = current * max(0, min(1, fraction))
+        setVolume(device: deviceID, volume: target)
+        logger.info("Volume lowered: \(current, format: .fixed(precision: 2)) → \(target, format: .fixed(precision: 2))")
+    }
+
+    /// Restore volume to the level saved before lowering.
+    static func restore() {
+        guard let saved = savedVolume else { return }
+        savedVolume = nil
+
+        guard let deviceID = defaultOutputDevice() else { return }
+        setVolume(device: deviceID, volume: saved)
+        logger.info("Volume restored: \(saved, format: .fixed(precision: 2))")
+    }
+
+    // MARK: - CoreAudio
+
+    private static func defaultOutputDevice() -> AudioDeviceID? {
+        var deviceID = AudioDeviceID(0)
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address, 0, nil, &size, &deviceID
+        )
+        guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
+        return deviceID
+    }
+
+    private static func getVolume(device: AudioDeviceID) -> Float? {
+        var volume: Float32 = 0
+        var size = UInt32(MemoryLayout<Float32>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = AudioObjectGetPropertyData(device, &address, 0, nil, &size, &volume)
+        guard status == noErr else { return nil }
+        return volume
+    }
+
+    private static func setVolume(device: AudioDeviceID, volume: Float) {
+        var vol = volume
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        AudioObjectSetPropertyData(device, &address, 0, nil, UInt32(MemoryLayout<Float32>.size), &vol)
+    }
+}

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -273,6 +273,11 @@ actor RecognitionSession {
         state = .recording
         DebugFileLogger.log("session entered recording state, waiting for first audio chunk")
 
+        // Lower system volume during recording if enabled
+        if UserDefaults.standard.bool(forKey: "tf_lowerVolumeOnRecord") {
+            SystemVolumeManager.lower(to: 0.2)
+        }
+
         // Pre-warm LLM connection for modes with post-processing
         if !currentMode.prompt.isEmpty, let llmConfig = KeychainService.loadLLMConfig() {
             let client = currentLLMClient()
@@ -504,6 +509,7 @@ actor RecognitionSession {
             currentTranscript = .empty
         }
         resetSpeculativeLLM()
+        SystemVolumeManager.restore()
         logger.info("Session complete, injected \(effectiveText.count) chars")
     }
 
@@ -645,6 +651,7 @@ actor RecognitionSession {
         currentTranscript = .empty
         hasEmittedReadyForCurrentSession = false
         currentConfig = nil
+        SystemVolumeManager.restore()
     }
 
 }

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -882,6 +882,7 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
 
     @AppStorage("tf_startSound") private var startSound = StartSoundStyle.chime.rawValue
     @AppStorage("tf_launchAtLogin") private var launchAtLogin = true
+    @AppStorage("tf_lowerVolumeOnRecord") private var lowerVolumeOnRecord = false
     @AppStorage("tf_visualStyle") private var visualStyle = "timeline"
     @AppStorage("tf_language") private var language = AppLanguage.systemDefault
 
@@ -910,6 +911,8 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
                     startSoundRow
                     SettingsDivider()
                     settingsToggleRow(L("开机自动启动", "Launch at login"), isOn: $launchAtLogin)
+                    SettingsDivider()
+                    settingsToggleRow(L("录音时降低系统音量", "Lower volume while recording"), isOn: $lowerVolumeOnRecord)
                     SettingsDivider()
                     visualStyleRow
                     SettingsDivider()


### PR DESCRIPTION
## Summary

录音时自动降低系统音量至 20%，结束后恢复。通过设置开关控制，默认关闭。

### 实现
- `SystemVolumeManager`: CoreAudio 读取/设置系统输出音量，save → lower → restore 模式
- 在 `RecognitionSession` 的 `startRecording` 和 `stopRecording`/`forceReset` 中调用
- 设置界面「偏好」卡片新增「录音时降低系统音量」开关
- `UserDefaults` key: `tf_lowerVolumeOnRecord`

Closes #13

## Test plan
- [ ] 开启开关，播放音乐，按热键录音，音量自动降低
- [ ] 录音结束后音量恢复到之前的值
- [ ] 录音中 force reset（如切换 provider）后音量也能恢复
- [ ] 关闭开关时录音不影响音量
- [ ] 音量已经很低时（< 5%）不再降低

🤖 Generated with [Claude Code](https://claude.com/claude-code)