### PR TITLE
test(deepgram): add regression tests for websocket handshake close behavior

### DIFF
--- a/Type4Me/ASR/DeepgramASRClient.swift
+++ b/Type4Me/ASR/DeepgramASRClient.swift
@@ -185,7 +185,7 @@ actor DeepgramASRClient: SpeechRecognizer {
     }
 }
 
-private final class DeepgramWebSocketDelegate: NSObject, URLSessionWebSocketDelegate, URLSessionTaskDelegate {
+final class DeepgramWebSocketDelegate: NSObject, URLSessionWebSocketDelegate, URLSessionTaskDelegate {
 
     private let connectionGate: DeepgramConnectionGate
 

--- a/Type4MeTests/DeepgramWebSocketDelegateTests.swift
+++ b/Type4MeTests/DeepgramWebSocketDelegateTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import XCTest
+@testable import Type4Me
+
+final class DeepgramWebSocketDelegateTests: XCTestCase {
+
+    func testDidCloseWith_beforeHandshakeMarksClosedBeforeHandshakeFailure() async {
+        let gate = DeepgramConnectionGate()
+        let delegate = DeepgramWebSocketDelegate(connectionGate: gate)
+        let session = URLSession(configuration: .ephemeral)
+        let task = session.webSocketTask(with: URL(string: "wss://example.com/socket")!)
+
+        delegate.urlSession(
+            session,
+            webSocketTask: task,
+            didCloseWith: .goingAway,
+            reason: Data("bye".utf8)
+        )
+
+        do {
+            try await gate.waitUntilOpen(timeout: .milliseconds(50))
+            XCTFail("Expected handshake wait to fail")
+        } catch {
+            guard case let DeepgramASRError.closedBeforeHandshake(code, reason) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+
+            XCTAssertEqual(code, Int(URLSessionWebSocketTask.CloseCode.goingAway.rawValue))
+            XCTAssertEqual(reason, "bye")
+        }
+    }
+
+    func testDidCloseWith_afterHandshakeOpens_doesNotOverrideOpenState() async throws {
+        let gate = DeepgramConnectionGate()
+        let delegate = DeepgramWebSocketDelegate(connectionGate: gate)
+        let session = URLSession(configuration: .ephemeral)
+        let task = session.webSocketTask(with: URL(string: "wss://example.com/socket")!)
+
+        delegate.urlSession(session, webSocketTask: task, didOpenWithProtocol: nil)
+        try await Task.sleep(for: .milliseconds(20))
+
+        delegate.urlSession(
+            session,
+            webSocketTask: task,
+            didCloseWith: .normalClosure,
+            reason: Data("normal".utf8)
+        )
+        try await Task.sleep(for: .milliseconds(20))
+
+        try await gate.waitUntilOpen(timeout: .milliseconds(50))
+        let opened = await gate.hasOpened
+        XCTAssertTrue(opened)
+    }
+}


### PR DESCRIPTION
## 概要

本 PR 补充 Deepgram WebSocket 握手关闭语义的回归测试，并已基于最新 `upstream/main` 完成 rebase，方便 reviewer 直接聚焦本次变更。

## 变更内容

- 新增 `DeepgramWebSocketDelegateTests`
- 覆盖握手前收到 `didCloseWith` 的场景，确认会标记为 `closedBeforeHandshake`
- 覆盖握手成功后再收到正常关闭的场景，确认不会影响已打开的 `ConnectionGate`
- 将 `DeepgramWebSocketDelegate` 调整为模块内可见，以支持更聚焦的单元测试

## 目的

当前实现已经区分了两类关闭语义：

- 握手前关闭：应视为连接失败
- 握手后正常关闭：不应再被当作握手失败

本 PR 不修改现有业务行为，主要是把这层边界条件用测试固定下来，降低后续重构或补日志、metrics 时发生语义回归的风险。

## 验证

已在本地完成验证：

- `swift test`

## 备注

本分支已 rebase 到最新 `upstream/main`。  
rebase 后看到的若干 Swift warning 来自当前上游代码，不是本 PR 引入的问题。