### PR TITLE
feat(asr): add AssemblyAI streaming provider 增加了对于 AssemblyAI 的支持

### DIFF
--- a/Type4Me/ASR/ASRProvider.swift
+++ b/Type4Me/ASR/ASRProvider.swift
@@ -11,6 +11,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
     case google
     case aws
     case deepgram
+    case assemblyai
     // China
     case volcano
     case aliyun
@@ -28,6 +29,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
         case .google:   return "Google Cloud STT"
         case .aws:      return "AWS Transcribe"
         case .deepgram: return "Deepgram"
+        case .assemblyai: return "AssemblyAI"
         case .volcano:  return L("火山引擎 (Doubao)", "Volcano (Doubao)")
         case .aliyun:   return L("阿里云", "Alibaba Cloud")
         case .bailian:  return L("阿里云百炼", "Alibaba Cloud Bailian")

--- a/Type4Me/ASR/ASRProviderRegistry.swift
+++ b/Type4Me/ASR/ASRProviderRegistry.swift
@@ -74,6 +74,11 @@ enum ASRProviderRegistry {
                 createClient: { DeepgramASRClient() },
                 capabilities: .quickOnly
             ),
+            .assemblyai: ProviderEntry(
+                configType: AssemblyAIASRConfig.self,
+                createClient: { AssemblyAIASRClient() },
+                capabilities: .quickOnly
+            ),
             .bailian: ProviderEntry(
                 configType: BailianASRConfig.self,
                 createClient: { BailianASRClient() },

--- a/Type4Me/ASR/AssemblyAIASRClient.swift
+++ b/Type4Me/ASR/AssemblyAIASRClient.swift
@@ -1,0 +1,428 @@
+import Foundation
+import os
+
+enum AssemblyAIASRError: Error, LocalizedError {
+    case unsupportedProvider
+    case handshakeTimedOut
+    case closedBeforeSessionBegan(code: Int, reason: String?)
+    case unauthorized(reason: String?)
+    case serverCancelled(reason: String?)
+    case closed(code: Int, reason: String?)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedProvider:
+            return "AssemblyAIASRClient requires AssemblyAIASRConfig"
+        case .handshakeTimedOut:
+            return "AssemblyAI streaming session begin timed out"
+        case .closedBeforeSessionBegan(let code, let reason):
+            if let reason, !reason.isEmpty {
+                return "AssemblyAI WebSocket closed before session begin (\(code)): \(reason)"
+            }
+            return "AssemblyAI WebSocket closed before session begin (\(code))"
+        case .unauthorized(let reason):
+            if let reason, !reason.isEmpty {
+                return "AssemblyAI unauthorized connection: \(reason)"
+            }
+            return "AssemblyAI unauthorized connection"
+        case .serverCancelled(let reason):
+            if let reason, !reason.isEmpty {
+                return "AssemblyAI session cancelled: \(reason)"
+            }
+            return "AssemblyAI session cancelled"
+        case .closed(let code, let reason):
+            if let reason, !reason.isEmpty {
+                return "AssemblyAI session closed (\(code)): \(reason)"
+            }
+            return "AssemblyAI session closed (\(code))"
+        }
+    }
+}
+
+actor AssemblyAIASRClient: SpeechRecognizer {
+    private let logger = Logger(
+        subsystem: "com.type4me.asr",
+        category: "AssemblyAIASRClient"
+    )
+
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var receiveTask: Task<Void, Never>?
+    private var session: URLSession?
+    private var sessionDelegate: AssemblyAIWebSocketDelegate?
+    private var connectionGate: AssemblyAIConnectionGate?
+    private var closeTracker: AssemblyAICloseTracker?
+
+    private var eventContinuation: AsyncStream<RecognitionEvent>.Continuation?
+    private var _events: AsyncStream<RecognitionEvent>?
+
+    private var accumulator = AssemblyAITranscriptAccumulator()
+    private var lastTranscript: RecognitionTranscript = .empty
+    private var audioPacketCount = 0
+    private var didRequestTerminate = false
+
+    var events: AsyncStream<RecognitionEvent> {
+        if let existing = _events {
+            return existing
+        }
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        eventContinuation = continuation
+        _events = stream
+        return stream
+    }
+
+    func connect(config: any ASRProviderConfig, options: ASRRequestOptions = ASRRequestOptions()) async throws {
+        guard let assemblyConfig = config as? AssemblyAIASRConfig else {
+            throw AssemblyAIASRError.unsupportedProvider
+        }
+
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        eventContinuation = continuation
+        _events = stream
+
+        let url = try AssemblyAIProtocol.buildWebSocketURL(config: assemblyConfig, options: options)
+        var request = URLRequest(url: url)
+        request.setValue(assemblyConfig.apiKey, forHTTPHeaderField: "Authorization")
+
+        let gate = AssemblyAIConnectionGate()
+        let closeTracker = AssemblyAICloseTracker()
+        let delegate = AssemblyAIWebSocketDelegate(connectionGate: gate, closeTracker: closeTracker)
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        let task = session.webSocketTask(with: request)
+        task.resume()
+
+        self.connectionGate = gate
+        self.closeTracker = closeTracker
+        sessionDelegate = delegate
+        self.session = session
+        webSocketTask = task
+        accumulator = AssemblyAITranscriptAccumulator()
+        lastTranscript = .empty
+        audioPacketCount = 0
+        didRequestTerminate = false
+
+        startReceiveLoop()
+
+        try await gate.waitUntilReady(timeout: .seconds(5))
+        logger.info("AssemblyAI WebSocket connected: \(url.absoluteString, privacy: .private(mask: .hash))")
+    }
+
+    func sendAudio(_ data: Data) async throws {
+        guard let task = webSocketTask else { return }
+        audioPacketCount += 1
+        try await task.send(.data(data))
+    }
+
+    func endAudio() async throws {
+        guard let task = webSocketTask else { return }
+        didRequestTerminate = true
+        try await task.send(.string(AssemblyAIProtocol.terminateMessage()))
+    }
+
+    func disconnect() {
+        receiveTask?.cancel()
+        receiveTask = nil
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        webSocketTask = nil
+        session?.invalidateAndCancel()
+        session = nil
+        sessionDelegate = nil
+        connectionGate = nil
+        closeTracker = nil
+        eventContinuation?.finish()
+        eventContinuation = nil
+        _events = nil
+        accumulator = AssemblyAITranscriptAccumulator()
+        lastTranscript = .empty
+        audioPacketCount = 0
+        didRequestTerminate = false
+        logger.info("AssemblyAI disconnected")
+    }
+
+    private func startReceiveLoop() {
+        receiveTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                do {
+                    guard let task = await self.webSocketTask else { break }
+                    let message = try await task.receive()
+                    await self.handleMessage(message)
+                } catch {
+                    if Task.isCancelled {
+                        break
+                    }
+
+                    let gate = await self.connectionGate
+                    let hasBegun = await gate?.hasBegun ?? false
+                    let closeError = await self.closeTracker?.consumeCloseError()
+                    let didRequestTerminate = await self.didRequestTerminate
+                    let audioPacketCount = await self.audioPacketCount
+
+                    if let gate, !hasBegun {
+                        await gate.markFailure(closeError ?? error)
+                    } else if let closeError, !didRequestTerminate {
+                        await self.emitEvent(.error(closeError))
+                        await self.emitEvent(.completed)
+                    } else if didRequestTerminate || audioPacketCount > 0 {
+                        await self.emitEvent(.completed)
+                    } else {
+                        await self.emitEvent(.error(error))
+                        await self.emitEvent(.completed)
+                    }
+                    break
+                }
+            }
+
+            let continuation = await self.eventContinuation
+            continuation?.finish()
+        }
+    }
+
+    private func handleMessage(_ message: URLSessionWebSocketTask.Message) async {
+        do {
+            let data: Data
+            switch message {
+            case .data(let payload):
+                data = payload
+            case .string(let text):
+                data = Data(text.utf8)
+            @unknown default:
+                return
+            }
+
+            guard let event = try AssemblyAIProtocol.parseServerEvent(from: data) else {
+                return
+            }
+
+            switch event {
+            case .begin:
+                if let gate = connectionGate {
+                    await gate.markReady()
+                }
+
+            case .turn(let update):
+                applyTurnUpdate(update)
+
+            case .termination:
+                emitEvent(.completed)
+
+            case .speechStarted:
+                break
+            }
+        } catch {
+            if let gate = connectionGate {
+                await gate.markFailure(error)
+            }
+            emitEvent(.error(error))
+        }
+    }
+
+    private func applyTurnUpdate(_ update: AssemblyAITurnUpdate) {
+        accumulator.apply(update)
+        let transcript = accumulator.transcript
+        guard transcript != lastTranscript else { return }
+        lastTranscript = transcript
+        emitEvent(.transcript(transcript))
+    }
+}
+
+struct AssemblyAITranscriptAccumulator: Sendable {
+
+    private struct TurnState: Sendable {
+        let order: Int
+        var finalizedText: String
+        var displayText: String
+        var isCompleted: Bool
+        var isFormatted: Bool
+    }
+
+    private var turns: [Int: TurnState] = [:]
+
+    mutating func apply(_ update: AssemblyAITurnUpdate) {
+        let existing = turns[update.turnOrder]
+
+        if let existing, existing.isCompleted, !update.isFinal {
+            return
+        }
+
+        if update.isFinal {
+            if let existing, existing.isFormatted, !update.isFormatted {
+                return
+            }
+            turns[update.turnOrder] = TurnState(
+                order: update.turnOrder,
+                finalizedText: update.displayText,
+                displayText: update.displayText,
+                isCompleted: true,
+                isFormatted: update.isFormatted
+            )
+        } else {
+            turns[update.turnOrder] = TurnState(
+                order: update.turnOrder,
+                finalizedText: update.finalizedText,
+                displayText: update.displayText,
+                isCompleted: false,
+                isFormatted: update.isFormatted
+            )
+        }
+    }
+
+    var transcript: RecognitionTranscript {
+        let orderedTurns = turns.values.sorted { $0.order < $1.order }
+
+        var confirmedSegments: [String] = []
+        var existingText = ""
+        var activeTurn: TurnState?
+
+        for turn in orderedTurns {
+            if turn.isCompleted {
+                let normalized = normalize(segment: turn.displayText, after: existingText)
+                confirmedSegments.append(normalized)
+                existingText += normalized
+            } else {
+                activeTurn = turn
+            }
+        }
+
+        var partialText = ""
+        if let activeTurn {
+            if !activeTurn.finalizedText.isEmpty {
+                let normalizedFinalized = normalize(segment: activeTurn.finalizedText, after: existingText)
+                confirmedSegments.append(normalizedFinalized)
+                existingText += normalizedFinalized
+            }
+
+            let rawPartial: String
+            if !activeTurn.finalizedText.isEmpty,
+               activeTurn.displayText.hasPrefix(activeTurn.finalizedText) {
+                rawPartial = String(activeTurn.displayText.dropFirst(activeTurn.finalizedText.count))
+            } else if activeTurn.displayText == activeTurn.finalizedText {
+                rawPartial = ""
+            } else {
+                rawPartial = activeTurn.displayText
+            }
+
+            partialText = normalize(segment: rawPartial, after: existingText)
+        }
+
+        let authoritativeText = (confirmedSegments + (partialText.isEmpty ? [] : [partialText])).joined()
+        return RecognitionTranscript(
+            confirmedSegments: confirmedSegments,
+            partialText: partialText,
+            authoritativeText: authoritativeText,
+            isFinal: activeTurn == nil
+        )
+    }
+
+    private func normalize(segment: String, after existingText: String) -> String {
+        guard !segment.isEmpty else { return "" }
+        guard let last = existingText.last else { return segment }
+        guard let first = segment.first else { return segment }
+
+        if last.isWhitespace || first.isWhitespace {
+            return segment
+        }
+
+        if first.isClosingPunctuation || last.isOpeningPunctuation {
+            return segment
+        }
+
+        if last.isCJKUnifiedIdeograph || first.isCJKUnifiedIdeograph {
+            return segment
+        }
+
+        return " " + segment
+    }
+}
+
+private actor AssemblyAICloseTracker {
+
+    private var closeError: Error?
+
+    func storeCloseError(_ error: Error) {
+        closeError = error
+    }
+
+    func consumeCloseError() -> Error? {
+        let error = closeError
+        closeError = nil
+        return error
+    }
+}
+
+private extension AssemblyAIASRClient {
+    func emitEvent(_ event: RecognitionEvent) {
+        eventContinuation?.yield(event)
+    }
+}
+
+private final class AssemblyAIWebSocketDelegate: NSObject, URLSessionWebSocketDelegate, URLSessionTaskDelegate {
+
+    private let connectionGate: AssemblyAIConnectionGate
+    private let closeTracker: AssemblyAICloseTracker
+
+    init(connectionGate: AssemblyAIConnectionGate, closeTracker: AssemblyAICloseTracker) {
+        self.connectionGate = connectionGate
+        self.closeTracker = closeTracker
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        guard let error else { return }
+        Task {
+            await connectionGate.markFailure(error)
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
+        reason: Data?
+    ) {
+        let reasonText = reason.flatMap { String(data: $0, encoding: .utf8) }
+        let mappedError = AssemblyAIProtocol.makeCloseError(
+            code: Int(closeCode.rawValue),
+            reason: reasonText
+        )
+        Task {
+            await closeTracker.storeCloseError(mappedError)
+            guard await !connectionGate.hasBegun else { return }
+            if case AssemblyAIASRError.unauthorized = mappedError {
+                await connectionGate.markFailure(mappedError)
+            } else if case AssemblyAIASRError.serverCancelled = mappedError {
+                await connectionGate.markFailure(mappedError)
+            } else {
+                await connectionGate.markFailure(
+                    AssemblyAIASRError.closedBeforeSessionBegan(
+                        code: Int(closeCode.rawValue),
+                        reason: reasonText
+                    )
+                )
+            }
+        }
+    }
+}
+
+private extension Character {
+    var isClosingPunctuation: Bool {
+        ",.!?;:)]}\"'".contains(self)
+    }
+
+    var isOpeningPunctuation: Bool {
+        "([{/\"'".contains(self)
+    }
+
+    var isCJKUnifiedIdeograph: Bool {
+        unicodeScalars.contains { scalar in
+            switch scalar.value {
+            case 0x3400...0x4DBF, 0x4E00...0x9FFF, 0xF900...0xFAFF:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+}

--- a/Type4Me/ASR/AssemblyAIConnectionGate.swift
+++ b/Type4Me/ASR/AssemblyAIConnectionGate.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+actor AssemblyAIConnectionGate {
+
+    private var continuation: CheckedContinuation<Void, Error>?
+    private(set) var isReady = false
+    private var failure: Error?
+
+    var hasBegun: Bool { isReady }
+
+    func waitUntilReady(timeout: Duration) async throws {
+        let timeoutTask = Task {
+            try? await Task.sleep(for: timeout)
+            self.markFailure(AssemblyAIASRError.handshakeTimedOut)
+        }
+
+        defer { timeoutTask.cancel() }
+        try await wait()
+    }
+
+    func markReady() {
+        guard !isReady else { return }
+        isReady = true
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func markFailure(_ error: Error) {
+        guard !isReady, failure == nil else { return }
+        failure = error
+        continuation?.resume(throwing: error)
+        continuation = nil
+    }
+
+    private func wait() async throws {
+        if isReady { return }
+        if let failure { throw failure }
+
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+}

--- a/Type4Me/ASR/Providers/AssemblyAIASRConfig.swift
+++ b/Type4Me/ASR/Providers/AssemblyAIASRConfig.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+struct AssemblyAIASRConfig: ASRProviderConfig, Sendable {
+
+    static let provider = ASRProvider.assemblyai
+    static let displayName = "AssemblyAI"
+    static let defaultModel = "universal-streaming-multilingual"
+    static let supportedModels = [
+        "universal-streaming-multilingual",
+        "universal-streaming-english",
+        "u3-rt-pro",
+    ]
+
+    static var credentialFields: [CredentialField] {[
+        CredentialField(
+            key: "apiKey",
+            label: "API Key",
+            placeholder: "aa_...",
+            isSecure: true,
+            isOptional: false,
+            defaultValue: ""
+        ),
+        CredentialField(
+            key: "model",
+            label: L("Streaming Model (不支持中文)", "Streaming Model (No Chinese support)"),
+            placeholder: defaultModel,
+            isSecure: false,
+            isOptional: false,
+            defaultValue: defaultModel
+        ),
+    ]}
+
+    let apiKey: String
+    let model: String
+
+    init?(credentials: [String: String]) {
+        guard let apiKey = Self.sanitized(credentials["apiKey"]),
+              !apiKey.isEmpty
+        else {
+            return nil
+        }
+
+        let rawModel = Self.sanitized(credentials["model"])?.lowercased() ?? ""
+        self.apiKey = apiKey
+        self.model = Self.supportedModels.contains(rawModel) ? rawModel : Self.defaultModel
+    }
+
+    func toCredentials() -> [String: String] {
+        [
+            "apiKey": apiKey,
+            "model": model,
+        ]
+    }
+
+    var isValid: Bool {
+        !apiKey.isEmpty && Self.supportedModels.contains(model)
+    }
+
+    private static func sanitized(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Type4Me/Protocol/AssemblyAIProtocol.swift
+++ b/Type4Me/Protocol/AssemblyAIProtocol.swift
@@ -1,0 +1,294 @@
+import Foundation
+
+enum AssemblyAIProtocolError: Error, LocalizedError, Equatable {
+    case invalidEndpoint
+    case invalidMessage
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidEndpoint:
+            return "Failed to build AssemblyAI WebSocket URL"
+        case .invalidMessage:
+            return "Invalid AssemblyAI streaming message"
+        }
+    }
+}
+
+struct AssemblyAITurnUpdate: Sendable, Equatable {
+    let turnOrder: Int
+    let finalizedText: String
+    let displayText: String
+    let authoritativeText: String
+    let isFinal: Bool
+    let isFormatted: Bool
+}
+
+enum AssemblyAIServerEvent: Sendable, Equatable {
+    case begin(id: String, expiresAt: Int?)
+    case turn(AssemblyAITurnUpdate)
+    case termination(audioDurationSeconds: Double?)
+    case speechStarted
+}
+
+enum AssemblyAIProtocol {
+
+    private static let endpoint = "wss://streaming.assemblyai.com/v3/ws"
+    private static let maxKeytermCount = 100
+    private static let maxKeytermLength = 50
+
+    static func buildWebSocketURL(
+        config: AssemblyAIASRConfig,
+        options: ASRRequestOptions
+    ) throws -> URL {
+        guard var components = URLComponents(string: endpoint) else {
+            throw AssemblyAIProtocolError.invalidEndpoint
+        }
+
+        var queryItems = [
+            URLQueryItem(name: "sample_rate", value: "16000"),
+            URLQueryItem(name: "encoding", value: "pcm_s16le"),
+            URLQueryItem(name: "speech_model", value: config.model),
+        ]
+
+        if usesFormatTurns(model: config.model) {
+            queryItems.append(
+                URLQueryItem(name: "format_turns", value: options.enablePunc ? "true" : "false")
+            )
+        }
+
+        if let encodedKeyterms = encodedKeytermsPrompt(from: options.hotwords) {
+            queryItems.append(URLQueryItem(name: "keyterms_prompt", value: encodedKeyterms))
+        }
+
+        components.queryItems = queryItems
+
+        guard let url = components.url else {
+            throw AssemblyAIProtocolError.invalidEndpoint
+        }
+        return url
+    }
+
+    static func terminateMessage() -> String {
+        #"{"type":"Terminate"}"#
+    }
+
+    static func parseServerEvent(from data: Data) throws -> AssemblyAIServerEvent? {
+        let decoder = JSONDecoder()
+        let envelope = try decoder.decode(Envelope.self, from: data)
+
+        switch envelope.type {
+        case "Begin":
+            let begin = try decoder.decode(BeginMessage.self, from: data)
+            return .begin(id: begin.id, expiresAt: begin.expiresAt)
+
+        case "Turn":
+            let turn = try decoder.decode(TurnMessage.self, from: data)
+            guard let update = makeTurnUpdate(from: turn) else {
+                return nil
+            }
+            return .turn(update)
+
+        case "Termination":
+            let termination = try decoder.decode(TerminationMessage.self, from: data)
+            return .termination(audioDurationSeconds: termination.audioDurationSeconds)
+
+        case "SpeechStarted":
+            return .speechStarted
+
+        default:
+            return nil
+        }
+    }
+
+    static func makeTurnUpdate(from message: TurnMessage) -> AssemblyAITurnUpdate? {
+        let transcript = sanitized(message.transcript) ?? ""
+        let words = message.words ?? []
+        let displayText = transcriptText(from: message, transcript: transcript)
+        let finalizedText = message.endOfTurn ? displayText : finalizedPrefix(from: words)
+
+        guard !displayText.isEmpty || !finalizedText.isEmpty || message.endOfTurn else {
+            return nil
+        }
+
+        let authoritativeText = message.endOfTurn ? displayText : finalizedText
+
+        return AssemblyAITurnUpdate(
+            turnOrder: message.turnOrder,
+            finalizedText: finalizedText,
+            displayText: displayText,
+            authoritativeText: authoritativeText,
+            isFinal: message.endOfTurn,
+            isFormatted: message.turnIsFormatted
+        )
+    }
+
+    static func makeCloseError(code: Int, reason: String?) -> AssemblyAIASRError {
+        let cleanReason = sanitized(reason)
+        switch code {
+        case 1008:
+            return AssemblyAIASRError.unauthorized(reason: cleanReason)
+        case 3005:
+            return AssemblyAIASRError.serverCancelled(reason: cleanReason)
+        default:
+            return AssemblyAIASRError.closed(code: code, reason: cleanReason)
+        }
+    }
+
+    private static func usesFormatTurns(model: String) -> Bool {
+        model != "u3-rt-pro"
+    }
+
+    private static func sanitizedKeyterms(from hotwords: [String]) -> [String] {
+        hotwords
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .map { String($0.prefix(maxKeytermLength)) }
+            .prefix(maxKeytermCount)
+            .map { $0 }
+    }
+
+    private static func encodedKeytermsPrompt(from hotwords: [String]) -> String? {
+        let keyterms = sanitizedKeyterms(from: hotwords)
+        guard !keyterms.isEmpty else { return nil }
+        guard let data = try? JSONSerialization.data(withJSONObject: keyterms, options: []) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func transcriptText(from message: TurnMessage, transcript: String) -> String {
+        if message.endOfTurn {
+            return !transcript.isEmpty ? transcript : joinWords(message.words ?? [])
+        }
+
+        let joinedWords = joinWords(message.words ?? [])
+        if joinedWords.isEmpty {
+            return transcript
+        }
+
+        if transcript.isEmpty {
+            return joinedWords
+        }
+
+        return joinedWords.count >= transcript.count ? joinedWords : transcript
+    }
+
+    private static func finalizedPrefix(from words: [TurnWord]) -> String {
+        let finalizedWords = words.prefix { $0.wordIsFinal }
+        return joinWords(Array(finalizedWords))
+    }
+
+    private static func joinWords(_ words: [TurnWord]) -> String {
+        var text = ""
+        for word in words {
+            let token = sanitized(word.text) ?? ""
+            guard !token.isEmpty else { continue }
+            text += normalized(segment: token, after: text)
+        }
+        return text
+    }
+
+    private static func normalized(segment: String, after existingText: String) -> String {
+        guard !segment.isEmpty else { return "" }
+        guard let last = existingText.last else { return segment }
+        guard let first = segment.first else { return segment }
+
+        if last.isWhitespace || first.isWhitespace {
+            return segment
+        }
+
+        if first.isClosingPunctuation || last.isOpeningPunctuation {
+            return segment
+        }
+
+        if last.isCJKUnifiedIdeograph || first.isCJKUnifiedIdeograph {
+            return segment
+        }
+
+        return " " + segment
+    }
+
+    private static func sanitized(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private struct Envelope: Decodable {
+        let type: String
+    }
+
+    private struct BeginMessage: Decodable {
+        let type: String
+        let id: String
+        let expiresAt: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case id
+            case expiresAt = "expires_at"
+        }
+    }
+
+    struct TurnMessage: Decodable, Sendable {
+        let type: String
+        let turnOrder: Int
+        let turnIsFormatted: Bool
+        let endOfTurn: Bool
+        let transcript: String
+        let words: [TurnWord]?
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case turnOrder = "turn_order"
+            case turnIsFormatted = "turn_is_formatted"
+            case endOfTurn = "end_of_turn"
+            case transcript
+            case words
+        }
+    }
+
+    struct TurnWord: Decodable, Sendable, Equatable {
+        let text: String
+        let wordIsFinal: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case text
+            case wordIsFinal = "word_is_final"
+        }
+    }
+
+    private struct TerminationMessage: Decodable {
+        let type: String
+        let audioDurationSeconds: Double?
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case audioDurationSeconds = "audio_duration_seconds"
+        }
+    }
+}
+
+private extension Character {
+    var isClosingPunctuation: Bool {
+        ",.!?;:)]}\"'".contains(self)
+    }
+
+    var isOpeningPunctuation: Bool {
+        "([{/\"'".contains(self)
+    }
+
+    var isCJKUnifiedIdeograph: Bool {
+        unicodeScalars.contains { scalar in
+            switch scalar.value {
+            case 0x3400...0x4DBF, 0x4E00...0x9FFF, 0xF900...0xFAFF:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+}

--- a/Type4MeTests/ASRProviderRegistryTests.swift
+++ b/Type4MeTests/ASRProviderRegistryTests.swift
@@ -9,8 +9,8 @@ final class ASRProviderRegistryTests: XCTestCase {
         XCTAssertNil(ASRProviderRegistry.unsupportedReason(for: .performance, provider: .volcano))
     }
 
-    func testBailianAndDeepgramOnlySupportQuickMode() {
-        for provider in [ASRProvider.bailian, .deepgram] {
+    func testQuickOnlyProvidersOnlySupportQuickMode() {
+        for provider in [ASRProvider.bailian, .deepgram, .assemblyai] {
             XCTAssertTrue(ASRProviderRegistry.supports(.direct, for: provider))
             XCTAssertFalse(ASRProviderRegistry.supports(.performance, for: provider))
             XCTAssertEqual(
@@ -32,6 +32,10 @@ final class ASRProviderRegistryTests: XCTestCase {
             ASRProviderRegistry.resolvedMode(for: .performance, provider: .deepgram).id,
             ProcessingMode.directId
         )
+        XCTAssertEqual(
+            ASRProviderRegistry.resolvedMode(for: .performance, provider: .assemblyai).id,
+            ProcessingMode.directId
+        )
     }
 
     func testSupportedModesFilterOnlyRemovesPerformanceModeForQuickOnlyProviders() {
@@ -45,6 +49,9 @@ final class ASRProviderRegistryTests: XCTestCase {
 
         let bailianModes = ASRProviderRegistry.supportedModes(from: modes, for: .bailian)
         XCTAssertEqual(bailianModes.map(\.id), [ProcessingMode.directId, customMode.id])
+
+        let assemblyModes = ASRProviderRegistry.supportedModes(from: modes, for: .assemblyai)
+        XCTAssertEqual(assemblyModes.map(\.id), [ProcessingMode.directId, customMode.id])
 
         let volcanoModes = ASRProviderRegistry.supportedModes(from: modes, for: .volcano)
         XCTAssertEqual(volcanoModes.map(\.id), [ProcessingMode.directId, ProcessingMode.performanceId, customMode.id])

--- a/Type4MeTests/AssemblyAIASRConfigTests.swift
+++ b/Type4MeTests/AssemblyAIASRConfigTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import Type4Me
+
+final class AssemblyAIASRConfigTests: XCTestCase {
+
+    func testInit_usesDefaultModelWhenMissing() throws {
+        let config = try XCTUnwrap(AssemblyAIASRConfig(credentials: [
+            "apiKey": "aa_test_key",
+        ]))
+
+        XCTAssertEqual(config.model, AssemblyAIASRConfig.defaultModel)
+        XCTAssertTrue(config.isValid)
+    }
+
+    func testInit_rejectsMissingAPIKey() {
+        XCTAssertNil(AssemblyAIASRConfig(credentials: [:]))
+        XCTAssertNil(AssemblyAIASRConfig(credentials: ["apiKey": "   "]))
+    }
+
+    func testInit_fallsBackToDefaultModelForUnsupportedValue() throws {
+        let config = try XCTUnwrap(AssemblyAIASRConfig(credentials: [
+            "apiKey": "aa_test_key",
+            "model": "whisper-rt",
+        ]))
+
+        XCTAssertEqual(config.model, AssemblyAIASRConfig.defaultModel)
+    }
+
+    func testToCredentials_roundTrips() throws {
+        let config = try XCTUnwrap(AssemblyAIASRConfig(credentials: [
+            "apiKey": "aa_test_key",
+            "model": "u3-rt-pro",
+        ]))
+
+        XCTAssertEqual(
+            config.toCredentials(),
+            [
+                "apiKey": "aa_test_key",
+                "model": "u3-rt-pro",
+            ]
+        )
+    }
+}

--- a/Type4MeTests/AssemblyAIProtocolTests.swift
+++ b/Type4MeTests/AssemblyAIProtocolTests.swift
@@ -1,0 +1,221 @@
+import XCTest
+@testable import Type4Me
+
+final class AssemblyAIProtocolTests: XCTestCase {
+
+    func testBuildWebSocketURL_usesExpectedQueryItemsForUniversalStreaming() throws {
+        let config = try XCTUnwrap(AssemblyAIASRConfig(credentials: [
+            "apiKey": "aa_test_key",
+            "model": "universal-streaming-multilingual",
+        ]))
+
+        let url = try AssemblyAIProtocol.buildWebSocketURL(
+            config: config,
+            options: ASRRequestOptions(
+                enablePunc: true,
+                hotwords: [" Type4Me ", String(repeating: "a", count: 70), "keep-me"],
+                boostingTableID: "ignored"
+            )
+        )
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let items = components.queryItems ?? []
+
+        XCTAssertEqual(components.scheme, "wss")
+        XCTAssertEqual(components.host, "streaming.assemblyai.com")
+        XCTAssertEqual(components.path, "/v3/ws")
+        XCTAssertEqual(items.value(for: "sample_rate"), "16000")
+        XCTAssertEqual(items.value(for: "encoding"), "pcm_s16le")
+        XCTAssertEqual(items.value(for: "speech_model"), "universal-streaming-multilingual")
+        XCTAssertEqual(items.value(for: "format_turns"), "true")
+        XCTAssertEqual(
+            items.value(for: "keyterms_prompt"),
+            "[\"Type4Me\",\"\(String(repeating: "a", count: 50))\",\"keep-me\"]"
+        )
+    }
+
+    func testBuildWebSocketURL_omitsFormatTurnsForU3() throws {
+        let config = try XCTUnwrap(AssemblyAIASRConfig(credentials: [
+            "apiKey": "aa_test_key",
+            "model": "u3-rt-pro",
+        ]))
+
+        let url = try AssemblyAIProtocol.buildWebSocketURL(
+            config: config,
+            options: ASRRequestOptions(enablePunc: false, hotwords: ["alpha"])
+        )
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let items = components.queryItems ?? []
+
+        XCTAssertNil(items.value(for: "format_turns"))
+        XCTAssertEqual(items.value(for: "keyterms_prompt"), "[\"alpha\"]")
+    }
+
+    func testParseServerEvent_parsesBegin() throws {
+        let message = """
+        {
+          "type": "Begin",
+          "id": "session-123",
+          "expires_at": 1759796682
+        }
+        """
+
+        let event = try XCTUnwrap(AssemblyAIProtocol.parseServerEvent(from: Data(message.utf8)))
+        XCTAssertEqual(event, .begin(id: "session-123", expiresAt: 1759796682))
+    }
+
+    func testParseServerEvent_buildsPartialTranscriptForUniversalStreaming() throws {
+        let message = """
+        {
+          "type": "Turn",
+          "turn_order": 0,
+          "turn_is_formatted": true,
+          "end_of_turn": false,
+          "transcript": "Hello",
+          "words": [
+            { "text": "Hello", "word_is_final": true },
+            { "text": "world", "word_is_final": false }
+          ]
+        }
+        """
+
+        let event = try XCTUnwrap(AssemblyAIProtocol.parseServerEvent(from: Data(message.utf8)))
+        guard case .turn(let update) = event else {
+            return XCTFail("Expected turn event")
+        }
+
+        XCTAssertEqual(update.turnOrder, 0)
+        XCTAssertEqual(update.finalizedText, "Hello")
+        XCTAssertEqual(update.displayText, "Hello world")
+        XCTAssertFalse(update.isFinal)
+        XCTAssertTrue(update.isFormatted)
+    }
+
+    func testParseServerEvent_buildsFinalTranscript() throws {
+        let message = """
+        {
+          "type": "Turn",
+          "turn_order": 0,
+          "turn_is_formatted": true,
+          "end_of_turn": true,
+          "transcript": "Hello world.",
+          "words": [
+            { "text": "Hello", "word_is_final": true },
+            { "text": "world.", "word_is_final": true }
+          ]
+        }
+        """
+
+        let event = try XCTUnwrap(AssemblyAIProtocol.parseServerEvent(from: Data(message.utf8)))
+        guard case .turn(let update) = event else {
+            return XCTFail("Expected turn event")
+        }
+
+        XCTAssertEqual(update.finalizedText, "Hello world.")
+        XCTAssertEqual(update.displayText, "Hello world.")
+        XCTAssertTrue(update.isFinal)
+    }
+
+    func testParseServerEvent_supportsU3StylePartialWithoutFinalWords() throws {
+        let message = """
+        {
+          "type": "Turn",
+          "turn_order": 2,
+          "turn_is_formatted": false,
+          "end_of_turn": false,
+          "transcript": "Its 8888-8888",
+          "words": [
+            { "text": "Its", "word_is_final": false },
+            { "text": "8888-8888", "word_is_final": false }
+          ]
+        }
+        """
+
+        let event = try XCTUnwrap(AssemblyAIProtocol.parseServerEvent(from: Data(message.utf8)))
+        guard case .turn(let update) = event else {
+            return XCTFail("Expected turn event")
+        }
+
+        XCTAssertEqual(update.finalizedText, "")
+        XCTAssertEqual(update.displayText, "Its 8888-8888")
+        XCTAssertFalse(update.isFinal)
+    }
+
+    func testParseServerEvent_parsesTermination() throws {
+        let message = """
+        {
+          "type": "Termination",
+          "audio_duration_seconds": 3.2
+        }
+        """
+
+        let event = try XCTUnwrap(AssemblyAIProtocol.parseServerEvent(from: Data(message.utf8)))
+        XCTAssertEqual(event, .termination(audioDurationSeconds: 3.2))
+    }
+
+    func testParseServerEvent_throwsForInvalidJSON() {
+        XCTAssertThrowsError(
+            try AssemblyAIProtocol.parseServerEvent(from: Data("{".utf8))
+        )
+    }
+
+    func testMakeCloseError_mapsCommonCodes() {
+        let unauthorized = AssemblyAIProtocol.makeCloseError(code: 1008, reason: "Missing Authorization header")
+        let cancelled = AssemblyAIProtocol.makeCloseError(code: 3005, reason: "An error occurred")
+        let generic = AssemblyAIProtocol.makeCloseError(code: 3007, reason: "Input duration violation")
+
+        XCTAssertEqual(
+            unauthorized.errorDescription,
+            "AssemblyAI unauthorized connection: Missing Authorization header"
+        )
+        XCTAssertEqual(
+            cancelled.errorDescription,
+            "AssemblyAI session cancelled: An error occurred"
+        )
+        XCTAssertEqual(
+            generic.errorDescription,
+            "AssemblyAI session closed (3007): Input duration violation"
+        )
+    }
+
+    func testTurnUpdates_canModelFormattedOverwriteForSameTurn() throws {
+        let partial = try XCTUnwrap(
+            AssemblyAIProtocol.makeTurnUpdate(
+                from: .init(
+                    type: "Turn",
+                    turnOrder: 0,
+                    turnIsFormatted: false,
+                    endOfTurn: true,
+                    transcript: "hello world",
+                    words: [
+                        .init(text: "hello", wordIsFinal: true),
+                        .init(text: "world", wordIsFinal: true),
+                    ]
+                )
+            )
+        )
+        let formatted = try XCTUnwrap(
+            AssemblyAIProtocol.makeTurnUpdate(
+                from: .init(
+                    type: "Turn",
+                    turnOrder: 0,
+                    turnIsFormatted: true,
+                    endOfTurn: true,
+                    transcript: "Hello world.",
+                    words: [
+                        .init(text: "Hello", wordIsFinal: true),
+                        .init(text: "world.", wordIsFinal: true),
+                    ]
+                )
+            )
+        )
+
+        XCTAssertEqual(partial.displayText, "hello world")
+        XCTAssertEqual(formatted.displayText, "Hello world.")
+    }
+}
+
+private extension [URLQueryItem] {
+    func value(for name: String) -> String? {
+        first(where: { $0.name == name })?.value
+    }
+}

--- a/Type4MeTests/AssemblyAITranscriptAccumulatorTests.swift
+++ b/Type4MeTests/AssemblyAITranscriptAccumulatorTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import Type4Me
+
+final class AssemblyAITranscriptAccumulatorTests: XCTestCase {
+
+    func testPartialTranscript_splitsCurrentTurnIntoConfirmedAndPartial() {
+        var accumulator = AssemblyAITranscriptAccumulator()
+        accumulator.apply(.init(
+            turnOrder: 0,
+            finalizedText: "Hello",
+            displayText: "Hello world",
+            authoritativeText: "Hello",
+            isFinal: false,
+            isFormatted: true
+        ))
+
+        let transcript = accumulator.transcript
+        XCTAssertEqual(transcript.confirmedSegments, ["Hello"])
+        XCTAssertEqual(transcript.partialText, " world")
+        XCTAssertEqual(transcript.authoritativeText, "Hello world")
+        XCTAssertFalse(transcript.isFinal)
+    }
+
+    func testFinalTurn_movesWholeTurnIntoConfirmedSegments() {
+        var accumulator = AssemblyAITranscriptAccumulator()
+        accumulator.apply(.init(
+            turnOrder: 0,
+            finalizedText: "Hello world.",
+            displayText: "Hello world.",
+            authoritativeText: "Hello world.",
+            isFinal: true,
+            isFormatted: true
+        ))
+
+        let transcript = accumulator.transcript
+        XCTAssertEqual(transcript.confirmedSegments, ["Hello world."])
+        XCTAssertEqual(transcript.partialText, "")
+        XCTAssertEqual(transcript.authoritativeText, "Hello world.")
+        XCTAssertTrue(transcript.isFinal)
+    }
+
+    func testFormattedFinalUpdate_overwritesPriorUnformattedTurn() {
+        var accumulator = AssemblyAITranscriptAccumulator()
+        accumulator.apply(.init(
+            turnOrder: 0,
+            finalizedText: "hello world",
+            displayText: "hello world",
+            authoritativeText: "hello world",
+            isFinal: true,
+            isFormatted: false
+        ))
+        accumulator.apply(.init(
+            turnOrder: 0,
+            finalizedText: "Hello world.",
+            displayText: "Hello world.",
+            authoritativeText: "Hello world.",
+            isFinal: true,
+            isFormatted: true
+        ))
+
+        XCTAssertEqual(accumulator.transcript.confirmedSegments, ["Hello world."])
+        XCTAssertEqual(accumulator.transcript.authoritativeText, "Hello world.")
+    }
+
+    func testMultipleTurns_keepWhitespaceBetweenSegments() {
+        var accumulator = AssemblyAITranscriptAccumulator()
+        accumulator.apply(.init(
+            turnOrder: 0,
+            finalizedText: "Hello world.",
+            displayText: "Hello world.",
+            authoritativeText: "Hello world.",
+            isFinal: true,
+            isFormatted: true
+        ))
+        accumulator.apply(.init(
+            turnOrder: 1,
+            finalizedText: "I am",
+            displayText: "I am testing",
+            authoritativeText: "I am",
+            isFinal: false,
+            isFormatted: true
+        ))
+
+        let transcript = accumulator.transcript
+        XCTAssertEqual(transcript.confirmedSegments, ["Hello world.", " I am"])
+        XCTAssertEqual(transcript.partialText, " testing")
+        XCTAssertEqual(transcript.authoritativeText, "Hello world. I am testing")
+    }
+
+    func testU3PartialWithoutFinalizedPrefix_keepsWholeTextAsPartial() {
+        var accumulator = AssemblyAITranscriptAccumulator()
+        accumulator.apply(.init(
+            turnOrder: 0,
+            finalizedText: "",
+            displayText: "Its 8888-8888",
+            authoritativeText: "",
+            isFinal: false,
+            isFormatted: false
+        ))
+
+        let transcript = accumulator.transcript
+        XCTAssertEqual(transcript.confirmedSegments, [])
+        XCTAssertEqual(transcript.partialText, "Its 8888-8888")
+        XCTAssertEqual(transcript.authoritativeText, "Its 8888-8888")
+        XCTAssertFalse(transcript.isFinal)
+    }
+}

--- a/Type4MeTests/RecognitionSessionTests.swift
+++ b/Type4MeTests/RecognitionSessionTests.swift
@@ -50,4 +50,14 @@ final class RecognitionSessionTests: XCTestCase {
         let mode = await session.currentModeForTesting()
         XCTAssertEqual(mode.id, ProcessingMode.performanceId)
     }
+
+    func testSwitchModeFallsBackToDirectForAssemblyAI() async {
+        KeychainService.selectedASRProvider = .assemblyai
+        let session = RecognitionSession()
+
+        await session.switchMode(to: .performance)
+
+        let mode = await session.currentModeForTesting()
+        XCTAssertEqual(mode.id, ProcessingMode.directId)
+    }
 }


### PR DESCRIPTION
## Summary

- add AssemblyAI as a new quick-mode ASR provider
- implement AssemblyAI streaming config, protocol parsing, connection lifecycle, and transcript accumulation
- add tests for config validation, WebSocket URL generation, turn parsing, transcript accumulation, registry capabilities, and processing-mode fallback

### 概要

- 新增 AssemblyAI 作为一个新的快速模式 ASR provider
- 实现了 AssemblyAI 流式识别所需的配置、协议解析、连接生命周期管理和 transcript 累积逻辑
- 补充了配置校验、WebSocket URL 生成、turn 解析、transcript 累积、provider capability 和 mode fallback 的测试覆盖

## Why AssemblyAI

We want to support AssemblyAI because:

1. AssemblyAI has very strong English ASR accuracy (better performance comparing to GPT-4o transcribe)

<img width="3806" height="358" alt="CleanShot 2026-03-26 at 14 13 49@2x" src="https://github.com/user-attachments/assets/d4f6474b-3d8b-49ab-b0b8-9185ce35b7e6" />

2. it offers a generous free tier: ["Transcribe up to 333 hours of streaming audio for free"](https://www.assemblyai.com/pricing)
3. it is known for strong production stability and is used as the ASR provider **behind products like Zoom Granola** ([reference](https://www.assemblyai.com/customers/zoom-customer-story))

### 为什么接入 AssemblyAI

我们希望支持 AssemblyAI，主要有几个原因：

1. AssemblyAI 在英文识别上的准确率非常高，实测效果优于 GPT-4o transcribe
2. 它的免费额度比较慷慨：可免费转写最多 333 小时的流式音频
3. 它的系统稳定性很好，并且已经被 Zoom Granola 这类产品用作底层 ASR provider

## Implementation Notes

- this provider is intentionally quick-mode only for now
- the default model is `universal-streaming-multilingual`, and supports: `u3-rt-pro` and `universal-streaming-english`
- the `universal-streaming-multilingual` model supports English, Spanish, French, German, Italian, and Portuguese ([reference](https://www.assemblyai.com/docs/streaming/universal-streaming/multilingual-transcription#supported-languages))

### 实现说明

- 这次接入暂时只支持快速模式，不支持性能模式
- 默认模型为 `universal-streaming-multilingual`，同时支持 `u3-rt-pro` 和 `universal-streaming-english`
- `universal-streaming-multilingual` 当前支持英语、西班牙语、法语、德语、意大利语和葡萄牙语
- 本次实现还修复了 AssemblyAI 热词参数的编码方式，确保 hotwords 在开启时不会导致连接失败

## Validation

https://github.com/user-attachments/assets/2dc0d722-27d9-44e0-8d16-95a84848bbbd

- manual test: AssemblyAI connection test passes
- manual test: streaming dictation works with hotwords enabled/disabled
- `swift test --filter AssemblyAI`
- `swift test --filter ASRProviderRegistryTests`
- `swift test --filter RecognitionSessionTests`

### 验证

- 手动测试：AssemblyAI 的连接测试通过
- 手动测试：开启和关闭 hotwords 时，流式听写都可以正常工作
- `swift test --filter AssemblyAI`
- `swift test --filter ASRProviderRegistryTests`
- `swift test --filter RecognitionSessionTests`

## Notes

- full test coverage for the new AssemblyAI path is included
- the repo still has an unrelated existing full-suite test failure in `AppStateTests`, not introduced by this change

### 备注

- 本次 PR 已为新增的 AssemblyAI 路径补充完整测试覆盖
- 当前仓库的全量测试中仍有一个与本次改动无关的既有失败，位于 `AppStateTests`，不是这次改动引入的
