### PR TITLE
fix(build): 修正xcframework构建中的头文件路径错误

### DIFF
--- a/scripts/build-sherpa.sh
+++ b/scripts/build-sherpa.sh
@@ -83,7 +83,7 @@ if [ -f "$INSTALL_LIB/libonnxruntime.a" ]; then
     rm -rf "$BUILD_DIR/sherpa-onnx/build-swift-macos/sherpa-onnx.xcframework"
     xcodebuild -create-xcframework \
         -library "$INSTALL_LIB/libsherpa-onnx.a" \
-        -headers "$INSTALL_LIB/../install/include" \
+        -headers "$INSTALL_LIB/../include" \
         -output "$BUILD_DIR/sherpa-onnx/build-swift-macos/sherpa-onnx.xcframework"
     echo "→ xcframework rebuilt with onnxruntime"
 fi


### PR DESCRIPTION

执行 构建脚本 scripts/build-sherpa.sh 出现错误：

→ Rebuilding xcframework...
error: the path does not point to a valid headers location: type4me/.build-sherpa/sherpa-onnx/build-swift-macos/install/install/include