### PR TITLE
chore: remove outdated engine field from about page 删掉了【关于页面】硬编码的火山引擎字段

### DIFF
--- a/Type4Me/UI/Settings/AboutTab.swift
+++ b/Type4Me/UI/Settings/AboutTab.swift
@@ -21,8 +21,6 @@ struct AboutTab: View {
             SettingsDivider()
             SettingsRow(label: L("平台", "Platform"), value: "macOS 14+")
             SettingsDivider()
-            SettingsRow(label: L("引擎", "Engine"), value: L("火山引擎 Doubao Bigmodel", "Volcano Doubao Bigmodel"))
-            SettingsDivider()
             SettingsRow(label: L("许可证", "License"), value: "MIT")
 
             Spacer().frame(height: 24)


### PR DESCRIPTION
## Summary

- remove the hardcoded `Engine` row from the About Type4Me page

## Why

The About page currently shows a hardcoded engine value:

- `Volcano Doubao Bigmodel`

**This is no longer accurate now that the app supports multiple ASR providers, including Deepgram, AssemblyAI, and Alibaba Cloud Bailian.**

Rather than showing stale provider-specific information in a static About page, this change removes the field entirely.

## Validation

- visual check of the About Type4Me page
- confirm the About layout still looks correct after removing the row
