### PR TITLE
fix: build-sherpa.sh headers path and bridge file overwrite

### DIFF
--- a/scripts/build-sherpa.sh
+++ b/scripts/build-sherpa.sh
@@ -83,7 +83,7 @@ if [ -f "$INSTALL_LIB/libonnxruntime.a" ]; then
     rm -rf "$BUILD_DIR/sherpa-onnx/build-swift-macos/sherpa-onnx.xcframework"
     xcodebuild -create-xcframework \
         -library "$INSTALL_LIB/libsherpa-onnx.a" \
-        -headers "$INSTALL_LIB/../install/include" \
+        -headers "$INSTALL_LIB/../include" \
         -output "$BUILD_DIR/sherpa-onnx/build-swift-macos/sherpa-onnx.xcframework"
     echo "→ xcframework rebuilt with onnxruntime"
 fi
@@ -123,14 +123,17 @@ MODULEMAP
 fi
 
 # 4. Copy the Swift API wrapper
-echo "→ Copying Swift API wrapper..."
-SWIFT_API="$BUILD_DIR/sherpa-onnx/swift-api-examples/SherpaOnnx.swift"
-if [ -f "$SWIFT_API" ]; then
-    cp "$SWIFT_API" "$BRIDGE_DIR/SherpaOnnxBridge.swift"
-    echo "→ Copied SherpaOnnx.swift → Type4Me/Bridge/SherpaOnnxBridge.swift"
+echo "→ Checking Swift API wrapper..."
+if [ -f "$BRIDGE_DIR/SherpaOnnxBridge.swift" ]; then
+    echo "→ SherpaOnnxBridge.swift already exists, skipping copy (preserving project customizations)"
 else
-    echo "WARNING: SherpaOnnx.swift not found at $SWIFT_API"
-    echo "  You'll need to manually copy it from the sherpa-onnx repo."
+    SWIFT_API="$BUILD_DIR/sherpa-onnx/swift-api-examples/SherpaOnnx.swift"
+    if [ -f "$SWIFT_API" ]; then
+        cp "$SWIFT_API" "$BRIDGE_DIR/SherpaOnnxBridge.swift"
+        echo "→ Copied SherpaOnnx.swift → Type4Me/Bridge/SherpaOnnxBridge.swift"
+    else
+        echo "WARNING: SherpaOnnx.swift not found at $SWIFT_API"
+    fi
 fi
 
 # 5. Copy C header (if needed for bridging)


### PR DESCRIPTION
## Summary

- **Fix headers path**: `$INSTALL_LIB/../install/include` → `$INSTALL_LIB/../include` — the extra `install` segment caused `xcodebuild -create-xcframework` to fail with "the path does not point to a valid headers location"
- **Preserve SherpaOnnxBridge.swift**: skip copying upstream `SherpaOnnx.swift` when the project's customized bridge file already exists (with `#if HAS_SHERPA_ONNX` / `import SherpaOnnxLib`), preventing compilation errors

## Test plan
- [ ] Run `bash scripts/build-sherpa.sh` from a clean state (no existing framework) — should complete without errors
- [ ] Run `bash scripts/build-sherpa.sh` again with existing `SherpaOnnxBridge.swift` — should skip the copy step
- [ ] Run `bash scripts/deploy.sh` — should compile and deploy successfully