### PR TITLE
feat(packaging): add dmg build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ bash scripts/deploy.sh
 
 脚本会自动完成：编译 → 打包为 `.app` → 签名 → 安装到 `/Applications/` → 启动。
 
+如果需要生成可分发的 DMG 安装包，可执行：
+
+```bash
+bash scripts/build-dmg.sh
+```
+
 #### 第四步：下载识别模型
 
 本地识别需要下载模型文件。三种模型可选：

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && /bin/pwd -P)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && /bin/pwd -P)"
+APP_NAME="Type4Me"
+APP_VERSION="${APP_VERSION:-1.2.4}"
+DIST_DIR="${DIST_DIR:-$PROJECT_DIR/dist}"
+DMG_NAME="${DMG_NAME:-${APP_NAME}-v${APP_VERSION}.dmg}"
+DMG_PATH="$DIST_DIR/$DMG_NAME"
+VOLUME_NAME="${VOLUME_NAME:-$APP_NAME}"
+STAGING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/type4me-dmg.XXXXXX")"
+
+cleanup() {
+    rm -rf "$STAGING_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$DIST_DIR"
+
+APP_PATH="$STAGING_DIR/${APP_NAME}.app" bash "$SCRIPT_DIR/package-app.sh"
+ln -s /Applications "$STAGING_DIR/Applications"
+
+rm -f "$DMG_PATH"
+echo "Creating DMG at $DMG_PATH..."
+hdiutil create \
+    -volname "$VOLUME_NAME" \
+    -srcfolder "$STAGING_DIR" \
+    -ov \
+    -format UDZO \
+    "$DMG_PATH"
+
+echo "DMG ready at $DMG_PATH"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,99 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
-PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && /bin/pwd -P)"
 APP_PATH="${APP_PATH:-/Applications/Type4Me.app}"
 APP_NAME="Type4Me"
-APP_EXECUTABLE="Type4Me"
-APP_ICON_NAME="AppIcon"
-APP_BUNDLE_ID="${APP_BUNDLE_ID:-com.type4me.app}"
-APP_VERSION="${APP_VERSION:-1.2.4}"
-APP_BUILD="${APP_BUILD:-1}"
-MIN_SYSTEM_VERSION="${MIN_SYSTEM_VERSION:-14.0}"
-MICROPHONE_USAGE_DESCRIPTION="${MICROPHONE_USAGE_DESCRIPTION:-Type4Me 需要访问麦克风以录制语音并将其转换为文本。}"
-APPLE_EVENTS_USAGE_DESCRIPTION="${APPLE_EVENTS_USAGE_DESCRIPTION:-Type4Me 需要辅助功能权限来注入转写文字到其他应用}"
 LAUNCH_APP="${LAUNCH_APP:-1}"
-INFO_PLIST="$APP_PATH/Contents/Info.plist"
-if [ -n "${CODESIGN_IDENTITY:-}" ]; then
-    SIGNING_IDENTITY="$CODESIGN_IDENTITY"
-elif security find-identity -v -p codesigning 2>/dev/null | grep -q "Type4Me Dev"; then
-    SIGNING_IDENTITY="Type4Me Dev"
-else
-    SIGNING_IDENTITY="-"
-fi
-
-echo "Building universal release (arm64 + x86_64)..."
-swift build -c release --package-path "$PROJECT_DIR" --arch arm64 --arch x86_64 2>&1 | grep -E "Build complete|Build succeeded|error:|warning:" || true
-
-if [ -f "$PROJECT_DIR/.build/apple/Products/Release/Type4Me" ]; then
-    BINARY="$PROJECT_DIR/.build/apple/Products/Release/Type4Me"
-elif [ -f "$PROJECT_DIR/.build/release/Type4Me" ]; then
-    BINARY="$PROJECT_DIR/.build/release/Type4Me"
-else
-    BINARY="$(find "$PROJECT_DIR/.build" -path '*/release/Type4Me' -type f -not -path '*/x86_64/*' -not -path '*/arm64/*' | head -n 1)"
-fi
-
-if [ ! -f "$BINARY" ]; then
-    echo "Build failed: binary not found"
-    exit 1
-fi
 
 echo "Stopping Type4Me..."
 osascript -e "quit app \"$APP_NAME\"" 2>/dev/null || true
 sleep 1
 
-echo "Deploying to $APP_PATH..."
-mkdir -p "$APP_PATH/Contents/MacOS" "$APP_PATH/Contents/Resources"
-cp "$BINARY" "$APP_PATH/Contents/MacOS/$APP_EXECUTABLE"
-cp "$PROJECT_DIR/Type4Me/Resources/${APP_ICON_NAME}.icns" "$APP_PATH/Contents/Resources/${APP_ICON_NAME}.icns" 2>/dev/null || true
-
-cat >"$INFO_PLIST" <<EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>CFBundleDevelopmentRegion</key>
-    <string>en</string>
-    <key>CFBundleDisplayName</key>
-    <string>${APP_NAME}</string>
-    <key>CFBundleExecutable</key>
-    <string>${APP_EXECUTABLE}</string>
-    <key>CFBundleIconFile</key>
-    <string>${APP_ICON_NAME}</string>
-    <key>CFBundleIdentifier</key>
-    <string>${APP_BUNDLE_ID}</string>
-    <key>CFBundleInfoDictionaryVersion</key>
-    <string>6.0</string>
-    <key>CFBundleName</key>
-    <string>${APP_NAME}</string>
-    <key>CFBundlePackageType</key>
-    <string>APPL</string>
-    <key>CFBundleShortVersionString</key>
-    <string>${APP_VERSION}</string>
-    <key>CFBundleVersion</key>
-    <string>${APP_BUILD}</string>
-    <key>LSMinimumSystemVersion</key>
-    <string>${MIN_SYSTEM_VERSION}</string>
-    <key>NSMicrophoneUsageDescription</key>
-    <string>${MICROPHONE_USAGE_DESCRIPTION}</string>
-    <key>NSAppleEventsUsageDescription</key>
-    <string>${APPLE_EVENTS_USAGE_DESCRIPTION}</string>
-    <key>LSUIElement</key>
-    <true/>
-    <key>NSHighResolutionCapable</key>
-    <true/>
-    <key>NSPrincipalClass</key>
-    <string>NSApplication</string>
-</dict>
-</plist>
-EOF
-
-# Copy bundled sounds
-mkdir -p "$APP_PATH/Contents/Resources/Sounds"
-cp "$PROJECT_DIR/Type4Me/Resources/Sounds/"*.wav "$APP_PATH/Contents/Resources/Sounds/" 2>/dev/null || true
-
-echo "Signing with '${SIGNING_IDENTITY}'..."
-codesign -f -s "$SIGNING_IDENTITY" "$APP_PATH" 2>/dev/null && echo "Signed." || echo "Signing skipped (no identity available)."
+APP_PATH="$APP_PATH" bash "$SCRIPT_DIR/package-app.sh"
 
 if [ "$LAUNCH_APP" = "1" ]; then
     echo "Launching via GUI session (no shell env vars)..."

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && /bin/pwd -P)"
+APP_PATH="${APP_PATH:-$PROJECT_DIR/dist/Type4Me.app}"
+APP_NAME="Type4Me"
+APP_EXECUTABLE="Type4Me"
+APP_ICON_NAME="AppIcon"
+APP_BUNDLE_ID="${APP_BUNDLE_ID:-com.type4me.app}"
+APP_VERSION="${APP_VERSION:-1.2.4}"
+APP_BUILD="${APP_BUILD:-1}"
+MIN_SYSTEM_VERSION="${MIN_SYSTEM_VERSION:-14.0}"
+MICROPHONE_USAGE_DESCRIPTION="${MICROPHONE_USAGE_DESCRIPTION:-Type4Me 需要访问麦克风以录制语音并将其转换为文本。}"
+APPLE_EVENTS_USAGE_DESCRIPTION="${APPLE_EVENTS_USAGE_DESCRIPTION:-Type4Me 需要辅助功能权限来注入转写文字到其他应用}"
+INFO_PLIST="$APP_PATH/Contents/Info.plist"
+MODULE_CACHE_DIR="${MODULE_CACHE_DIR:-$PROJECT_DIR/.build/module-cache}"
+
+if [ -n "${CODESIGN_IDENTITY:-}" ]; then
+    SIGNING_IDENTITY="$CODESIGN_IDENTITY"
+elif security find-identity -v -p codesigning 2>/dev/null | grep -q "Type4Me Dev"; then
+    SIGNING_IDENTITY="Type4Me Dev"
+else
+    SIGNING_IDENTITY="-"
+fi
+
+echo "Building universal release (arm64 + x86_64)..."
+mkdir -p "$MODULE_CACHE_DIR"
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swift build -c release --package-path "$PROJECT_DIR" --arch arm64 --arch x86_64
+
+if [ -f "$PROJECT_DIR/.build/apple/Products/Release/Type4Me" ]; then
+    BINARY="$PROJECT_DIR/.build/apple/Products/Release/Type4Me"
+elif [ -f "$PROJECT_DIR/.build/release/Type4Me" ]; then
+    BINARY="$PROJECT_DIR/.build/release/Type4Me"
+else
+    BINARY="$(find "$PROJECT_DIR/.build" -path '*/release/Type4Me' -type f -not -path '*/x86_64/*' -not -path '*/arm64/*' | head -n 1)"
+fi
+
+if [ ! -f "$BINARY" ]; then
+    echo "Build failed: binary not found"
+    exit 1
+fi
+
+echo "Packaging app bundle at $APP_PATH..."
+mkdir -p "$APP_PATH/Contents/MacOS" "$APP_PATH/Contents/Resources"
+cp "$BINARY" "$APP_PATH/Contents/MacOS/$APP_EXECUTABLE"
+cp "$PROJECT_DIR/Type4Me/Resources/${APP_ICON_NAME}.icns" "$APP_PATH/Contents/Resources/${APP_ICON_NAME}.icns" 2>/dev/null || true
+
+cat >"$INFO_PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>${APP_NAME}</string>
+    <key>CFBundleExecutable</key>
+    <string>${APP_EXECUTABLE}</string>
+    <key>CFBundleIconFile</key>
+    <string>${APP_ICON_NAME}</string>
+    <key>CFBundleIdentifier</key>
+    <string>${APP_BUNDLE_ID}</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>${APP_NAME}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${APP_VERSION}</string>
+    <key>CFBundleVersion</key>
+    <string>${APP_BUILD}</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>${MIN_SYSTEM_VERSION}</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>${MICROPHONE_USAGE_DESCRIPTION}</string>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>${APPLE_EVENTS_USAGE_DESCRIPTION}</string>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>
+EOF
+
+mkdir -p "$APP_PATH/Contents/Resources/Sounds"
+cp "$PROJECT_DIR/Type4Me/Resources/Sounds/"*.wav "$APP_PATH/Contents/Resources/Sounds/" 2>/dev/null || true
+
+echo "Signing with '${SIGNING_IDENTITY}'..."
+codesign -f -s "$SIGNING_IDENTITY" "$APP_PATH" 2>/dev/null && echo "Signed." || echo "Signing skipped (no identity available)."
+
+echo "App bundle ready at $APP_PATH"


### PR DESCRIPTION
新增独立的 DMG 打包脚本，生成的安装包中包含 Type4Me.app 和指向 /Applications 的符号链接，方便
拖拽安装。
同时抽出公共 .app 打包逻辑，复用到 deploy 流程