### PR TITLE
fix: rename OpenAI ASR provider label 修改 OpenAI 识别引擎名称

### DIFF
--- a/Type4Me/ASR/ASRProvider.swift
+++ b/Type4Me/ASR/ASRProvider.swift
@@ -25,7 +25,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
     var displayName: String {
         switch self {
         case .sherpa:   return L("本地识别 (Paraformer)", "Local (Paraformer)")
-        case .openai:   return "OpenAI Whisper"
+        case .openai:   return "OpenAI"
         case .azure:    return "Azure Speech"
         case .google:   return "Google Cloud STT"
         case .aws:      return "AWS Transcribe"


### PR DESCRIPTION
## Summary

- rename the OpenAI ASR provider label from `OpenAI Whisper` to `OpenAI`

## Why

The current label is misleading.

Although the provider was displayed as `OpenAI Whisper`, the available models are not limited to Whisper and already include:

- `gpt-4o-transcribe`
- `gpt-4o-mini-transcribe`

Using `OpenAI` is more accurate and avoids implying that this provider is Whisper-only.

## Validation

- verified the provider display label source in the ASR provider registry / picker path

## Notes

- this is a UI naming change only
- no behavior or API integration logic changed
