### PR TITLE
修复快速模式可能存在的跨会话串字问题

### DIFF
--- a/Type4Me/Audio/AudioCaptureEngine.swift
+++ b/Type4Me/Audio/AudioCaptureEngine.swift
@@ -41,17 +41,26 @@ final class AudioCaptureEngine: NSObject, @unchecked Sendable, AVCaptureAudioDat
     // MARK: - Private
 
     private var captureSession: AVCaptureSession?
+    private let stateLock = NSLock()
     private let bufferLock = NSLock()
     private var buffer = Data()
     private var accumulatedAudio = Data()
     private var converter: AVAudioConverter?
     private let outputQueue = DispatchQueue(label: "com.type4me.audiocapture")
+    private let outputQueueKey = DispatchSpecificKey<UInt8>()
+    private let outputQueueTag: UInt8 = 1
+    private var activeOutput: AVCaptureAudioDataOutput?
     private var levelCounter = 0
 
     // MARK: - Warm-up
 
     private var isWarmedUp = false
     private var warmSession: AVCaptureSession?
+
+    override init() {
+        super.init()
+        outputQueue.setSpecific(key: outputQueueKey, value: outputQueueTag)
+    }
 
     /// Pre-initialize the audio capture pipeline so the first real recording starts instantly.
     func warmUp() {
@@ -120,6 +129,9 @@ final class AudioCaptureEngine: NSObject, @unchecked Sendable, AVCaptureAudioDat
             throw AudioCaptureError.converterCreationFailed
         }
         session.addOutput(output)
+        stateLock.withLock {
+            activeOutput = output
+        }
 
         session.startRunning()
         captureSession = session
@@ -129,6 +141,13 @@ final class AudioCaptureEngine: NSObject, @unchecked Sendable, AVCaptureAudioDat
 
     func stop() {
         captureSession?.stopRunning()
+        drainOutputQueue()
+        let output = stateLock.withLock { () -> AVCaptureAudioDataOutput? in
+            let current = activeOutput
+            activeOutput = nil
+            return current
+        }
+        output?.setSampleBufferDelegate(nil, queue: nil)
         captureSession = nil
         converter = nil
         levelCounter = 0
@@ -143,6 +162,8 @@ final class AudioCaptureEngine: NSObject, @unchecked Sendable, AVCaptureAudioDat
         didOutput sampleBuffer: CMSampleBuffer,
         from connection: AVCaptureConnection
     ) {
+        let isActiveOutput = stateLock.withLock { activeOutput === output }
+        guard isActiveOutput else { return }
         guard let pcmBuffer = sampleBuffer.toPCMBuffer() else { return }
 
         // Emit audio level ~20 times/sec (every 3rd callback at typical 60Hz buffer rate)
@@ -259,6 +280,13 @@ final class AudioCaptureEngine: NSObject, @unchecked Sendable, AVCaptureAudioDat
         if !remaining.isEmpty {
             onAudioChunk?(remaining)
         }
+    }
+
+    private func drainOutputQueue() {
+        if DispatchQueue.getSpecific(key: outputQueueKey) == outputQueueTag {
+            return
+        }
+        outputQueue.sync {}
     }
 }
 

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -28,6 +28,21 @@ actor RecognitionSession {
         currentMode
     }
 
+    /// Exposed for testing so stale-event behavior can be verified deterministically.
+    func currentTranscriptForTesting() -> RecognitionTranscript {
+        currentTranscript
+    }
+
+    /// Exposed for testing; production code should not advance epochs directly.
+    func advanceSessionEpochForTesting() -> UInt64 {
+        advanceSessionEpoch()
+    }
+
+    /// Exposed for testing so stale ASR events can be replayed against a known epoch.
+    func handleASREventForTesting(_ event: RecognitionEvent, sessionEpoch: UInt64) {
+        handleASREvent(event, sessionEpoch: sessionEpoch)
+    }
+
     // MARK: - Dependencies
 
     private let audioEngine = AudioCaptureEngine()
@@ -82,6 +97,7 @@ actor RecognitionSession {
     private var hasEmittedReadyForCurrentSession = false
     private var audioChunkContinuation: AsyncStream<Data>.Continuation?
     private var audioChunkSenderTask: Task<Void, Never>?
+    private var activeSessionEpoch: UInt64 = 0
 
     // MARK: - Prompt context (selected text + clipboard captured at recording start)
 
@@ -118,6 +134,7 @@ actor RecognitionSession {
             DebugFileLogger.log("session forcing reset from state=\(state)")
             await forceReset()
         }
+        let sessionEpoch = advanceSessionEpoch()
 
         let provider = KeychainService.selectedASRProvider
         let effectiveMode = ASRProviderRegistry.resolvedMode(for: mode, provider: provider)
@@ -285,7 +302,7 @@ actor RecognitionSession {
         eventConsumptionTask = Task { [weak self] in
             for await event in events {
                 guard let self else { break }
-                await self.handleASREvent(event)
+                await self.handleASREvent(event, sessionEpoch: sessionEpoch)
                 if case .completed = event { break }
             }
         }
@@ -581,7 +598,11 @@ actor RecognitionSession {
 
     // MARK: - ASR Events
 
-    private func handleASREvent(_ event: RecognitionEvent) {
+    private func handleASREvent(_ event: RecognitionEvent, sessionEpoch: UInt64) {
+        guard sessionEpoch == activeSessionEpoch else {
+            DebugFileLogger.log("ignoring stale ASR event for epoch=\(sessionEpoch), active=\(activeSessionEpoch)")
+            return
+        }
         switch event {
         case .ready:
             // Deduplicate: ASR clients may emit .ready, but we also emit it
@@ -752,6 +773,7 @@ actor RecognitionSession {
     /// Used when a new recording is requested but the session is stuck
     /// (e.g. stopRecording hung on a WebSocket timeout).
     private func forceReset() async {
+        _ = advanceSessionEpoch()
         NSLog("[Session] forceReset from state=%@", String(describing: state))
         DebugFileLogger.log("forceReset from state=\(state)")
 
@@ -774,6 +796,11 @@ actor RecognitionSession {
         hasEmittedReadyForCurrentSession = false
         currentConfig = nil
         SystemVolumeManager.restore()
+    }
+
+    private func advanceSessionEpoch() -> UInt64 {
+        activeSessionEpoch &+= 1
+        return activeSessionEpoch
     }
 
 }

--- a/Type4MeTests/RecognitionSessionTests.swift
+++ b/Type4MeTests/RecognitionSessionTests.swift
@@ -50,4 +50,24 @@ final class RecognitionSessionTests: XCTestCase {
         let mode = await session.currentModeForTesting()
         XCTAssertEqual(mode.id, ProcessingMode.directId)
     }
+
+    func testStaleASREventDoesNotPolluteNewSession() async {
+        let session = RecognitionSession()
+        let staleEpoch = await session.advanceSessionEpochForTesting()
+        let activeEpoch = await session.advanceSessionEpochForTesting()
+        let transcript = RecognitionTranscript(
+            confirmedSegments: ["上一次"],
+            partialText: "尾巴",
+            authoritativeText: "上一次尾巴",
+            isFinal: false
+        )
+
+        await session.handleASREventForTesting(.transcript(transcript), sessionEpoch: staleEpoch)
+        let ignoredTranscript = await session.currentTranscriptForTesting()
+        XCTAssertEqual(ignoredTranscript, .empty)
+
+        await session.handleASREventForTesting(.transcript(transcript), sessionEpoch: activeEpoch)
+        let acceptedTranscript = await session.currentTranscriptForTesting()
+        XCTAssertEqual(acceptedTranscript, transcript)
+    }
 }


### PR DESCRIPTION
## 背景

这个 PR 更像是一个 **bug 反馈 + 初步修正**，而不是已经完整验证过的最终修复。

有用户反馈：在“快速模式”下，如果连续进行两次较短的录音，上一轮语音末尾的一两个字，有时会被带到下一轮开头。现象大致如下：

1. 结束一段较短的快速模式语音输入
2. 很快开始下一段快速模式语音输入
3. 新一段输入的开头，偶尔会混入上一段结尾的几个字

## 代码层面的初步分析

我目前**没有在本机完成完整复现和实机验证**，所以这里更准确地说，是基于当前代码路径做出的一个具体推断。

目前看有两个地方比较可疑：

- `AudioCaptureEngine.stop()` 在停止 `AVCaptureSession` 并 flush 剩余 buffer 后，没有显式等待 `AVCaptureAudioDataOutput` 的回调队列彻底排空。如果上一轮录音尾部的音频回调在下一轮录音已经重新绑定 `onAudioChunk` 之后才到，就有可能把旧音频尾巴送进新会话。
- `RecognitionSession` 在消费 ASR 事件时，没有按“录音会话”做隔离。理论上，如果旧会话的 transcript 事件较晚到达，也存在污染新一轮 `currentTranscript` 的可能。

从用户描述来看，第一种情况和现象更吻合，也就是：**上一轮录音的尾部音频穿过了会话边界，落到了下一轮开头**。

## 这个 PR 做了什么

这个 PR 在两个层面加了防御性保护：

- 在 `AudioCaptureEngine` 中：停止录音时主动 drain 输出回调队列、移除 sample buffer delegate、并忽略已经失效的 `AVCaptureAudioDataOutput` 回调。
- 在 `RecognitionSession` 中：为 ASR 事件处理增加 session epoch，丢弃旧会话迟到的事件，避免它们更新当前会话的 transcript。

## 测试状态

这个修改 **没有经过完整本地测试**。

我补了一个比较窄的单测，用来覆盖“旧 ASR 事件不应污染新会话”的情况；但由于我本地环境存在 Swift / SDK toolchain 不匹配问题，没能顺利完成完整测试跑通。

所以请把这个 PR 视为：

- 一个带明确背景和代码分析的 bug 反馈
- 外加一个基于当前判断的初步修正

而不是已经被充分验证的最终 fix。

## 备注

如果你更倾向于把这类内容拆成两步处理，也完全可以：

- 先作为 issue 记录问题和时序分析
- 等补充日志、确认根因后，再提交更小更确定的修复 PR

我先把当前分析和补丁一并发出来，目的是让问题背景、怀疑路径和可改进方向都尽量具体一些。