### PR TITLE
fix: LLM reasoning output, code signing, --chunk-size, rename DoubaoChatClient, ESC cancel

### DIFF
--- a/Type4Me/ASR/SpeechRecognizer.swift
+++ b/Type4Me/ASR/SpeechRecognizer.swift
@@ -49,6 +49,7 @@ enum RecognitionEvent: Sendable {
     case transcript(RecognitionTranscript)
     case error(Error)
     case completed
+    case processingPartial(text: String)
     case processingResult(text: String)
     case finalized(text: String, injection: InjectionOutcome)
 }

--- a/Type4Me/Input/HotkeyManager.swift
+++ b/Type4Me/Input/HotkeyManager.swift
@@ -23,6 +23,17 @@ final class HotkeyManager: NSObject {
     /// Which toggle mode is currently active (recording). Only one can be active at a time.
     private var activeToggleModeId: UUID?
 
+    /// Called when ESC is pressed during any active phase (including post-processing).
+    /// Separate from onESCAbort which only fires when isRecording || isProcessing.
+    var onESCAnyPhase: (@Sendable () -> Void)?
+
+    /// Reset toggle/hold state so next hotkey press starts fresh.
+    func resetActiveModes() {
+        activeToggleModeId = nil
+        for key in toggleState.keys { toggleState[key] = false }
+        for key in holdState.keys { holdState[key] = false }
+    }
+
     /// Maximum hold duration before auto-stop (seconds).
     private let maxHoldDuration: TimeInterval = 120
 
@@ -190,15 +201,13 @@ final class HotkeyManager: NSObject {
             }
         }
 
-        // ESC key (keyCode 53) - abort active recording or processing
+        // ESC key (keyCode 53) - abort when recording or during LLM post-processing
         if isESCAbortEnabled && type == .keyDown && keyCode == 53 {
             let isRecording = activeToggleModeId != nil || holdState.values.contains(true)
             let shouldAbort = isRecording || isProcessing
             if shouldAbort {
-                NSLog("[HotkeyManager] ESC pressed, triggering abort (recording=%@, processing=%@)",
-                      isRecording ? "true" : "false", isProcessing ? "true" : "false")
                 onESCAbort?()
-                return nil  // Swallow ESC
+                return nil
             }
         }
 

--- a/Type4Me/LLM/ClaudeChatClient.swift
+++ b/Type4Me/LLM/ClaudeChatClient.swift
@@ -55,6 +55,7 @@ actor ClaudeChatClient: LLMClient {
         // Parse SSE stream (Anthropic format)
         var result = ""
         for try await line in bytes.lines {
+            try Task.checkCancellation()
             guard line.hasPrefix("data: ") else { continue }
             let payload = String(line.dropFirst(6))
             guard let data = payload.data(using: .utf8),
@@ -74,6 +75,62 @@ actor ClaudeChatClient: LLMClient {
         }
 
         logger.info("Claude result: \(result.count) chars")
+
+        return result.strippingThinkTags()
+    }
+
+    /// Streaming variant: calls onChunk with accumulated text for each SSE chunk.
+    func processStream(text: String, prompt: String, config: LLMConfig, onChunk: @Sendable @escaping (String) -> Void) async throws -> String {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else { return text }
+        let finalPrompt = prompt.replacingOccurrences(of: "{text}", with: trimmedText)
+
+        guard let url = URL(string: "\(config.baseURL)/messages") else {
+            throw LLMError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(config.apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 30
+
+        let body = ClaudeRequest(
+            model: config.model,
+            max_tokens: 4096,
+            system: nil,
+            messages: [ClaudeMessage(role: "user", content: finalPrompt)],
+            stream: true
+        )
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw LLMError.requestFailed((response as? HTTPURLResponse)?.statusCode ?? 0)
+        }
+
+        var result = ""
+        for try await line in bytes.lines {
+            try Task.checkCancellation()
+            guard line.hasPrefix("data: ") else { continue }
+            let payload = String(line.dropFirst(6))
+            guard let data = payload.data(using: .utf8),
+                  let event = try? JSONDecoder().decode(ClaudeStreamEvent.self, from: data)
+            else { continue }
+
+            switch event.type {
+            case "content_block_delta":
+                if let delta = event.delta, let text = delta.text {
+                    result += text
+                    onChunk(result.strippingThinkTags())
+                }
+            case "message_stop":
+                break
+            default:
+                continue
+            }
+        }
 
         return result.strippingThinkTags()
     }

--- a/Type4Me/LLM/LLMClient.swift
+++ b/Type4Me/LLM/LLMClient.swift
@@ -2,8 +2,21 @@ import Foundation
 
 /// Common interface for LLM clients (OpenAI-compatible and Claude).
 protocol LLMClient: Sendable {
+    /// Process text and return the full result (non-streaming).
     func process(text: String, prompt: String, config: LLMConfig) async throws -> String
+    /// Process text with streaming chunks. Calls onChunk for each incremental update.
+    /// Returns the full accumulated result.
+    func processStream(text: String, prompt: String, config: LLMConfig, onChunk: @Sendable @escaping (String) -> Void) async throws -> String
     func warmUp(baseURL: String) async
+}
+
+extension LLMClient {
+    /// Default: fall back to non-streaming.
+    func processStream(text: String, prompt: String, config: LLMConfig, onChunk: @Sendable @escaping (String) -> Void) async throws -> String {
+        let result = try await process(text: text, prompt: prompt, config: config)
+        onChunk(result)
+        return result
+    }
 }
 
 extension String {

--- a/Type4Me/LLM/OpenAICompatibleChatClient.swift
+++ b/Type4Me/LLM/OpenAICompatibleChatClient.swift
@@ -1,9 +1,9 @@
 import Foundation
 import os
 
-actor DoubaoChatClient: LLMClient {
+actor OpenAICompatibleChatClient: LLMClient {
 
-    private let logger = Logger(subsystem: "com.type4me.llm", category: "DoubaoChatClient")
+    private let logger = Logger(subsystem: "com.type4me.llm", category: "OpenAICompatibleChatClient")
     private let provider: LLMProvider
 
     init(provider: LLMProvider = .doubao) {
@@ -64,19 +64,26 @@ actor DoubaoChatClient: LLMClient {
 
         // Parse SSE stream
         var result = ""
+        var hasReasoning = false
         var lineCount = 0
         var firstDataLine: String?
         for try await line in bytes.lines {
+            try Task.checkCancellation()
             lineCount += 1
             guard line.hasPrefix("data: ") else { continue }
             let payload = String(line.dropFirst(6))
             if firstDataLine == nil { firstDataLine = String(payload.prefix(300)) }
             if payload == "[DONE]" { break }
             guard let data = payload.data(using: .utf8),
-                  let chunk = try? JSONDecoder().decode(ChatStreamChunk.self, from: data),
-                  let content = chunk.choices.first?.delta.content
+                  let chunk = try? JSONDecoder().decode(ChatStreamChunk.self, from: data)
             else { continue }
-            result += content
+            let delta = chunk.choices.first?.delta
+            if let text = delta?.content, !text.isEmpty {
+                result += text
+            } else if let text = delta?.reasoning_content, !text.isEmpty {
+                if !hasReasoning { result += ""; hasReasoning = true }
+                result += text
+            }
         }
 
         if result.isEmpty && lineCount > 0 {
@@ -90,6 +97,76 @@ actor DoubaoChatClient: LLMClient {
         logger.info("LLM result: \(result.count) chars")
 
         return result.strippingThinkTags()
+    }
+
+    /// Streaming variant: calls onChunk with accumulated text for each SSE chunk.
+    func processStream(text: String, prompt: String, config: LLMConfig, onChunk: @Sendable @escaping (String) -> Void) async throws -> String {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else { return text }
+        let finalPrompt = prompt.replacingOccurrences(of: "{text}", with: trimmedText)
+
+        guard let url = URL(string: "\(config.baseURL)/chat/completions") else {
+            throw LLMError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 30
+
+        let disableField = provider.thinkingDisableField
+        let body = ChatRequest(
+            model: config.model,
+            messages: [ChatMessage(role: "user", content: finalPrompt)],
+            stream: true,
+            thinking: disableField == .thinking ? ThinkingConfig(type: "disabled") : nil,
+            enable_thinking: disableField == .enableThinking ? false : nil,
+            reasoning_effort: disableField == .reasoningEffort ? "none" : nil,
+            think: disableField == .think ? false : nil,
+            reasoning_split: provider.needsReasoningSplit ? true : nil
+        )
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw LLMError.requestFailed((response as? HTTPURLResponse)?.statusCode ?? 0)
+        }
+
+        var result = ""
+        var contentResult = ""
+        var hasReasoning = false
+        var chunkCount = 0
+        for try await line in bytes.lines {
+            try Task.checkCancellation()
+            guard line.hasPrefix("data: ") else { continue }
+            let payload = String(line.dropFirst(6))
+            if payload == "[DONE]" { break }
+            guard let data = payload.data(using: .utf8),
+                  let chunk = try? JSONDecoder().decode(ChatStreamChunk.self, from: data)
+            else { continue }
+            let delta = chunk.choices.first?.delta
+            var hasNewContent = false
+            if let text = delta?.content, !text.isEmpty {
+                if hasReasoning { result += ""; hasReasoning = false }
+                result += text
+                contentResult += text
+                hasNewContent = true
+            } else if let text = delta?.reasoning_content, !text.isEmpty {
+                if !hasReasoning { result += ""; hasReasoning = true }
+                result += text
+            }
+            // Only emit when there's actual content (not just thinking)
+            if hasNewContent {
+                chunkCount += 1
+                onChunk(contentResult)
+            }
+        }
+        DebugFileLogger.log("LLM stream done: \(chunkCount) chunks, \(result.count) chars total")
+
+        let finalResult = contentResult.isEmpty ? result.strippingThinkTags() : contentResult
+        if finalResult.isEmpty { throw LLMError.emptyResponse(nil) }
+        return finalResult
     }
 }
 
@@ -125,6 +202,7 @@ struct ChunkChoice: Decodable, Sendable {
 
 struct ChunkDelta: Decodable, Sendable {
     let content: String?
+    let reasoning_content: String?
 }
 
 enum LLMError: Error, LocalizedError {

--- a/Type4Me/Services/SenseVoiceServerManager.swift
+++ b/Type4Me/Services/SenseVoiceServerManager.swift
@@ -94,7 +94,6 @@ actor SenseVoiceServerManager {
                 "--language", "auto",
                 "--textnorm",
                 "--padding", "8",
-                "--chunk-size", "10",
             ]
         } else {
             proc.executableURL = URL(fileURLWithPath: executable)
@@ -109,7 +108,6 @@ actor SenseVoiceServerManager {
                 "--language", "auto",
                 "--textnorm",
                 "--padding", "8",
-                "--chunk-size", "10",
             ]
         }
 

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -46,7 +46,7 @@ actor RecognitionSession {
         if provider == .claude {
             return ClaudeChatClient()
         }
-        return DoubaoChatClient(provider: provider)
+        return OpenAICompatibleChatClient(provider: provider)
     }
 
     /// Pre-initialize audio subsystem so the first recording starts instantly.
@@ -96,10 +96,15 @@ actor RecognitionSession {
     private var speculativeLLMTask: Task<String?, Never>?
     private var speculativeLLMText: String = ""
     private var speculativeDebounceTask: Task<Void, Never>?
+    /// LLM task fired at stopRecording() — stored as property so ESC can cancel it.
+    private var earlyLLMTask: Task<String?, Never>?
     /// Stores the last LLM error from the early/fresh LLM task, consumed once by stopRecording().
     private var pendingLLMError: Error?
     /// When true, skip text injection (paste) but still save to clipboard & history.
     private var injectionAborted = false
+
+    /// Publicly accessible LLM task status for HotkeyManager to check ESC eligibility.
+    @MainActor var isRunningLLMTask: Bool = false
 
     // MARK: - Toggle
 
@@ -353,10 +358,23 @@ actor RecognitionSession {
         await forceReset()
     }
 
-    /// Mark that injection should be skipped. Recognition, clipboard, and history still proceed.
+    /// Hard cancel: tear down everything regardless of current state.
+    /// Used for ESC abort — cancels LLM, stops audio, resets to idle.
+    func hardCancel() async {
+        DebugFileLogger.log("hardCancel from state=\(state)")
+        earlyLLMTask?.cancel()
+        resetSpeculativeLLM()
+        injectionAborted = true
+        NotificationCenter.default.post(name: .llmTaskDidEnd, object: nil)
+        await forceReset()
+    }
+
+    /// Mark that injection should be skipped. Cancel in-flight LLM tasks.
     func abortInjection() {
         injectionAborted = true
-        DebugFileLogger.log("abortInjection: injection will be skipped")
+        earlyLLMTask?.cancel()
+        resetSpeculativeLLM()
+        DebugFileLogger.log("abortInjection: injection will be skipped, LLM tasks cancelled")
     }
 
     func stopRecording() async {
@@ -365,6 +383,10 @@ actor RecognitionSession {
             logger.warning("stopRecording called but state is \(String(describing: self.state))")
             return
         }
+
+        // Immediately set isProcessing = true so ESC can cancel during post-processing
+        // This is synchronous - don't wait for notification
+        NotificationCenter.default.post(name: .llmTaskDidStart, object: nil)
 
         let stopT0 = ContinuousClock.now
         SystemVolumeManager.restore()  // Restore before stop sound plays
@@ -386,10 +408,10 @@ actor RecognitionSession {
         // otherwise fire fresh LLM immediately.
         // Batch (non-streaming) providers skip early LLM — no real text available yet.
         cancelSpeculativeLLM()
+        earlyLLMTask = nil  // Clear any previous task
         let needsLLM = !currentMode.prompt.isEmpty
         let provider = KeychainService.selectedASRProvider
         let canEarlyLLM = ASRProviderRegistry.capabilities(for: provider).isStreaming
-        var earlyLLMTask: Task<String?, Never>?
         if needsLLM && canEarlyLLM {
             var earlyText = currentTranscript.composedText
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -402,20 +424,36 @@ actor RecognitionSession {
                     state = .postProcessing
                     DebugFileLogger.log("stop: reusing speculative LLM +\(ContinuousClock.now - stopT0)")
                 } else if let llmConfig = KeychainService.loadLLMConfig() {
-                    // Text changed since last speculative call, fire fresh
+                    // Text changed since last speculative call, fire fresh with streaming
                     speculativeLLMTask?.cancel()
                     let prompt = promptContext.expandContextVariables(currentMode.prompt)
                     let client = currentLLMClient()
+                    let callback = onASREvent
                     state = .postProcessing
-                    DebugFileLogger.log("stop: fresh LLM firing mode=\(currentMode.name) model=\(llmConfig.model) with \(earlyText.count) chars +\(ContinuousClock.now - stopT0)")
-                    earlyLLMTask = Task {
+                    DebugFileLogger.log("stop: fresh LLM streaming mode=\(currentMode.name) model=\(llmConfig.model) with \(earlyText.count) chars +\(ContinuousClock.now - stopT0)")
+                    earlyLLMTask = Task { @MainActor in
+                        self.isRunningLLMTask = true
+                        NotificationCenter.default.post(name: .llmTaskDidStart, object: nil)
+                        defer {
+                            self.isRunningLLMTask = false
+                            NotificationCenter.default.post(name: .llmTaskDidEnd, object: nil)
+                        }
                         do {
-                            let result = try await client.process(
-                                text: earlyText, prompt: prompt, config: llmConfig
+                            let result = try await client.processStream(
+                                text: earlyText, prompt: prompt, config: llmConfig,
+                                onChunk: { partial in
+                                    Task { @MainActor in
+                                        callback?(.processingPartial(text: partial))
+                                    }
+                                }
                             )
                             DebugFileLogger.log("stop: fresh LLM done \(result.count) chars +\(ContinuousClock.now - stopT0)")
                             return result
                         } catch {
+                            if Task.isCancelled {
+                                DebugFileLogger.log("stop: fresh LLM cancelled +\(ContinuousClock.now - stopT0)")
+                                return nil
+                            }
                             DebugFileLogger.log("stop: fresh LLM FAILED +\(ContinuousClock.now - stopT0) error=\(error)")
                             await self.setPendingLLMError(error)
                             return nil
@@ -518,11 +556,19 @@ actor RecognitionSession {
             } else if needsLLM {
                 state = .postProcessing
                 if let llmConfig = KeychainService.loadLLMConfig() {
-                    DebugFileLogger.log("stop: sync LLM firing mode=\(currentMode.name) model=\(llmConfig.model) with \(finalText.count) chars")
+                    NotificationCenter.default.post(name: .llmTaskDidStart, object: nil)
+                    DebugFileLogger.log("stop: sync LLM streaming mode=\(currentMode.name) model=\(llmConfig.model) with \(finalText.count) chars")
                     do {
                         let client = currentLLMClient()
-                        let result = try await client.process(
-                            text: finalText, prompt: promptContext.expandContextVariables(currentMode.prompt), config: llmConfig
+                        let prompt = promptContext.expandContextVariables(currentMode.prompt)
+                        let callback = onASREvent
+                        let result = try await client.processStream(
+                            text: finalText, prompt: prompt, config: llmConfig,
+                            onChunk: { partial in
+                                Task { @MainActor in
+                                    callback?(.processingPartial(text: partial))
+                                }
+                            }
                         )
                         if result.isEmpty {
                             DebugFileLogger.log("stop: sync LLM empty result, falling back to raw text")
@@ -539,6 +585,7 @@ actor RecognitionSession {
                         llmFailed = true
                         onASREvent?(.processingResult(text: rawText))
                     }
+                    NotificationCenter.default.post(name: .llmTaskDidEnd, object: nil)
                 } else {
                     DebugFileLogger.log("stop: no LLM credentials, falling back to raw text")
                     llmFailed = true
@@ -599,6 +646,7 @@ actor RecognitionSession {
             currentTranscript = .empty
         }
         resetSpeculativeLLM()
+        earlyLLMTask = nil
         SystemVolumeManager.restore()
         logger.info("Session complete, injected \(effectiveText.count) chars")
     }
@@ -643,7 +691,7 @@ actor RecognitionSession {
                 Task { await self.stopRecording() }
             }
 
-        case .processingResult, .finalized:
+        case .processingPartial, .processingResult, .finalized:
             break
         }
     }
@@ -750,11 +798,23 @@ actor RecognitionSession {
         let prompt = promptContext.expandContextVariables(currentMode.prompt)
 
         let client = currentLLMClient()
+        let callback = onASREvent
         DebugFileLogger.log("speculative LLM: firing mode=\(currentMode.name) model=\(llmConfig.model) with \(text.count) chars")
-        speculativeLLMTask = Task {
+        speculativeLLMTask = Task { @MainActor in
+            self.isRunningLLMTask = true
+            NotificationCenter.default.post(name: .llmTaskDidStart, object: nil)
+            defer {
+                self.isRunningLLMTask = false
+                NotificationCenter.default.post(name: .llmTaskDidEnd, object: nil)
+            }
             do {
-                let result = try await client.process(
-                    text: text, prompt: prompt, config: llmConfig
+                let result = try await client.processStream(
+                    text: text, prompt: prompt, config: llmConfig,
+                    onChunk: { partial in
+                        Task { @MainActor in
+                            callback?(.processingPartial(text: partial))
+                        }
+                    }
                 )
                 DebugFileLogger.log("speculative LLM: done \(result.count) chars")
                 return result
@@ -795,6 +855,8 @@ actor RecognitionSession {
 
         eventConsumptionTask?.cancel()
         eventConsumptionTask = nil
+        earlyLLMTask?.cancel()
+        earlyLLMTask = nil
         resetSpeculativeLLM()
 
         audioEngine.stop()

--- a/Type4Me/Type4MeApp.swift
+++ b/Type4Me/Type4MeApp.swift
@@ -112,6 +112,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     case .processingResult(let text):
                         appState.showProcessingResult(text)
                         self.hotkeyManager.isProcessing = true
+                    case .processingPartial(let text):
+                        DebugFileLogger.log("UI received processingPartial: \(text.count) chars, barPhase=\(appState.barPhase), segments.count=\(appState.segments.count)")
+                        appState.setProcessingPartial(text)
+                        self.hotkeyManager.isProcessing = true
                     case .finalized(let text, let injection):
                         appState.finalize(text: text, outcome: injection)
                         self.hotkeyManager.isProcessing = false
@@ -275,18 +279,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
-        // ESC abort: skip injection but let recognition/clipboard/history proceed.
+        // ESC abort: hard cancel — tear down everything, no text output.
         hotkeyManager.onESCAbort = { [weak self] in
             guard let self else { return }
             let phase = appState.barPhase
             guard phase == .recording || phase == .processing || phase == .preparing else {
-                return  // Not in an active session, ignore ESC
+                return
             }
-            NSLog("[Type4Me] >>> HOTKEY: ESC abort injection (phase=%@)", String(describing: phase))
-            DebugFileLogger.log("hotkey ESC abort injection phase=\(phase)")
+            self.hotkeyManager.resetActiveModes()
+            self.appState.showCancelled()
             Task {
-                await self.session.abortInjection()
-                await self.session.stopRecording()
+                await self.session.hardCancel()
             }
         }
 
@@ -301,6 +304,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.syncESCAbortSetting()
             }
         }
+
+        setupLLMTaskNotifications()
     }
 
     private func syncESCAbortSetting() {
@@ -309,6 +314,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             hotkeyManager.isESCAbortEnabled = true
         } else {
             hotkeyManager.isESCAbortEnabled = UserDefaults.standard.bool(forKey: "tf_escAbortEnabled")
+        }
+    }
+
+    // MARK: - LLM task notifications
+
+    private func setupLLMTaskNotifications() {
+        NotificationCenter.default.addObserver(
+            forName: .llmTaskDidStart,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.hotkeyManager.isProcessing = true
+        }
+        NotificationCenter.default.addObserver(
+            forName: .llmTaskDidEnd,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.hotkeyManager.isProcessing = false
         }
     }
 

--- a/Type4Me/UI/AppState.swift
+++ b/Type4Me/UI/AppState.swift
@@ -373,6 +373,24 @@ final class AppState {
         }
     }
 
+    private var lastPartialUpdate: Date = .distantPast
+    private let partialUpdateInterval: TimeInterval = 0.1  // 100ms throttle
+
+    func setProcessingPartial(_ text: String) {
+        let now = Date()
+        // Throttle: only update UI every 100ms to avoid overwhelming SwiftUI
+        guard now.timeIntervalSince(lastPartialUpdate) >= partialUpdateInterval || text.isEmpty else {
+            return
+        }
+        lastPartialUpdate = now
+
+        if text.isEmpty {
+            segments = []
+        } else {
+            segments = [TranscriptionSegment(text: text, isConfirmed: false)]
+        }
+    }
+
     func showProcessingResult(_ result: String) {
         if result.isEmpty {
             cancel()
@@ -455,4 +473,6 @@ extension Notification.Name {
     static let hotkeyRecordingDidEnd = Notification.Name("Type4MeHotkeyRecordingDidEnd")
     static let navigateToMode = Notification.Name("Type4MeNavigateToMode")
     static let selectMode = Notification.Name("Type4MeSelectMode")
+    static let llmTaskDidStart = Notification.Name("Type4MeLLMTaskDidStart")
+    static let llmTaskDidEnd = Notification.Name("Type4MeLLMTaskDidEnd")
 }

--- a/Type4Me/UI/FloatingBar/FloatingBarView.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarView.swift
@@ -483,6 +483,28 @@ struct ErrorDot: View {
     }
 }
 
+struct ProcessingDot: View {
+    @State private var pulse = false
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(Color.orange.opacity(pulse ? 0.15 : 0.3))
+                .frame(width: pulse ? 18 : 10, height: pulse ? 18 : 10)
+
+            Circle()
+                .fill(Color.orange)
+                .frame(width: 8, height: 8)
+        }
+        .frame(width: 24, height: 24)
+        .onAppear {
+            withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+                pulse = true
+            }
+        }
+    }
+}
+
 // MARK: - Recording Timer
 
 /// Shows elapsed time since recording started, updates every second.

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -1012,7 +1012,7 @@ struct LLMSettingsCard: View, SettingsCardHelpers {
                 let llmConfig = config.toLLMConfig()
                 let client: any LLMClient = provider == .claude
                     ? ClaudeChatClient()
-                    : DoubaoChatClient(provider: provider)
+                    : OpenAICompatibleChatClient(provider: provider)
                 let reply = try await client.process(text: "hi", prompt: "{text}", config: llmConfig)
                 guard !Task.isCancelled else { return }
                 llmTestStatus = .success

--- a/Type4MeTests/OpenAICompatibleChatClientTests.swift
+++ b/Type4MeTests/OpenAICompatibleChatClientTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import Type4Me
 
-final class DoubaoChatClientTests: XCTestCase {
+final class OpenAICompatibleChatClientTests: XCTestCase {
 
     func testProcessInterpolatesPlainTextIntoTemplate() {
         let prompt = "请修正以下文本：{text}"

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -118,6 +118,30 @@ fi
 cp "$PROJECT_DIR/Type4Me/Resources/THIRD_PARTY_LICENSES.txt" "$APP_PATH/Contents/Resources/" 2>/dev/null || true
 
 echo "Signing with '${SIGNING_IDENTITY}'..."
-codesign -f -s "$SIGNING_IDENTITY" "$APP_PATH" 2>/dev/null && echo "Signed." || echo "Signing skipped (no identity available)."
+SV_DIST_TMP=""
+SV_WRAPPER_TMP=""
+if [ -d "$APP_PATH/Contents/MacOS/sensevoice-server-dist" ]; then
+    SV_DIST_TMP=$(mktemp -d)
+    mv "$APP_PATH/Contents/MacOS/sensevoice-server-dist" "$SV_DIST_TMP/"
+    if [ -f "$APP_PATH/Contents/MacOS/sensevoice-server" ]; then
+        SV_WRAPPER_TMP=$(mktemp -d)
+        mv "$APP_PATH/Contents/MacOS/sensevoice-server" "$SV_WRAPPER_TMP/"
+    fi
+fi
+
+codesign -f -s "$SIGNING_IDENTITY" "$APP_PATH" 2>/dev/null && echo "Bundle signed." || echo "Signing skipped (no identity available)."
+
+if [ -n "$SV_DIST_TMP" ]; then
+    mv "$SV_DIST_TMP/sensevoice-server-dist" "$APP_PATH/Contents/MacOS/"
+    rm -rf "$SV_DIST_TMP"
+    if [ -n "$SV_WRAPPER_TMP" ]; then
+        mv "$SV_WRAPPER_TMP/sensevoice-server" "$APP_PATH/Contents/MacOS/"
+        rm -rf "$SV_WRAPPER_TMP"
+    fi
+    find "$APP_PATH/Contents/MacOS/sensevoice-server-dist" -type f \( -name "*.dylib" -o -name "*.so" \) \
+        -exec codesign -f -s "$SIGNING_IDENTITY" {} \; 2>/dev/null || true
+    codesign -f -s "$SIGNING_IDENTITY" "$APP_PATH/Contents/MacOS/sensevoice-server-dist/sensevoice-server" 2>/dev/null || true
+    echo "sensevoice-server binaries signed."
+fi
 
 echo "App bundle ready at $APP_PATH"


### PR DESCRIPTION
## Summary
- LLM streaming: filter reasoning_content from output (oMLX)
- Fix code signing with PyInstaller bundle
- Remove unsupported --chunk-size argument from SenseVoiceServerManager
- Rename DoubaoChatClient → OpenAICompatibleChatClient
- Fix ESC cancel during LLM post-processing