### PR TITLE
[bug] 修复“最后两个字丢失”问题

### DIFF
--- a/Type4Me/Audio/AudioCaptureEngine.swift
+++ b/Type4Me/Audio/AudioCaptureEngine.swift
@@ -1,5 +1,14 @@
 @preconcurrency import AVFoundation
 
+protocol AudioCapturing: AnyObject, Sendable {
+    var onAudioChunk: ((Data) -> Void)? { get set }
+    var onAudioLevel: ((Float) -> Void)? { get set }
+
+    func warmUp()
+    func start() throws
+    func stop()
+}
+
 enum AudioCaptureError: Error, LocalizedError {
     case converterCreationFailed
     case microphonePermissionDenied
@@ -17,7 +26,7 @@ enum AudioCaptureError: Error, LocalizedError {
     }
 }
 
-final class AudioCaptureEngine: NSObject, @unchecked Sendable, AVCaptureAudioDataOutputSampleBufferDelegate {
+final class AudioCaptureEngine: NSObject, @unchecked Sendable, AVCaptureAudioDataOutputSampleBufferDelegate, AudioCapturing {
 
     // MARK: - Static properties
 
@@ -128,11 +137,16 @@ final class AudioCaptureEngine: NSObject, @unchecked Sendable, AVCaptureAudioDat
     }
 
     func stop() {
-        captureSession?.stopRunning()
-        captureSession = nil
-        converter = nil
-        levelCounter = 0
-        flushRemaining()
+        outputQueue.sync {
+            // Drain any pending AVCapture callbacks on the delegate queue before
+            // flushing the tail buffer, otherwise the last spoken frames can be
+            // stranded behind stop() and never reach the session pipeline.
+            captureSession?.stopRunning()
+            captureSession = nil
+            converter = nil
+            levelCounter = 0
+            flushRemaining()
+        }
         NSLog("[Audio] Capture session stopped")
     }
 

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -2,6 +2,8 @@ import AppKit
 import os
 
 actor RecognitionSession {
+    private static let stopCaptureGracePeriod: Duration = .milliseconds(350)
+    private static let stopSoundRestoreDelay: Duration = .milliseconds(50)
 
     // MARK: - State
 
@@ -30,15 +32,25 @@ actor RecognitionSession {
 
     // MARK: - Dependencies
 
-    private let audioEngine = AudioCaptureEngine()
-    private let injectionEngine = TextInjectionEngine()
-    let historyStore = HistoryStore()
+    private let audioEngine: any AudioCapturing
+    private let injectionEngine: TextInjectionEngine
+    let historyStore: HistoryStore
     private var asrClient: (any SpeechRecognizer)?
 
     private let logger = Logger(
         subsystem: "com.type4me.session",
         category: "RecognitionSession"
     )
+
+    init(
+        audioEngine: any AudioCapturing = AudioCaptureEngine(),
+        injectionEngine: TextInjectionEngine = TextInjectionEngine(),
+        historyStore: HistoryStore = HistoryStore()
+    ) {
+        self.audioEngine = audioEngine
+        self.injectionEngine = injectionEngine
+        self.historyStore = historyStore
+    }
 
     /// Return the appropriate LLM client for the currently selected provider.
     private func currentLLMClient() -> any LLMClient {
@@ -368,15 +380,23 @@ actor RecognitionSession {
         }
 
         let stopT0 = ContinuousClock.now
-        SystemVolumeManager.restore()  // Restore before stop sound plays
-        try? await Task.sleep(for: .milliseconds(50))  // Let OS apply volume change
-        SoundFeedback.playStop()
         state = .finishing
+
+        // Give CoreAudio a brief grace window to deliver frames that were spoken
+        // just before the stop hotkey event but have not yet surfaced as callbacks.
+        try? await Task.sleep(for: Self.stopCaptureGracePeriod)
 
         // Stop capture first so flushRemaining() can emit the tail audio chunk.
         audioEngine.stop()
-        audioEngine.onAudioChunk = nil
         await finishAudioChunkPipeline()
+        audioEngine.onAudioChunk = nil
+        audioEngine.onAudioLevel = nil
+
+        // Stop feedback should play only after the microphone is fully stopped,
+        // otherwise the end sound itself can mask the user's trailing syllables.
+        SystemVolumeManager.restore()
+        try? await Task.sleep(for: Self.stopSoundRestoreDelay)
+        SoundFeedback.playStop()
         DebugFileLogger.log("stop: audio stopped +\(ContinuousClock.now - stopT0)")
         guard sessionGeneration == myGeneration else {
             DebugFileLogger.log("stopRecording: zombie after audio pipeline, bailing")
@@ -391,12 +411,14 @@ actor RecognitionSession {
         let provider = KeychainService.selectedASRProvider
         let canEarlyLLM = ASRProviderRegistry.capabilities(for: provider).isStreaming
         var earlyLLMTask: Task<String?, Never>?
+        var earlyLLMInputText: String?
         if needsLLM && canEarlyLLM {
             var earlyText = currentTranscript.composedText
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             earlyText = SnippetStorage.applyEffective(to: earlyText)
             DebugFileLogger.log("stop: needsLLM=true mode=\(currentMode.name) text=\(earlyText.count)chars specMatch=\(earlyText == speculativeLLMText)")
             if !earlyText.isEmpty {
+                earlyLLMInputText = earlyText
                 if earlyText == speculativeLLMText, let specTask = speculativeLLMTask {
                     // Speculative LLM matches — reuse (may already be done!)
                     earlyLLMTask = specTask
@@ -426,55 +448,50 @@ actor RecognitionSession {
             }
         }
 
-        // ASR teardown: streaming providers can skip endAudio in LLM modes since
-        // we already have text. Batch providers (e.g. OpenAI REST) MUST await endAudio
-        // because that's where the actual recognition happens.
+        // ASR teardown: correctness matters more than latency here. Always await
+        // final ASR teardown so trailing words that were captured before the stop
+        // hotkey still have a chance to become part of the final transcript.
+        // Batch providers (e.g. OpenAI REST) MUST await endAudio because that's
+        // where the actual recognition happens.
         let providerIsStreaming = ASRProviderRegistry.capabilities(for: provider).isStreaming
         if let client = asrClient {
-            if needsLLM && earlyLLMTask != nil && providerIsStreaming {
-                // Fast path (streaming only): just disconnect, skip the 2-3s finalization.
-                eventConsumptionTask?.cancel()
-                await client.disconnect()
-                DebugFileLogger.log("stop: ASR fast-disconnect +\(ContinuousClock.now - stopT0)")
-            } else {
-                // Full teardown: batch providers get a longer timeout for the HTTP round-trip.
-                let endAudioTimeout: Duration = providerIsStreaming ? .seconds(3) : .seconds(60)
-                do {
-                    try await withThrowingTaskGroup(of: Void.self) { group in
-                        group.addTask { try await client.endAudio() }
-                        group.addTask {
-                            try await Task.sleep(for: endAudioTimeout)
-                            throw CancellationError()
-                        }
-                        try await group.next()
-                        group.cancelAll()
+            // Full teardown: batch providers get a longer timeout for the HTTP round-trip.
+            let endAudioTimeout: Duration = providerIsStreaming ? .seconds(3) : .seconds(60)
+            do {
+                try await withThrowingTaskGroup(of: Void.self) { group in
+                    group.addTask { try await client.endAudio() }
+                    group.addTask {
+                        try await Task.sleep(for: endAudioTimeout)
+                        throw CancellationError()
                     }
-                } catch {
-                    NSLog("[Session] endAudio timed out or failed: %@", String(describing: error))
-                    DebugFileLogger.log("endAudio timeout/error: \(error)")
+                    try await group.next()
+                    group.cancelAll()
                 }
-                let drainTimeout: Duration = providerIsStreaming ? .seconds(2) : .seconds(5)
-                if let task = eventConsumptionTask {
-                    let streamDrained = await withTaskGroup(of: Bool.self) { group in
-                        group.addTask {
-                            await task.value
-                            return true
-                        }
-                        group.addTask {
-                            try? await Task.sleep(for: drainTimeout)
-                            return false
-                        }
-                        let first = await group.next() ?? true
-                        group.cancelAll()
-                        return first
-                    }
-                    if !streamDrained {
-                        task.cancel()
-                        DebugFileLogger.log("event stream drain timeout; eventConsumptionTask cancelled")
-                    }
-                }
-                await client.disconnect()
+            } catch {
+                NSLog("[Session] endAudio timed out or failed: %@", String(describing: error))
+                DebugFileLogger.log("endAudio timeout/error: \(error)")
             }
+            let drainTimeout: Duration = providerIsStreaming ? .seconds(2) : .seconds(5)
+            if let task = eventConsumptionTask {
+                let streamDrained = await withTaskGroup(of: Bool.self) { group in
+                    group.addTask {
+                        await task.value
+                        return true
+                    }
+                    group.addTask {
+                        try? await Task.sleep(for: drainTimeout)
+                        return false
+                    }
+                    let first = await group.next() ?? true
+                    group.cancelAll()
+                    return first
+                }
+                if !streamDrained {
+                    task.cancel()
+                    DebugFileLogger.log("event stream drain timeout; eventConsumptionTask cancelled")
+                }
+            }
+            await client.disconnect()
         }
         eventConsumptionTask = nil
         asrClient = nil
@@ -500,7 +517,8 @@ actor RecognitionSession {
             // LLM post-processing: prefer early result (fired at stop time),
             // fall back to synchronous call for very short recordings where
             // no streaming text was available yet.
-            if let earlyTask = earlyLLMTask {
+            if let earlyTask = earlyLLMTask,
+               earlyLLMInputText == finalText {
                 state = .postProcessing
                 DebugFileLogger.log("stop: awaiting early LLM result +\(ContinuousClock.now - stopT0)")
                 let earlyResult = await earlyTask.value
@@ -518,6 +536,9 @@ actor RecognitionSession {
                 }
             } else if needsLLM {
                 state = .postProcessing
+                if let earlyLLMInputText, earlyLLMInputText != finalText {
+                    DebugFileLogger.log("stop: final transcript changed after stop, discarding stale early LLM result")
+                }
                 if let llmConfig = KeychainService.loadLLMConfig() {
                     DebugFileLogger.log("stop: sync LLM firing mode=\(currentMode.name) model=\(llmConfig.model) with \(finalText.count) chars")
                     do {
@@ -716,6 +737,22 @@ actor RecognitionSession {
         audioChunkSenderTask = nil
     }
 
+    func prepareForStopTesting(
+        client: any SpeechRecognizer,
+        mode: ProcessingMode = .direct,
+        transcript: RecognitionTranscript = .empty
+    ) {
+        asrClient = client
+        currentMode = mode
+        currentTranscript = transcript
+        state = .recording
+
+        let chunkContinuation = setupAudioChunkPipeline()
+        audioEngine.onAudioChunk = { data in
+            chunkContinuation.yield(data)
+        }
+    }
+
     private func markReadyIfNeeded() {
         guard !hasEmittedReadyForCurrentSession else { return }
         hasEmittedReadyForCurrentSession = true
@@ -804,9 +841,9 @@ actor RecognitionSession {
         resetSpeculativeLLM()
 
         audioEngine.stop()
+        await finishAudioChunkPipeline(timeout: .milliseconds(100))
         audioEngine.onAudioChunk = nil
         audioEngine.onAudioLevel = nil
-        await finishAudioChunkPipeline(timeout: .milliseconds(100))
 
         if let client = asrClient {
             Task { await client.disconnect() }  // fire-and-forget: don't block reset on WebSocket teardown

--- a/Type4MeTests/RecognitionSessionTests.swift
+++ b/Type4MeTests/RecognitionSessionTests.swift
@@ -50,4 +50,105 @@ final class RecognitionSessionTests: XCTestCase {
         let mode = await session.currentModeForTesting()
         XCTAssertEqual(mode.id, ProcessingMode.directId)
     }
+
+    func testStopRecordingWaitsForTailChunkBeforeEndAudio() async throws {
+        KeychainService.selectedASRProvider = .volcano
+
+        let tempDB = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("sqlite")
+        let audioEngine = FakeAudioEngine(tailChunk: Data([1, 2, 3, 4]))
+        let recognizer = FakeSpeechRecognizer()
+        let session = RecognitionSession(
+            audioEngine: audioEngine,
+            historyStore: HistoryStore(path: tempDB.path)
+        )
+
+        await session.prepareForStopTesting(client: recognizer)
+
+        let stopTask = Task {
+            await session.stopRecording()
+        }
+
+        try await Task.sleep(for: .milliseconds(100))
+        let didCallEndAudio = await recognizer.didCallEndAudio
+        let sentAudioBeforeResume = await recognizer.sentAudio
+        XCTAssertFalse(didCallEndAudio)
+        XCTAssertEqual(sentAudioBeforeResume, [])
+
+        await recognizer.resumeSendAudio()
+        await stopTask.value
+
+        let sentAudioAfterResume = await recognizer.sentAudio
+        let callOrder = await recognizer.callOrder
+        XCTAssertEqual(sentAudioAfterResume, [Data([1, 2, 3, 4])])
+        XCTAssertEqual(callOrder, ["sendAudio", "endAudio", "disconnect"])
+    }
+}
+
+private final class FakeAudioEngine: AudioCapturing, @unchecked Sendable {
+    var onAudioChunk: ((Data) -> Void)?
+    var onAudioLevel: ((Float) -> Void)?
+
+    private let tailChunk: Data
+
+    init(tailChunk: Data) {
+        self.tailChunk = tailChunk
+    }
+
+    func warmUp() {}
+    func start() throws {}
+
+    func stop() {
+        onAudioChunk?(tailChunk)
+    }
+}
+
+private actor FakeSpeechRecognizer: SpeechRecognizer {
+    private var sendContinuation: CheckedContinuation<Void, Never>?
+    private var shouldResumeImmediately = false
+    private(set) var sentAudio: [Data] = []
+    private(set) var callOrder: [String] = []
+
+    var didCallEndAudio: Bool {
+        callOrder.contains("endAudio")
+    }
+
+    var events: AsyncStream<RecognitionEvent> {
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        continuation.finish()
+        return stream
+    }
+
+    func connect(config: any ASRProviderConfig, options: ASRRequestOptions) async throws {}
+
+    func sendAudio(_ data: Data) async throws {
+        callOrder.append("sendAudio")
+        if shouldResumeImmediately {
+            shouldResumeImmediately = false
+            sentAudio.append(data)
+            return
+        }
+        await withCheckedContinuation { continuation in
+            sendContinuation = continuation
+        }
+        sentAudio.append(data)
+    }
+
+    func endAudio() async throws {
+        callOrder.append("endAudio")
+    }
+
+    func disconnect() async {
+        callOrder.append("disconnect")
+    }
+
+    func resumeSendAudio() {
+        if let sendContinuation {
+            sendContinuation.resume()
+            self.sendContinuation = nil
+        } else {
+            shouldResumeImmediately = true
+        }
+    }
 }


### PR DESCRIPTION
## 背景

当前语音输入在“说完最后一个字立即按快捷键停止”时，最后一两个字容易丢失。
实际体验上，这部分内容通常已经说出口，甚至已经进入音频链路，但因为 stop 时机过于激进、ASR/LLM 收尾路径过早截断，导致尾部文本没有进入
最终结果。

## 复现方法

**当我们按下快捷键时可以开始输入，但说完话后立即按下快捷键会发现最后两个字被截断无法输入。**

## 修复内容

本 PR 主要从三个层面修复录音结束时的尾字截断问题：

### 1. 修复音频采集 stop 时尾包丢失
在 `AudioCaptureEngine.stop()` 中，先同步排空 `AVCapture` 的 delegate 队列，再执行 `flushRemaining()`。

这样可以避免：
- 最后一小段音频还滞留在回调队列里
- 上层已经进入 stop 流程
- 尾音来不及进入 session 管线而被直接丢弃

### 2. 调整 stop 语义，给尾音和最终识别留出收敛窗口
在 `RecognitionSession.stopRecording()` 中：

- 增加 stop 后的短尾窗（`350ms`）
- 先停止采集并 drain 音频发送管线
- 再播放 stop 提示音

这样可以避免：
- 用户刚说完就按停时，尚未浮出为 callback 的尾音被截断
- stop 提示音在麦克风仍在采集时介入，污染尾部音频

### 3. 移除流式 ASR + LLM 模式下的“快速断开”快路径
此前在流式引擎 + LLM 模式下，如果已经拿到一版 early text，会直接跳过最终 ASR finalize 并断开连接。
这会导致 stop 后才补出来的最后几个字根本没有机会进入最终 transcript。

本 PR 改为：
- stop 后始终等待 ASR 正常 `endAudio/finalize`
- 等待事件流 drain
- 如果最终 transcript 与 early LLM 输入不一致，则丢弃旧的 early LLM 结果，改用最终完整文本重新处理

这样能保证正确性优先，不再因为快路径牺牲尾字完整性。

## 测试

新增回归测试，验证 stop 过程中：

- 尾包音频必须先送出
- `endAudio()` 不能早于最后一块音频发送完成
- stop 链路在有尾包时仍能正确完成收尾

已验证：
- `swift test --filter RecognitionSessionTests`

## 影响

预期修复以下场景：

- 快速说完后立即按停止键，最后一两个字被截断
- 流式识别 + LLM 后处理模式下，stop 后尾字更容易丢失
- stop 提示音对尾部识别造成干扰

## 说明

这次修改优先保证 stop 时的识别完整性，接受极小的收尾等待成本，以换取明显更稳定的尾字保留效果。