### PR TITLE
fix: reset TCC Accessibility entry after rebuild

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -12,6 +12,11 @@ sleep 1
 
 APP_PATH="$APP_PATH" bash "$SCRIPT_DIR/package-app.sh"
 
+# Reset Accessibility TCC entry so the system re-prompts after rebuild.
+# Self-signed certs produce a new CDHash on every build, which silently
+# invalidates the old TCC record without triggering a new prompt.
+tccutil reset Accessibility com.type4me.app 2>/dev/null || true
+
 if [ "$LAUNCH_APP" = "1" ]; then
     echo "Launching via GUI session (no shell env vars)..."
     launchctl asuser "$(id -u)" /usr/bin/open "$APP_PATH"


### PR DESCRIPTION
 修复使用deploy.sh时，无法成功进行辅助功能授权。
 
  根本原因：每次 deploy.sh 重新构建并签名 app
  时（package-app.sh:246），codesign -f 会生成新的 CDHash。macOS TCC
  数据库里已经有一条旧的授权记录（绑定旧 CDHash），但新 binary 的 hash
  不匹配了。这时候 macOS 的行为是：

  1. 旧 TCC 记录还在，所以 AXIsProcessTrustedWithOptions(prompt: true)
  不会弹出新的授权弹窗（系统认为"已经处理过了"）
  2. 但旧记录对应的 CDHash 和新 binary 不匹配，所以实际权限是无效的
  3. 结果就是：看起来已授权，但实际不工作。只有 tccutil reset
  清掉旧记录后，系统才会重新弹窗

  最简单的修复：在 deploy.sh 里签名完成后自动 reset TCC。