### PR TITLE
feat(history): show ASR provider name in history records

### DIFF
--- a/Type4Me/Database/HistoryStore.swift
+++ b/Type4Me/Database/HistoryStore.swift
@@ -32,7 +32,8 @@ actor HistoryStore {
                 processed_text TEXT,
                 final_text TEXT NOT NULL,
                 status TEXT NOT NULL,
-                character_count INTEGER
+                character_count INTEGER,
+                asr_provider TEXT
             );
             """
             sqlite3_exec(db, sql, nil, nil, nil)
@@ -40,6 +41,10 @@ actor HistoryStore {
             // Migration: add character_count column if it doesn't exist (for existing databases)
             let alterSQL = "ALTER TABLE recognition_history ADD COLUMN character_count INTEGER;"
             sqlite3_exec(db, alterSQL, nil, nil, nil)
+
+            // Migration: add asr_provider column if it doesn't exist
+            let alterASRSQL = "ALTER TABLE recognition_history ADD COLUMN asr_provider TEXT;"
+            sqlite3_exec(db, alterASRSQL, nil, nil, nil)
         }
     }
 
@@ -48,8 +53,8 @@ actor HistoryStore {
     func insert(_ record: HistoryRecord) {
         let sql = """
         INSERT OR REPLACE INTO recognition_history
-        (id, created_at, duration_seconds, raw_text, processing_mode, processed_text, final_text, status, character_count)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+        (id, created_at, duration_seconds, raw_text, processing_mode, processed_text, final_text, status, character_count, asr_provider)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
         """
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return }
@@ -69,6 +74,7 @@ actor HistoryStore {
         } else {
             sqlite3_bind_null(stmt, 9)
         }
+        bindOptional(stmt, 10, record.asrProvider)
         if sqlite3_step(stmt) == SQLITE_DONE {
             postDidChangeNotification()
         }
@@ -97,7 +103,8 @@ actor HistoryStore {
                 processedText: optionalColumn(stmt, 5),
                 finalText: column(stmt, 6),
                 status: column(stmt, 7),
-                characterCount: sqlite3_column_type(stmt, 8) == SQLITE_NULL ? nil : Int(sqlite3_column_int(stmt, 8))
+                characterCount: sqlite3_column_type(stmt, 8) == SQLITE_NULL ? nil : Int(sqlite3_column_int(stmt, 8)),
+                asrProvider: optionalColumn(stmt, 9)
             ))
         }
         return records

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -709,7 +709,8 @@ actor RecognitionSession {
                 processedText: processedText,
                 finalText: finalText,
                 status: status,
-                characterCount: finalText.count
+                characterCount: finalText.count,
+                asrProvider: activeProvider.displayName
             ))
 
             // Note: injectionAborted and llmFailed info is already conveyed
@@ -731,7 +732,8 @@ actor RecognitionSession {
                     processedText: nil,
                     finalText: "",
                     status: status,
-                    characterCount: 0
+                    characterCount: 0,
+                    asrProvider: activeProvider.displayName
                 ))
                 DebugFileLogger.log("stop: no text recognized, saved to history as \(status)")
             }

--- a/Type4Me/UI/Settings/HistoryTab.swift
+++ b/Type4Me/UI/Settings/HistoryTab.swift
@@ -12,6 +12,7 @@ struct HistoryRecord: Identifiable, Hashable {
     let finalText: String
     let status: String
     let characterCount: Int?
+    let asrProvider: String?
 }
 
 // MARK: - View
@@ -382,6 +383,9 @@ struct HistoryTab: View {
                 }
                 if let mode = record.processingMode {
                     Label(mode, systemImage: "text.bubble")
+                }
+                if let provider = record.asrProvider {
+                    Label(provider, systemImage: "mic")
                 }
                 Spacer()
             }


### PR DESCRIPTION
## Summary

- Adds `asr_provider` column to the `recognition_history` SQLite table
- Stores the active ASR provider's display name (e.g. "Deepgram", "Volcano", "SenseVoice") on every insert
- Displays the provider name in the History tab metadata row, alongside duration, char count, and processing mode
- Includes a safe `ALTER TABLE` migration so existing databases upgrade automatically on first launch

<img width="634" height="474" alt="image" src="https://github.com/user-attachments/assets/acb1c0f2-e003-4853-8583-c0dfcdccc948" />

截屏
只有启用之后，新的语音语音输入才会有模型，因为数据库做了一些调整，但应该不影响之前的history。 

## Test plan

- [ ] Do a recording with any ASR provider — History tab shows provider name in the metadata row
- [ ] Existing records (before upgrade) show no provider label — no crash or missing data
- [ ] Export CSV still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)