### PR TITLE
feat(deepgram): advanced settings — Numerals toggle + Hotwords text area

### DIFF
--- a/Type4Me/ASR/ASRProvider.swift
+++ b/Type4Me/ASR/ASRProvider.swift
@@ -68,13 +68,19 @@ struct CredentialField: Sendable, Identifiable {
     /// When true (and options is non-empty), the picker includes a "Custom" entry
     /// that reveals a text field for free-form input.
     let allowCustomInput: Bool
+    /// When true, renders a multi-line TextEditor instead of a single-line TextField.
+    let isTextArea: Bool
+    /// Optional note shown between the field label and the input control.
+    let note: String?
+    /// For text area fields: cap used in the word-count hint (nil = no cap).
+    let wordLimit: Int?
 
     /// Sentinel value used in the picker to represent "custom input" mode.
     static let customValue = "_custom"
 
     var id: String { key }
 
-    init(key: String, label: String, placeholder: String, isSecure: Bool, isOptional: Bool, defaultValue: String, options: [FieldOption] = [], allowCustomInput: Bool = false) {
+    init(key: String, label: String, placeholder: String, isSecure: Bool, isOptional: Bool, defaultValue: String, options: [FieldOption] = [], allowCustomInput: Bool = false, isTextArea: Bool = false, note: String? = nil, wordLimit: Int? = nil) {
         self.key = key
         self.label = label
         self.placeholder = placeholder
@@ -83,6 +89,9 @@ struct CredentialField: Sendable, Identifiable {
         self.defaultValue = defaultValue
         self.options = options
         self.allowCustomInput = allowCustomInput
+        self.isTextArea = isTextArea
+        self.note = note
+        self.wordLimit = wordLimit
     }
 }
 

--- a/Type4Me/ASR/Providers/DeepgramASRConfig.swift
+++ b/Type4Me/ASR/Providers/DeepgramASRConfig.swift
@@ -29,12 +29,16 @@ struct DeepgramASRConfig: ASRProviderConfig, Sendable {
             options: supportedLanguages.map { FieldOption(value: $0, label: $0) }),
         CredentialField(key: "numerals", label: L("数字转换", "Numerals"), placeholder: "false", isSecure: false, isOptional: true, defaultValue: "false",
             options: [FieldOption(value: "true", label: "On"), FieldOption(value: "false", label: "Off")]),
+        CredentialField(key: "hotwords", label: L("热词", "Hotwords"), placeholder: L("word1, word2（逗号分隔）", "word1, word2 — comma separated"), isSecure: false, isOptional: true, defaultValue: "", isTextArea: true,
+            note: L("受接口限制，热词仅取前 30 个", "Due to API limits, only the first 30 hotwords are used"),
+            wordLimit: 30),
     ]}
 
     let apiKey: String
     let model: String
     let language: String
     let numerals: Bool
+    let hotwords: [String]
 
     init?(credentials: [String: String]) {
         guard let apiKey = credentials["apiKey"]?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -48,6 +52,10 @@ struct DeepgramASRConfig: ASRProviderConfig, Sendable {
         self.model = model?.isEmpty == false ? model! : Self.defaultModel
         self.language = language?.isEmpty == false ? language! : Self.defaultLanguage
         self.numerals = credentials["numerals"] == "true"
+        self.hotwords = (credentials["hotwords"] ?? "")
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
     }
 
     func toCredentials() -> [String: String] {
@@ -56,6 +64,7 @@ struct DeepgramASRConfig: ASRProviderConfig, Sendable {
             "model": model,
             "language": language,
             "numerals": numerals ? "true" : "false",
+            "hotwords": hotwords.joined(separator: ", "),
         ]
     }
 

--- a/Type4Me/Protocol/DeepgramProtocol.swift
+++ b/Type4Me/Protocol/DeepgramProtocol.swift
@@ -45,9 +45,10 @@ enum DeepgramProtocol {
             queryItems.append(URLQueryItem(name: "numerals", value: "true"))
         }
 
-        let hotwords = options.hotwords
+        var seen = Set<String>()
+        let hotwords = (config.hotwords + options.hotwords)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
+            .filter { !$0.isEmpty && seen.insert($0.lowercased()).inserted }
             .prefix(maxURLKeyterms)
 
         if config.model.lowercased().hasPrefix("nova-3") {

--- a/Type4Me/UI/Settings/ASRSettingsCard.swift
+++ b/Type4Me/UI/Settings/ASRSettingsCard.swift
@@ -148,7 +148,31 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
                         .foregroundStyle(TF.settingsTextSecondary)
                         .padding(.vertical, 8)
                 } else if hasASRCredentials && !isEditingASR {
-                    credentialSummaryCard(rows: asrSummaryRows)
+                    let gridFields = currentASRFields.filter { !$0.isTextArea }
+                    let textAreaFields = currentASRFields.filter { $0.isTextArea }
+                    credentialSummaryCard(rows: asrSummaryRows(for: gridFields))
+                    ForEach(textAreaFields) { field in
+                        SettingsDivider()
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(field.label.uppercased())
+                                .font(.system(size: 10, weight: .semibold))
+                                .tracking(0.8)
+                                .foregroundStyle(TF.settingsTextTertiary)
+                            if let note = field.note {
+                                Text(note)
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(TF.settingsTextTertiary)
+                            }
+                            let val = savedASRValues[field.key] ?? asrCredentialValues[field.key] ?? ""
+                            Text(val.isEmpty ? field.placeholder : val)
+                                .font(.system(size: 12))
+                                .foregroundStyle(val.isEmpty ? TF.settingsTextTertiary.opacity(0.6) : TF.settingsTextSecondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(12)
+                                .background(RoundedRectangle(cornerRadius: 8).fill(TF.settingsCardAlt))
+                        }
+                        .padding(.vertical, 6)
+                    }
                 } else {
                     dynamicCredentialFields
                 }
@@ -188,12 +212,6 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
                         .padding(.top, 4)
                 }
 
-                if let note = currentProviderNote {
-                    Text(note)
-                        .font(.system(size: 10))
-                        .foregroundStyle(TF.settingsTextTertiary)
-                        .padding(.top, 4)
-                }
 
 
             }
@@ -305,9 +323,11 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
     // MARK: - Credential Fields
 
     private var dynamicCredentialFields: some View {
-        let fields = currentASRFields
-        let rows = stride(from: 0, to: fields.count, by: 2).map { i in
-            Array(fields[i..<min(i+2, fields.count)])
+        let allFields = currentASRFields
+        let gridFields = allFields.filter { !$0.isTextArea }
+        let textAreaFields = allFields.filter { $0.isTextArea }
+        let rows = stride(from: 0, to: gridFields.count, by: 2).map { i in
+            Array(gridFields[i..<min(i+2, gridFields.count)])
         }
         return VStack(spacing: 0) {
             ForEach(Array(rows.enumerated()), id: \.offset) { index, row in
@@ -322,12 +342,33 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
                     }
                 }
             }
+            ForEach(textAreaFields) { field in
+                SettingsDivider()
+                credentialFieldRow(field)
+            }
         }
     }
 
     @ViewBuilder
     private func credentialFieldRow(_ field: CredentialField) -> some View {
-        if !field.options.isEmpty {
+        if field.isTextArea {
+            let binding = Binding<String>(
+                get: {
+                    let val = asrCredentialValues[field.key] ?? ""
+                    return val.isEmpty ? (savedASRValues[field.key] ?? field.defaultValue) : val
+                },
+                set: {
+                    asrCredentialValues[field.key] = $0
+                    editedFields.insert(field.key)
+                }
+            )
+            let resetAction: (() -> Void)? = field.key == "hotwords" ? {
+                let words = HotwordStorage.loadEffective().joined(separator: ", ")
+                asrCredentialValues[field.key] = words
+                editedFields.insert(field.key)
+            } : nil
+            settingsTextAreaField(field.label, text: binding, prompt: field.placeholder, note: field.note, onReset: resetAction, wordLimit: field.wordLimit)
+        } else if !field.options.isEmpty {
             let pickerBinding = Binding<String>(
                 get: {
                     let val = asrCredentialValues[field.key] ?? ""
@@ -368,9 +409,9 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
         }
     }
 
-    private var asrSummaryRows: [(String, String)] {
+    private func asrSummaryRows(for fields: [CredentialField]) -> [(String, String)] {
         var rows: [(String, String)] = []
-        for field in currentASRFields {
+        for field in fields {
             let val = asrCredentialValues[field.key] ?? ""
             guard !val.isEmpty else { continue }
             let displayValue: String
@@ -620,7 +661,10 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
     private func loadASRCredentialsForProvider(_ provider: ASRProvider) {
         testTask?.cancel()
         editedFields = []
-        if let values = KeychainService.loadASRCredentials(for: provider) {
+        if var values = KeychainService.loadASRCredentials(for: provider) {
+            if provider == .deepgram && (values["hotwords"] ?? "").isEmpty {
+                values["hotwords"] = HotwordStorage.loadEffective().joined(separator: ", ")
+            }
             asrCredentialValues = values
             savedASRValues = values
             hasStoredASR = true
@@ -630,6 +674,9 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
             let fields = ASRProviderRegistry.configType(for: provider)?.credentialFields ?? []
             for field in fields where !field.defaultValue.isEmpty {
                 defaults[field.key] = field.defaultValue
+            }
+            if provider == .deepgram {
+                defaults["hotwords"] = HotwordStorage.loadEffective().joined(separator: ", ")
             }
             asrCredentialValues = defaults
             savedASRValues = [:]

--- a/Type4Me/UI/Settings/SettingsCardHelpers.swift
+++ b/Type4Me/UI/Settings/SettingsCardHelpers.swift
@@ -77,6 +77,53 @@ extension SettingsCardHelpers {
         .padding(.vertical, 6)
     }
 
+    func settingsTextAreaField(_ label: String, text: Binding<String>, prompt: String, note: String? = nil, onReset: (() -> Void)? = nil, wordLimit: Int? = nil) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label.uppercased())
+                .font(.system(size: 10, weight: .semibold))
+                .tracking(0.8)
+                .foregroundStyle(TF.settingsTextTertiary)
+            if note != nil || onReset != nil {
+                HStack(spacing: 4) {
+                    if let note {
+                        Text(note)
+                            .font(.system(size: 10))
+                            .foregroundStyle(TF.settingsTextTertiary)
+                    }
+                    if let onReset {
+                        Button(L("从词汇表重新加载", "reload hotwords from vocabulary")) { onReset() }
+                            .buttonStyle(.plain)
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundStyle(TF.settingsAccentBlue)
+                    }
+                }
+            }
+            ZStack(alignment: .topLeading) {
+                if text.wrappedValue.isEmpty {
+                    Text(prompt)
+                        .font(.system(size: 12))
+                        .foregroundStyle(TF.settingsTextTertiary.opacity(0.6))
+                        .padding(.horizontal, 13)
+                        .padding(.vertical, 9)
+                }
+                TextEditor(text: text)
+                    .font(.system(size: 12))
+                    .scrollContentBackground(.hidden)
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 5)
+            }
+            .frame(minHeight: 72)
+            .background(RoundedRectangle(cornerRadius: 8).fill(TF.settingsCardAlt))
+
+            if let hint = textAreaWordHint(text.wrappedValue, limit: wordLimit) {
+                Text(hint)
+                    .font(.system(size: 10))
+                    .foregroundStyle(TF.settingsTextTertiary)
+            }
+        }
+        .padding(.vertical, 6)
+    }
+
     func settingsPickerField(_ label: String, selection: Binding<String>, options: [FieldOption]) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(label.uppercased())
@@ -281,5 +328,22 @@ extension SettingsCardHelpers {
         let prefix = value.prefix(4)
         let suffix = value.suffix(4)
         return "\(prefix)••••\(suffix)"
+    }
+
+    func textAreaWordHint(_ text: String, limit: Int? = nil) -> String? {
+        let words = text
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !words.isEmpty else { return nil }
+        if let limit, words.count > limit {
+            let effectiveWord = words[limit - 1]
+            return L("共 \(words.count) 个词，仅发送前 \(limit) 个，第 \(limit) 个词：\(effectiveWord)",
+                     "Currently \(words.count) words, only first \(limit) will be sent, last effective word is \(effectiveWord)")
+        } else if let last = words.last {
+            return L("共 \(words.count) 个词，最后一个有效词：\(last)",
+                     "Currently \(words.count) words, last effective word is \(last)")
+        }
+        return nil
     }
 }


### PR DESCRIPTION
我还蛮喜欢 Deepgram 的。加了两个 setting：一个是控制是否用数字还是英文。我个人更喜欢用数字，显得更加亲切一些。另外一个是热词，添加了一个设定，能够显示当前所有的词，然后告诉你某个词之后就不能再用，用户也可以自己修改。 
<img width="973" height="620" alt="image" src="https://github.com/user-attachments/assets/8cd5b681-f373-4b68-b939-6882e73646ca" />

## Summary

- **Numerals toggle** (default Off): adds `numerals=true` to the WebSocket URL for spoken-number → digit conversion (en/es/de/fr etc.; no-op for zh/ja/ko)
- **Hotwords text area**: Deepgram-specific keyterms field, pre-populated from global vocabulary (HotwordStorage) on first load, editable, saved as a non-sensitive credential
- **"reload hotwords from vocabulary"** link inline with the API-limits note to resync from global hotwords at any time
- **Word count hint** below the text area: shows total words + last effective word; when over the 30-word limit, highlights the 30th word that will actually be sent
- Hotwords merged with session hotwords (deduped, max 30) when building the WebSocket URL — config keyterms take priority
- Adds `isTextArea`, `note`, `wordLimit` to `CredentialField` for generic multi-line field support; text-area fields render full-width below the 2-column grid

## Test plan

- [ ] Numerals On → record a number in English → digits appear in transcript
- [ ] Hotwords text area pre-populates with global vocabulary on first load
- [ ] Edit hotwords, save → words sent as keyterm/keywords params in WebSocket URL
- [ ] "reload hotwords from vocabulary" resets text area to current global hotwords
- [ ] With >30 words: hint shows 30th word, not the last word
- [ ] Trailing comma / extra whitespace handled gracefully in hint and URL params
- [ ] View mode shows Hotwords full-width with note; other providers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)