### PR TITLE
feat(asr): add ElevenLabs Scribe v2 realtime STT provider

### DIFF
--- a/Type4Me/ASR/ASRProvider.swift
+++ b/Type4Me/ASR/ASRProvider.swift
@@ -13,6 +13,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
     case aws
     case deepgram
     case assemblyai
+    case elevenlabs
     case soniox
     // China
     case volcano
@@ -34,6 +35,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
         case .aws:      return "AWS Transcribe"
         case .deepgram: return "Deepgram"
         case .assemblyai: return "AssemblyAI"
+        case .elevenlabs: return "ElevenLabs"
         case .soniox:   return "Soniox"
         case .volcano:  return L("火山引擎 (Doubao)", "Volcano (Doubao)")
         case .aliyun:   return L("阿里云", "Alibaba Cloud")

--- a/Type4Me/ASR/ASRProviderRegistry.swift
+++ b/Type4Me/ASR/ASRProviderRegistry.swift
@@ -68,6 +68,11 @@ enum ASRProviderRegistry {
                 createClient: { AssemblyAIASRClient() },
                 capabilities: .streaming()
             ),
+            .elevenlabs: ProviderEntry(
+                configType: ElevenLabsASRConfig.self,
+                createClient: { ElevenLabsASRClient() },
+                capabilities: .streaming()
+            ),
             .soniox: ProviderEntry(
                 configType: SonioxASRConfig.self,
                 createClient: { SonioxASRClient() },

--- a/Type4Me/ASR/ElevenLabsASRClient.swift
+++ b/Type4Me/ASR/ElevenLabsASRClient.swift
@@ -1,0 +1,241 @@
+import Foundation
+import os
+
+enum ElevenLabsASRError: Error, LocalizedError {
+    case unsupportedProvider
+    case handshakeTimedOut
+    case closedBeforeHandshake(code: Int, reason: String?)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedProvider:
+            return "ElevenLabsASRClient requires ElevenLabsASRConfig"
+        case .handshakeTimedOut:
+            return "ElevenLabs WebSocket handshake timed out"
+        case .closedBeforeHandshake(let code, let reason):
+            if let reason, !reason.isEmpty {
+                return "ElevenLabs WebSocket closed before handshake (\(code)): \(reason)"
+            }
+            return "ElevenLabs WebSocket closed before handshake (\(code))"
+        }
+    }
+}
+
+actor ElevenLabsASRClient: SpeechRecognizer {
+
+    private let logger = Logger(subsystem: "com.type4me.asr", category: "ElevenLabsASRClient")
+
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var receiveTask: Task<Void, Never>?
+    private var session: URLSession?
+    private var sessionDelegate: ElevenLabsWebSocketDelegate?
+
+    private var eventContinuation: AsyncStream<RecognitionEvent>.Continuation?
+    private var _events: AsyncStream<RecognitionEvent>?
+
+    private var confirmedSegments: [String] = []
+    private var lastTranscript: RecognitionTranscript = .empty
+    private var audioPacketCount = 0
+    private var didRequestClose = false
+    private var pendingFinalCommit = false   // true after endAudio() sends commit
+    private var connectionGate: ElevenLabsConnectionGate?
+
+    var events: AsyncStream<RecognitionEvent> {
+        if let existing = _events { return existing }
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        eventContinuation = continuation
+        _events = stream
+        return stream
+    }
+
+    func connect(config: any ASRProviderConfig, options: ASRRequestOptions = ASRRequestOptions()) async throws {
+        guard let elevenConfig = config as? ElevenLabsASRConfig else {
+            throw ElevenLabsASRError.unsupportedProvider
+        }
+
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        eventContinuation = continuation
+        _events = stream
+
+        let url = try ElevenLabsProtocol.buildWebSocketURL(config: elevenConfig, options: options)
+        var request = URLRequest(url: url)
+        request.setValue(elevenConfig.apiKey, forHTTPHeaderField: "xi-api-key")
+
+        let gate = ElevenLabsConnectionGate()
+        let delegate = ElevenLabsWebSocketDelegate(gate: gate)
+        let session = URLSession(configuration: options.urlSessionConfiguration, delegate: delegate, delegateQueue: nil)
+        let task = session.webSocketTask(with: request)
+        task.resume()
+
+        self.connectionGate = gate
+        self.sessionDelegate = delegate
+        self.session = session
+        self.webSocketTask = task
+        confirmedSegments = []
+        lastTranscript = .empty
+        audioPacketCount = 0
+        didRequestClose = false
+        pendingFinalCommit = false
+
+        try await gate.waitUntilOpen(timeout: .seconds(5))
+        logger.info("ElevenLabs WebSocket connected: \(url.absoluteString, privacy: .private(mask: .hash))")
+        startReceiveLoop()
+    }
+
+    func sendAudio(_ data: Data) async throws {
+        guard let task = webSocketTask else { return }
+        // ElevenLabs STT requires base64-encoded JSON, not raw binary
+        try await task.send(.string(ElevenLabsProtocol.audioChunkMessage(data)))
+        audioPacketCount += 1
+    }
+
+    func endAudio() async throws {
+        guard let task = webSocketTask else { return }
+        pendingFinalCommit = true
+        didRequestClose = true
+        try await task.send(.string(ElevenLabsProtocol.commitMessage()))
+    }
+
+    func disconnect() {
+        receiveTask?.cancel()
+        receiveTask = nil
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        webSocketTask = nil
+        session?.invalidateAndCancel()
+        session = nil
+        sessionDelegate = nil
+        eventContinuation?.finish()
+        eventContinuation = nil
+        _events = nil
+        connectionGate = nil
+        confirmedSegments = []
+        lastTranscript = .empty
+        audioPacketCount = 0
+        didRequestClose = false
+        logger.info("ElevenLabs disconnected")
+    }
+
+    // MARK: - Receive Loop
+
+    private func startReceiveLoop() {
+        receiveTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                do {
+                    guard let task = await self.webSocketTask else { break }
+                    let message = try await task.receive()
+                    await self.handleMessage(message)
+                } catch {
+                    if Task.isCancelled { break }
+                    logger.info("ElevenLabs receive loop ended: \(String(describing: error), privacy: .public)")
+                    let didClose = await self.didRequestClose
+                    let packetCount = await self.audioPacketCount
+                    if didClose || packetCount > 0 {
+                        await self.emitEvent(.completed)
+                    } else {
+                        await self.emitEvent(.error(error))
+                        await self.emitEvent(.completed)
+                    }
+                    break
+                }
+            }
+            await self.eventContinuation?.finish()
+        }
+    }
+
+    private func handleMessage(_ message: URLSessionWebSocketTask.Message) {
+        do {
+            let data: Data
+            switch message {
+            case .data(let d): data = d
+            case .string(let s):
+                data = Data(s.utf8)
+            @unknown default: return
+            }
+
+            if let update = try ElevenLabsProtocol.makeTranscriptUpdate(
+                from: data,
+                confirmedSegments: confirmedSegments,
+                isFinalCommit: pendingFinalCommit
+            ) {
+                confirmedSegments = update.confirmedSegments
+                guard update.transcript != lastTranscript else { return }
+                lastTranscript = update.transcript
+                logger.info("ElevenLabs transcript confirmed=\(update.transcript.confirmedSegments.count) partial=\(update.transcript.partialText.count) final=\(update.transcript.isFinal)")
+                emitEvent(.transcript(update.transcript))
+            }
+        } catch {
+            logger.error("ElevenLabs decode error: \(String(describing: error), privacy: .public)")
+            emitEvent(.error(error))
+        }
+    }
+
+    private func emitEvent(_ event: RecognitionEvent) {
+        eventContinuation?.yield(event)
+    }
+}
+
+// MARK: - Connection Gate
+
+actor ElevenLabsConnectionGate {
+    private var continuation: CheckedContinuation<Void, Error>?
+    private(set) var isOpen = false
+    private var failure: Error?
+
+    var hasOpened: Bool { isOpen }
+
+    func waitUntilOpen(timeout: Duration) async throws {
+        let timeoutTask = Task {
+            try? await Task.sleep(for: timeout)
+            self.markFailure(ElevenLabsASRError.handshakeTimedOut)
+        }
+        defer { timeoutTask.cancel() }
+        try await wait()
+    }
+
+    func markOpen() {
+        guard !isOpen else { return }
+        isOpen = true
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func markFailure(_ error: Error) {
+        guard !isOpen, failure == nil else { return }
+        failure = error
+        continuation?.resume(throwing: error)
+        continuation = nil
+    }
+
+    private func wait() async throws {
+        if isOpen { return }
+        if let failure { throw failure }
+        try await withCheckedThrowingContinuation { self.continuation = $0 }
+    }
+}
+
+// MARK: - WebSocket Delegate
+
+final class ElevenLabsWebSocketDelegate: NSObject, URLSessionWebSocketDelegate, URLSessionTaskDelegate, @unchecked Sendable {
+
+    private let gate: ElevenLabsConnectionGate
+
+    init(gate: ElevenLabsConnectionGate) { self.gate = gate }
+
+    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
+        Task { await gate.markOpen() }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let error else { return }
+        Task { await gate.markFailure(error) }
+    }
+
+    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        let reasonText = reason.flatMap { String(data: $0, encoding: .utf8) }
+        Task {
+            guard await !gate.hasOpened else { return }
+            await gate.markFailure(ElevenLabsASRError.closedBeforeHandshake(code: Int(closeCode.rawValue), reason: reasonText))
+        }
+    }
+}

--- a/Type4Me/ASR/Providers/ElevenLabsASRConfig.swift
+++ b/Type4Me/ASR/Providers/ElevenLabsASRConfig.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+struct ElevenLabsASRConfig: ASRProviderConfig, Sendable {
+
+    static let provider = ASRProvider.elevenlabs
+    static let displayName = "ElevenLabs"
+
+    static let supportedLanguages = [
+        "",         // auto-detect
+        "en", "zh", "zh-TW", "ja", "ko",
+        "es", "fr", "de", "it", "pt",
+        "ru", "ar", "hi", "nl", "pl",
+    ]
+
+    static var credentialFields: [CredentialField] {[
+        CredentialField(key: "apiKey", label: "API Key", placeholder: L("粘贴 API Key", "Paste your API Key"), isSecure: true, isOptional: false, defaultValue: ""),
+        CredentialField(key: "language", label: L("语言", "Language"), placeholder: "auto", isSecure: false, isOptional: true, defaultValue: "",
+            options: supportedLanguages.map { FieldOption(value: $0, label: $0.isEmpty ? L("自动检测", "auto-detect") : $0) }),
+    ]}
+
+    let apiKey: String
+    let language: String
+
+    init?(credentials: [String: String]) {
+        guard let apiKey = credentials["apiKey"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !apiKey.isEmpty
+        else { return nil }
+        self.apiKey = apiKey
+        self.language = credentials["language"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+
+    func toCredentials() -> [String: String] {
+        ["apiKey": apiKey, "language": language]
+    }
+
+    var isValid: Bool { !apiKey.isEmpty }
+}

--- a/Type4Me/Protocol/ElevenLabsProtocol.swift
+++ b/Type4Me/Protocol/ElevenLabsProtocol.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+enum ElevenLabsProtocolError: Error, LocalizedError {
+    case invalidEndpoint
+
+    var errorDescription: String? { "Failed to build ElevenLabs WebSocket URL" }
+}
+
+struct ElevenLabsTermsError: Error, LocalizedError {
+    var errorDescription: String? {
+        "ElevenLabs terms not accepted. Please visit elevenlabs.io/app/product-terms to enable Speech-to-Text."
+    }
+}
+
+struct ElevenLabsTranscriptUpdate: Sendable, Equatable {
+    let transcript: RecognitionTranscript
+    let confirmedSegments: [String]
+}
+
+enum ElevenLabsProtocol {
+
+    private static let endpoint = "wss://api.elevenlabs.io/v1/speech-to-text/realtime"
+    private static let sampleRate = 16000
+
+    // MARK: - URL
+
+    static func buildWebSocketURL(config: ElevenLabsASRConfig, options: ASRRequestOptions) throws -> URL {
+        guard var components = URLComponents(string: endpoint) else {
+            throw ElevenLabsProtocolError.invalidEndpoint
+        }
+        var queryItems = [
+            URLQueryItem(name: "model_id", value: "scribe_v2_realtime"),
+            URLQueryItem(name: "audio_format", value: "pcm_16000"),
+        ]
+        if !config.language.isEmpty {
+            queryItems.append(URLQueryItem(name: "language_code", value: config.language))
+        }
+        // Keyterm prompting: ElevenLabs supports up to 1000 keyterms
+        let keyterms = options.hotwords
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .prefix(1000)
+        for term in keyterms {
+            queryItems.append(URLQueryItem(name: "keyterm", value: term))
+        }
+        components.queryItems = queryItems
+        guard let url = components.url else {
+            throw ElevenLabsProtocolError.invalidEndpoint
+        }
+        return url
+    }
+
+    // MARK: - Outbound messages
+
+    /// Encode a PCM audio chunk as a JSON message with base64 audio.
+    static func audioChunkMessage(_ pcmData: Data) -> String {
+        let b64 = pcmData.base64EncodedString()
+        let payload: [String: Any] = [
+            "message_type": "input_audio_chunk",
+            "audio_base_64": b64,
+            "sample_rate": sampleRate,
+        ]
+        return jsonString(payload)
+    }
+
+    /// Final commit message — tells the server to finalize the current segment.
+    static func commitMessage() -> String {
+        let payload: [String: Any] = [
+            "message_type": "input_audio_chunk",
+            "audio_base_64": "",
+            "commit": true,
+            "sample_rate": sampleRate,
+        ]
+        return jsonString(payload)
+    }
+
+    // MARK: - Inbound message parsing
+
+    private struct InboundMessage: Decodable {
+        let messageType: String
+        let text: String?          // ElevenLabs uses "text" not "transcript"
+
+        enum CodingKeys: String, CodingKey {
+            case messageType = "message_type"
+            case text
+        }
+    }
+
+    static func makeTranscriptUpdate(
+        from data: Data,
+        confirmedSegments: [String],
+        isFinalCommit: Bool = false
+    ) throws -> ElevenLabsTranscriptUpdate? {
+        guard data.first == UInt8(ascii: "{") else { return nil }
+        let message = try JSONDecoder().decode(InboundMessage.self, from: data)
+
+        switch message.messageType {
+        case "partial_transcript":
+            guard let text = message.text,
+                  !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+            let normalized = normalize(segment: text, after: confirmedSegments.joined())
+            let transcript = RecognitionTranscript(
+                confirmedSegments: confirmedSegments,
+                partialText: normalized,
+                authoritativeText: (confirmedSegments + [normalized]).joined(),
+                isFinal: false
+            )
+            return ElevenLabsTranscriptUpdate(transcript: transcript, confirmedSegments: confirmedSegments)
+
+        case "committed_transcript":
+            let trimmed = message.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            var next = confirmedSegments
+            if !trimmed.isEmpty {
+                let normalized = normalize(segment: trimmed, after: confirmedSegments.joined())
+                next.append(normalized)
+            }
+            // Mid-stream auto-commits (VAD) use isFinal: false so the session keeps recording.
+            // Only the explicit endAudio() commit uses isFinal: true to trigger injection.
+            let transcript = RecognitionTranscript(
+                confirmedSegments: next,
+                partialText: "",
+                authoritativeText: next.joined(),
+                isFinal: isFinalCommit
+            )
+            return ElevenLabsTranscriptUpdate(transcript: transcript, confirmedSegments: next)
+
+        case "commit_throttled":
+            // VAD already committed all audio before our explicit commit — treat as final.
+            if !confirmedSegments.isEmpty || isFinalCommit {
+                let transcript = RecognitionTranscript(
+                    confirmedSegments: confirmedSegments,
+                    partialText: "",
+                    authoritativeText: confirmedSegments.joined(),
+                    isFinal: true
+                )
+                return ElevenLabsTranscriptUpdate(transcript: transcript, confirmedSegments: confirmedSegments)
+            }
+            return nil
+
+        case "unaccepted_terms":
+            // Surface this as a real error — user must accept terms at elevenlabs.io/app/product-terms
+            throw ElevenLabsTermsError()
+
+        case "session_time_limit_exceeded", "insufficient_audio_activity",
+             "chunk_size_exceeded", "error":
+            return nil
+
+        default:
+            return nil
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func jsonString(_ payload: [String: Any]) -> String {
+        (try? JSONSerialization.data(withJSONObject: payload))
+            .flatMap { String(data: $0, encoding: .utf8) } ?? ""
+    }
+
+    private static func normalize(segment: String, after existingText: String) -> String {
+        guard !segment.isEmpty, let last = existingText.last, let first = segment.first else {
+            return segment
+        }
+        if last.isWhitespace || first.isWhitespace { return segment }
+        if first.isClosingPunctuation || last.isOpeningPunctuation { return segment }
+        if last.isCJKUnifiedIdeograph || first.isCJKUnifiedIdeograph { return segment }
+        return " " + segment
+    }
+}

--- a/Type4Me/UI/Settings/ASRSettingsCard.swift
+++ b/Type4Me/UI/Settings/ASRSettingsCard.swift
@@ -75,6 +75,10 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
                 (L("可用模型", "Models"), L("查看", "view"), URL(string: "https://www.assemblyai.com/docs/getting-started/models")!),
                 ("API Key", L("获取", "get"), URL(string: "https://www.assemblyai.com/docs/faq/how-to-get-your-api-key")!),
             ]
+        case .elevenlabs:
+            return [
+                ("API Key", L("获取", "get"), URL(string: "https://elevenlabs.io/app/settings/api-keys")!),
+            ]
         case .soniox:
             return [
                 ("API Key", L("获取", "get"), URL(string: "https://console.soniox.com")!),


### PR DESCRIPTION
我现在终于加了一个新的模型，用Elevenlabs
中英文都支持，而且支持1000个热词


https://github.com/user-attachments/assets/940f0096-75af-4b92-b54e-f0bf39ccdb5a


## Summary

- Adds **ElevenLabs** as a streaming ASR provider in the Others group, positioned below AssemblyAI
- Uses the Scribe v2 realtime WebSocket API (`wss://api.elevenlabs.io/v1/speech-to-text/realtime`)
- **Auto language detection** by default (no `language_code` param); optional ISO 639-1 language hint
- **Live transcription** via `partial_transcript` events while speaking
- **Keyterm prompting**: all vocabulary hotwords sent as `keyterm` query params — ElevenLabs supports up to 1000 (vs Deepgram's 30)

## Implementation notes

- Audio sent as **base64-encoded JSON** (`audio_base_64` field) — ElevenLabs STT rejects raw binary frames
- VAD (voice activity detection) handles mid-stream commits automatically; mid-stream `committed_transcript` events emit `isFinal: false` so recording continues uninterrupted
- Only the explicit `endAudio()` commit emits `isFinal: true` to trigger text injection
- `commit_throttled` handled gracefully (VAD already committed all audio)
- `unaccepted_terms` surfaces a clear error: user must accept ElevenLabs product terms at `elevenlabs.io/app/product-terms` to enable the realtime STT feature

## Setup required

1. Get API key at [elevenlabs.io/app/settings/api-keys](https://elevenlabs.io/app/settings/api-keys)
2. Accept Speech-to-Text product terms at [elevenlabs.io/app/product-terms](https://elevenlabs.io/app/product-terms)

## Test plan

- [ ] Settings → ASR Provider → ElevenLabs appears below AssemblyAI in Others
- [ ] Enter API key, save, Test Connection passes
- [ ] Short recording: partial transcripts appear in real time, final text injected on stop
- [ ] Long recording: multiple VAD commits accumulate correctly, no mid-session cut
- [ ] Hotwords from vocabulary appear in the WebSocket URL as keyterm params
- [ ] Without accepting product terms: clear error message shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)