### PR TITLE
Improve privacy defaults and move secrets to Keychain

### DIFF
--- a/Type4Me/ASR/SonioxASRClient.swift
+++ b/Type4Me/ASR/SonioxASRClient.swift
@@ -216,7 +216,7 @@ actor SonioxASRClient: SpeechRecognizer {
         emitEvent(.transcript(transcript))
 
         if transcript.isFinal, !transcript.authoritativeText.isEmpty {
-            NSLog("[Soniox] Final transcript: '%@'", transcript.authoritativeText)
+            NSLog("[Soniox] Final transcript received (%d chars)", transcript.authoritativeText.count)
         }
     }
 }

--- a/Type4Me/ASR/VolcASRClient.swift
+++ b/Type4Me/ASR/VolcASRClient.swift
@@ -272,7 +272,7 @@ actor VolcASRClient: SpeechRecognizer {
                 emitEvent(.transcript(transcript))
 
                 if transcript.isFinal, !transcript.authoritativeText.isEmpty {
-                    NSLog("[ASR] Final transcript: '%@'", transcript.authoritativeText)
+                    NSLog("[ASR] Final transcript received (%d chars)", transcript.authoritativeText.count)
                 }
             } catch {
                 NSLog("[ASR] Decode error: %@", String(describing: error))

--- a/Type4Me/LLM/DoubaoChatClient.swift
+++ b/Type4Me/LLM/DoubaoChatClient.swift
@@ -82,12 +82,10 @@ actor DoubaoChatClient: LLMClient {
 
         var result = ""
         var lineCount = 0
-        var firstDataLine: String?
         for try await line in bytes.lines {
             lineCount += 1
             guard line.hasPrefix("data: ") else { continue }
             let payload = String(line.dropFirst(6))
-            if firstDataLine == nil { firstDataLine = String(payload.prefix(300)) }
             if payload == "[DONE]" { break }
             guard let data = payload.data(using: .utf8),
                   let chunk = try? JSONDecoder().decode(ChatStreamChunk.self, from: data),
@@ -97,8 +95,8 @@ actor DoubaoChatClient: LLMClient {
         }
 
         if result.isEmpty && lineCount > 0 {
-            DebugFileLogger.log("LLM[\(model)]: \(lineCount) lines but 0 content chars; first data=\(firstDataLine ?? "(none)")")
-            throw LLMError.emptyResponse(firstDataLine)
+            DebugFileLogger.log("LLM[\(model)]: \(lineCount) lines but 0 content chars")
+            throw LLMError.emptyResponse("stream contained no text")
         }
         if result.isEmpty {
             DebugFileLogger.log("LLM[\(model)]: 0 lines received (connection closed immediately)")
@@ -123,9 +121,8 @@ actor DoubaoChatClient: LLMClient {
         guard let json = try? JSONDecoder().decode(ChatCompletionResponse.self, from: data),
               let content = json.choices.first?.message.content, !content.isEmpty
         else {
-            let raw = String(data: data.prefix(300), encoding: .utf8)
-            DebugFileLogger.log("LLM[\(model)]: non-streaming empty; raw=\(raw ?? "(nil)")")
-            throw LLMError.emptyResponse(raw)
+            DebugFileLogger.log("LLM[\(model)]: non-streaming empty response")
+            throw LLMError.emptyResponse("empty response body")
         }
         return content
     }

--- a/Type4Me/LLM/PromptContext.swift
+++ b/Type4Me/LLM/PromptContext.swift
@@ -8,6 +8,7 @@ import os
 struct PromptContext: Sendable {
     let selectedText: String
     let clipboardText: String
+    static let empty = PromptContext(selectedText: "", clipboardText: "")
 
     /// Capture the current selected text (via Accessibility) and clipboard content.
     /// Clipboard is read on MainActor (AppKit requirement).
@@ -44,6 +45,10 @@ struct PromptContext: Sendable {
         }
         result += remaining
         return result
+    }
+
+    static func referencesSensitiveVariables(in prompt: String) -> Bool {
+        prompt.contains("{selected}") || prompt.contains("{clipboard}")
     }
 
     // MARK: - Private

--- a/Type4Me/Services/KeychainService.swift
+++ b/Type4Me/Services/KeychainService.swift
@@ -1,9 +1,12 @@
 import Foundation
+import Security
 
 enum KeychainService {
 
     private static let lock = NSLock()
     private static var cachedCredentials: [String: Any]?
+    private static let keychainScalarService = "com.type4me.scalar"
+    private static let keychainGroupedService = "com.type4me.grouped"
 
     private static var credentialsURL: URL {
         let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
@@ -43,27 +46,16 @@ enum KeychainService {
     // MARK: - Scalar key-value (for LLM keys and misc)
 
     static func save(key: String, value: String) throws {
-        lock.lock()
-        defer { lock.unlock() }
-        var dict = _loadAllUnlocked()
-        dict[key] = value
-        try saveAll(dict)
-        cachedCredentials = dict
+        try saveSecureString(value, service: keychainScalarService, account: key)
     }
 
     static func load(key: String) -> String? {
-        loadAll()[key] as? String
+        loadSecureString(service: keychainScalarService, account: key)
     }
 
     @discardableResult
     static func delete(key: String) -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        var dict = _loadAllUnlocked()
-        guard dict.removeValue(forKey: key) != nil else { return false }
-        let ok = (try? saveAll(dict)) != nil
-        if ok { cachedCredentials = dict } else { cachedCredentials = nil }
-        return ok
+        deleteSecureValue(service: keychainScalarService, account: key)
     }
 
     // MARK: - Selected ASR Provider (UserDefaults)
@@ -95,14 +87,29 @@ enum KeychainService {
         lock.lock()
         defer { lock.unlock() }
         var dict = _loadAllUnlocked()
-        dict[asrStorageKey(for: provider)] = values
+        let storageKey = asrStorageKey(for: provider)
+        let split = splitCredentials(values, using: ASRProviderRegistry.configType(for: provider)?.credentialFields ?? [])
+        if split.secure.isEmpty {
+            _ = deleteSecureValue(service: keychainGroupedService, account: storageKey)
+        } else {
+            try saveSecureValues(split.secure, account: storageKey)
+        }
+        if split.plaintext.isEmpty {
+            dict.removeValue(forKey: storageKey)
+        } else {
+            dict[storageKey] = split.plaintext
+        }
         try saveAll(dict)
         cachedCredentials = dict
     }
 
     static func loadASRCredentials(for provider: ASRProvider) -> [String: String]? {
         let dict = loadAll()
-        return dict[asrStorageKey(for: provider)] as? [String: String]
+        let storageKey = asrStorageKey(for: provider)
+        let plaintext = dict[storageKey] as? [String: String] ?? [:]
+        let secure = loadSecureValues(account: storageKey)
+        let merged = plaintext.merging(secure) { _, secure in secure }
+        return merged.isEmpty ? nil : merged
     }
 
     static func loadASRConfig(for provider: ASRProvider) -> (any ASRProviderConfig)? {
@@ -174,14 +181,29 @@ enum KeychainService {
         lock.lock()
         defer { lock.unlock() }
         var dict = _loadAllUnlocked()
-        dict[llmStorageKey(for: provider)] = values
+        let storageKey = llmStorageKey(for: provider)
+        let split = splitCredentials(values, using: LLMProviderRegistry.configType(for: provider)?.credentialFields ?? [])
+        if split.secure.isEmpty {
+            _ = deleteSecureValue(service: keychainGroupedService, account: storageKey)
+        } else {
+            try saveSecureValues(split.secure, account: storageKey)
+        }
+        if split.plaintext.isEmpty {
+            dict.removeValue(forKey: storageKey)
+        } else {
+            dict[storageKey] = split.plaintext
+        }
         try saveAll(dict)
         cachedCredentials = dict
     }
 
     static func loadLLMCredentials(for provider: LLMProvider) -> [String: String]? {
         let dict = loadAll()
-        return dict[llmStorageKey(for: provider)] as? [String: String]
+        let storageKey = llmStorageKey(for: provider)
+        let plaintext = dict[storageKey] as? [String: String] ?? [:]
+        let secure = loadSecureValues(account: storageKey)
+        let merged = plaintext.merging(secure) { _, secure in secure }
+        return merged.isEmpty ? nil : merged
     }
 
     static func loadLLMProviderConfig(for provider: LLMProvider) -> (any LLMProviderConfig)? {
@@ -293,10 +315,158 @@ enum KeychainService {
             NSLog("[KeychainService] Migrated MiniMax CN base URL: api.minimax.chat → api.minimaxi.com")
         }
 
-        if migrated {
+        let secureFieldsMigrated = migrateSecureCredentialGroups(in: &mutableDict)
+
+        if migrated || secureFieldsMigrated {
             try? saveAll(mutableDict)
             cachedCredentials = mutableDict
         }
+    }
+
+    // MARK: - Keychain helpers
+
+    private static func keychainQuery(service: String, account: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+
+    private static func saveSecureString(_ value: String, service: String, account: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw KeychainError.invalidEncoding
+        }
+        try saveSecureData(data, service: service, account: account)
+    }
+
+    private static func loadSecureString(service: String, account: String) -> String? {
+        guard let data = loadSecureData(service: service, account: account) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func saveSecureValues(_ values: [String: String], account: String) throws {
+        let data = try JSONSerialization.data(withJSONObject: values, options: [.sortedKeys])
+        try saveSecureData(data, service: keychainGroupedService, account: account)
+    }
+
+    private static func loadSecureValues(account: String) -> [String: String] {
+        guard let data = loadSecureData(service: keychainGroupedService, account: account),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: String]
+        else {
+            return [:]
+        }
+        return object
+    }
+
+    private static func saveSecureData(_ data: Data, service: String, account: String) throws {
+        let query = keychainQuery(service: service, account: account)
+        let attributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
+        ]
+
+        let status = SecItemCopyMatching(query as CFDictionary, nil)
+        switch status {
+        case errSecSuccess:
+            let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+            guard updateStatus == errSecSuccess else {
+                throw KeychainError.saveFailed(updateStatus)
+            }
+        case errSecItemNotFound:
+            var addQuery = query
+            addQuery.merge(attributes) { _, new in new }
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
+                throw KeychainError.saveFailed(addStatus)
+            }
+        default:
+            throw KeychainError.saveFailed(status)
+        }
+    }
+
+    private static func loadSecureData(service: String, account: String) -> Data? {
+        var query = keychainQuery(service: service, account: account)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess else { return nil }
+        return result as? Data
+    }
+
+    @discardableResult
+    private static func deleteSecureValue(service: String, account: String) -> Bool {
+        let status = SecItemDelete(keychainQuery(service: service, account: account) as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+
+    // MARK: - Secure field splitting
+
+    private static func splitCredentials(
+        _ values: [String: String],
+        using fields: [CredentialField]
+    ) -> (plaintext: [String: String], secure: [String: String]) {
+        let secureKeys = Set(fields.filter(\.isSecure).map(\.key))
+        guard !secureKeys.isEmpty else {
+            return (values, [:])
+        }
+
+        var plaintext: [String: String] = [:]
+        var secure: [String: String] = [:]
+
+        for (key, value) in values {
+            if secureKeys.contains(key) {
+                if !value.isEmpty {
+                    secure[key] = value
+                }
+            } else if !value.isEmpty {
+                plaintext[key] = value
+            }
+        }
+        return (plaintext, secure)
+    }
+
+    @discardableResult
+    private static func migrateSecureCredentialGroups(in dict: inout [String: Any]) -> Bool {
+        var changed = false
+        for provider in ASRProvider.allCases {
+            changed = migrateSecureFields(
+                in: &dict,
+                storageKey: asrStorageKey(for: provider),
+                fields: ASRProviderRegistry.configType(for: provider)?.credentialFields ?? []
+            ) || changed
+        }
+
+        for provider in LLMProvider.allCases {
+            changed = migrateSecureFields(
+                in: &dict,
+                storageKey: llmStorageKey(for: provider),
+                fields: LLMProviderRegistry.configType(for: provider)?.credentialFields ?? []
+            ) || changed
+        }
+        return changed
+    }
+
+    @discardableResult
+    private static func migrateSecureFields(
+        in dict: inout [String: Any],
+        storageKey: String,
+        fields: [CredentialField]
+    ) -> Bool {
+        guard let values = dict[storageKey] as? [String: String] else { return false }
+        let split = splitCredentials(values, using: fields)
+        guard split.plaintext.count != values.count || !split.secure.isEmpty else { return false }
+        if !split.secure.isEmpty {
+            try? saveSecureValues(split.secure, account: storageKey)
+        }
+        if split.plaintext.isEmpty {
+            dict.removeValue(forKey: storageKey)
+        } else {
+            dict[storageKey] = split.plaintext
+        }
+        return true
     }
 
     // MARK: - Application Support Directory Migration
@@ -375,5 +545,6 @@ enum KeychainService {
 }
 
 enum KeychainError: Error {
+    case invalidEncoding
     case saveFailed(OSStatus)
 }

--- a/Type4Me/Services/PrivacyPreferences.swift
+++ b/Type4Me/Services/PrivacyPreferences.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum PrivacyPreferences {
+    static let allowSensitivePromptContextKey = "tf_allowSensitivePromptContext"
+    static let sonioxAsyncCalibrationKey = "tf_sonioxAsyncCalibration"
+
+    static var allowSensitivePromptContext: Bool {
+        UserDefaults.standard.object(forKey: allowSensitivePromptContextKey) as? Bool ?? false
+    }
+
+    static var sonioxAsyncCalibrationEnabled: Bool {
+        UserDefaults.standard.object(forKey: sonioxAsyncCalibrationKey) as? Bool ?? false
+    }
+
+    static func shouldCapturePromptContext(for prompt: String, llmProvider: LLMProvider?) -> Bool {
+        guard PromptContext.referencesSensitiveVariables(in: prompt) else { return false }
+        if let llmProvider, llmProvider.isLocal {
+            return true
+        }
+        return allowSensitivePromptContext
+    }
+}

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -223,8 +223,13 @@ actor RecognitionSession {
             bypassProxy: ProxyBypassMode.current.bypassASR
         )
 
-        // Capture prompt context while the user's selection is still active.
-        promptContext = await PromptContext.capture()
+        // Capture prompt context only when the current prompt actually needs it.
+        let llmProvider = needsLLM ? KeychainService.selectedLLMProvider : nil
+        if PrivacyPreferences.shouldCapturePromptContext(for: effectiveMode.prompt, llmProvider: llmProvider) {
+            promptContext = await PromptContext.capture()
+        } else {
+            promptContext = .empty
+        }
         guard sessionGeneration == myGeneration else {
             DebugFileLogger.log("startRecording: zombie detected after capture, bailing")
             return
@@ -414,7 +419,7 @@ actor RecognitionSession {
         // Kick off Soniox async calibration EARLY, in parallel with RT teardown.
         // Grab audio now before audioEngine.stop() clears it.
         let sonioxAsyncEnabled = provider == .soniox
-            && UserDefaults.standard.bool(forKey: "tf_sonioxAsyncCalibration")
+            && PrivacyPreferences.sonioxAsyncCalibrationEnabled
         var sonioxAsyncTask: Task<SonioxAsyncClient.TranscriptionResult?, Never>?
         if sonioxAsyncEnabled, let sonioxConfig = currentConfig as? SonioxASRConfig {
             let fullAudio = audioEngine.getRecordedAudio()
@@ -675,7 +680,7 @@ actor RecognitionSession {
             // still emitted only after injection completes, preserving ordering.
             let engine = injectionEngine
             let aborted = injectionAborted
-            let injectLog = "stop: injecting method=clipboard text=[\(finalText.prefix(50))] len=\(finalText.count) +\(ContinuousClock.now - stopT0)"
+            let injectLog = "stop: injecting method=clipboard len=\(finalText.count) +\(ContinuousClock.now - stopT0)"
             let injectionOutcome: InjectionOutcome = await withCheckedContinuation { continuation in
                 Task.detached {
                     let outcome: InjectionOutcome

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -20,6 +20,8 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
     @AppStorage("tf_preserveClipboard") private var preserveClipboard = true
     @AppStorage("tf_showDockIcon") private var showDockIcon = true
     @AppStorage("tf_bypassProxy") private var bypassProxy = "off"
+    @AppStorage("tf_allowSensitivePromptContext") private var allowSensitivePromptContext = false
+    @AppStorage("tf_sonioxAsyncCalibration") private var sonioxAsyncCalibration = false
 
     @State private var hasMic = false
     @State private var hasAccessibility = false
@@ -139,25 +141,13 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
             // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
             settingsGroupCard(L("高级设置", "Advanced"), icon: "wrench.and.screwdriver") {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(L("绕过系统代理", "Bypass System Proxy").uppercased())
-                        .font(.system(size: 10, weight: .semibold))
-                        .tracking(0.8)
-                        .foregroundStyle(TF.settingsTextTertiary)
-                    settingsDropdown(
-                        selection: $bypassProxy,
-                        options: [
-                            ("off", L("关闭", "Off")),
-                            ("all", L("全局绕过", "All Connections")),
-                            ("asr", L("语音识别绕过", "ASR Only")),
-                            ("llm", L("文本处理 LLM 绕过", "LLM Only")),
-                        ]
-                    )
-                    Text(L("不经过代理软件，直连对应服务器", "Connect directly to servers, bypassing proxy"))
-                        .font(.system(size: 10))
-                        .foregroundStyle(TF.settingsTextTertiary)
+                VStack(alignment: .leading, spacing: 0) {
+                    bypassProxyRow
+                    SettingsDivider()
+                    sensitivePromptContextRow
+                    SettingsDivider()
+                    sonioxCalibrationRow
                 }
-                .padding(.vertical, 6)
             }
 
         }
@@ -401,6 +391,74 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
                 options: AppLanguage.allCases.map { ($0.rawValue, $0.displayName) },
                 icon: "globe"
             )
+        }
+        .padding(.vertical, 6)
+    }
+
+    private var bypassProxyRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(L("绕过系统代理", "Bypass System Proxy").uppercased())
+                .font(.system(size: 10, weight: .semibold))
+                .tracking(0.8)
+                .foregroundStyle(TF.settingsTextTertiary)
+            settingsDropdown(
+                selection: $bypassProxy,
+                options: [
+                    ("off", L("关闭", "Off")),
+                    ("all", L("全局绕过", "All Connections")),
+                    ("asr", L("语音识别绕过", "ASR Only")),
+                    ("llm", L("文本处理 LLM 绕过", "LLM Only")),
+                ]
+            )
+            Text(L("不经过代理软件，直连对应服务器", "Connect directly to servers, bypassing proxy"))
+                .font(.system(size: 10))
+                .foregroundStyle(TF.settingsTextTertiary)
+        }
+        .padding(.vertical, 6)
+    }
+
+    private var sensitivePromptContextRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(L("云端上下文共享", "Cloud Context Sharing").uppercased())
+                .font(.system(size: 10, weight: .semibold))
+                .tracking(0.8)
+                .foregroundStyle(TF.settingsTextTertiary)
+            settingsDropdown(
+                selection: Binding(
+                    get: { allowSensitivePromptContext ? "on" : "off" },
+                    set: { allowSensitivePromptContext = $0 == "on" }
+                ),
+                options: [
+                    ("off", L("关闭", "Off")),
+                    ("on", L("开启", "On")),
+                ]
+            )
+            Text(L("仅当模式 prompt 使用 {selected} 或 {clipboard} 时，允许把选中文本和剪贴板发送给云端 LLM。本地 Ollama 不受此开关限制。", "Allow selected text and clipboard content to be sent to cloud LLMs only when a mode prompt uses {selected} or {clipboard}. Local Ollama is unaffected by this switch."))
+                .font(.system(size: 10))
+                .foregroundStyle(TF.settingsTextTertiary)
+        }
+        .padding(.vertical, 6)
+    }
+
+    private var sonioxCalibrationRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(L("SONIOX 二次云端校准", "Soniox Secondary Cloud Pass").uppercased())
+                .font(.system(size: 10, weight: .semibold))
+                .tracking(0.8)
+                .foregroundStyle(TF.settingsTextTertiary)
+            settingsDropdown(
+                selection: Binding(
+                    get: { sonioxAsyncCalibration ? "on" : "off" },
+                    set: { sonioxAsyncCalibration = $0 == "on" }
+                ),
+                options: [
+                    ("off", L("关闭", "Off")),
+                    ("on", L("开启", "On")),
+                ]
+            )
+            Text(L("录音结束后把完整音频再上传一次到 Soniox 做异步校准，可提高准确率，但会额外发送整段录音并产生额外计费。", "Upload the full recording to Soniox for an async second pass after stop. This can improve accuracy, but sends the entire recording again and may incur extra billing."))
+                .font(.system(size: 10))
+                .foregroundStyle(TF.settingsTextTertiary)
         }
         .padding(.vertical, 6)
     }

--- a/Type4Me/UI/Settings/LLMSettingsCard.swift
+++ b/Type4Me/UI/Settings/LLMSettingsCard.swift
@@ -308,7 +308,7 @@ struct LLMSettingsCard: View, SettingsCardHelpers {
                 let reply = try await client.process(text: "hi", prompt: "{text}", config: llmConfig)
                 guard !Task.isCancelled else { return }
                 llmTestStatus = .success
-                NSLog("[Settings] LLM test OK (%@): %@", provider.rawValue, reply)
+                NSLog("[Settings] LLM test OK (%@): %d chars", provider.rawValue, reply.count)
             } catch {
                 guard !Task.isCancelled else { return }
                 NSLog("[Settings] LLM test failed (%@): %@", provider.rawValue, String(describing: error))

--- a/Type4MeTests/KeychainServiceTests.swift
+++ b/Type4MeTests/KeychainServiceTests.swift
@@ -4,6 +4,11 @@ import XCTest
 final class KeychainServiceTests: XCTestCase {
 
     private var originalProvider: ASRProvider!
+    private let appSupportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        .appendingPathComponent("Type4Me", isDirectory: true)
+    private var credentialsURL: URL {
+        appSupportDir.appendingPathComponent("credentials.json")
+    }
 
     override func setUp() {
         super.setUp()
@@ -12,6 +17,7 @@ final class KeychainServiceTests: XCTestCase {
 
     override func tearDown() {
         KeychainService.delete(key: "test_key")
+        try? KeychainService.saveASRCredentials(for: .volcano, values: [:])
         KeychainService.selectedASRProvider = originalProvider
         super.tearDown()
     }
@@ -60,6 +66,23 @@ final class KeychainServiceTests: XCTestCase {
         XCTAssertEqual(config?.appKey, "myAppKey")
         XCTAssertEqual(config?.accessKey, "myAccessKey")
         XCTAssertEqual(config?.resourceId, "myResource")
+    }
+
+    func testSaveASRCredentials_storesSecureFieldsOutsideCredentialsFile() throws {
+        try KeychainService.saveASRCredentials(for: .volcano, values: [
+            "appKey": "myAppKey",
+            "accessKey": "myAccessKey",
+            "resourceId": "myResource",
+        ])
+
+        let fileData = try Data(contentsOf: credentialsURL)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: fileData) as? [String: Any])
+        let stored = try XCTUnwrap(json["tf_asr_volcano"] as? [String: String])
+
+        XCTAssertEqual(stored["appKey"], "myAppKey")
+        XCTAssertEqual(stored["resourceId"], "myResource")
+        XCTAssertNil(stored["accessKey"])
+        XCTAssertEqual(KeychainService.loadASRCredentials(for: .volcano)?["accessKey"], "myAccessKey")
     }
 
     func testSelectedASRProviderPostsNotificationOnChange() {

--- a/Type4MeTests/PromptContextTests.swift
+++ b/Type4MeTests/PromptContextTests.swift
@@ -3,6 +3,11 @@ import XCTest
 
 final class PromptContextTests: XCTestCase {
 
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: PrivacyPreferences.allowSensitivePromptContextKey)
+        super.tearDown()
+    }
+
     func testExpandContextVariables_replacesSelected() {
         let ctx = PromptContext(selectedText: "hello world", clipboardText: "")
         let result = ctx.expandContextVariables("Fix: {selected}")
@@ -44,5 +49,40 @@ final class PromptContextTests: XCTestCase {
         let ctx = PromptContext(selectedText: "sel", clipboardText: "clip")
         let result = ctx.expandContextVariables("修正以下文本：{text}")
         XCTAssertEqual(result, "修正以下文本：{text}")
+    }
+
+    func testReferencesSensitiveVariables_detectsSelectedAndClipboard() {
+        XCTAssertTrue(PromptContext.referencesSensitiveVariables(in: "A={selected}"))
+        XCTAssertTrue(PromptContext.referencesSensitiveVariables(in: "B={clipboard}"))
+        XCTAssertFalse(PromptContext.referencesSensitiveVariables(in: "Only {text}"))
+    }
+
+    func testShouldCapturePromptContext_disablesCloudContextByDefault() {
+        XCTAssertFalse(
+            PrivacyPreferences.shouldCapturePromptContext(
+                for: "Use {selected}",
+                llmProvider: .openai
+            )
+        )
+    }
+
+    func testShouldCapturePromptContext_allowsCloudContextWhenEnabled() {
+        UserDefaults.standard.set(true, forKey: PrivacyPreferences.allowSensitivePromptContextKey)
+
+        XCTAssertTrue(
+            PrivacyPreferences.shouldCapturePromptContext(
+                for: "Use {clipboard}",
+                llmProvider: .claude
+            )
+        )
+    }
+
+    func testShouldCapturePromptContext_allowsLocalLLMWithoutGlobalToggle() {
+        XCTAssertTrue(
+            PrivacyPreferences.shouldCapturePromptContext(
+                for: "Use {selected}",
+                llmProvider: .ollama
+            )
+        )
     }
 }


### PR DESCRIPTION
## Summary

This PR improves Type4Me's privacy defaults and secret handling.

## What changed

- Move sensitive ASR/LLM credential fields from  into macOS Keychain
- Auto-migrate existing secure fields out of the local JSON file
- Only capture selected text / clipboard when the active prompt actually references  or 
- Default cloud LLM prompt-context sharing to off
- Add explicit settings for:
  - Cloud Context Sharing
  - Soniox secondary cloud calibration
- Remove transcript/content snippets from local debug logs
- Replace some sensitive logs with length-only logging

## Why

Previously:
- secure fields could be stored in a local file
- selected text / clipboard could be captured more broadly than needed
- debug logs could retain pieces of user content
- Soniox async second-pass upload was not exposed clearly in settings

Now:
- secrets live in Keychain
- cloud-sensitive context sharing is opt-in
- logs are safer by default
- Soniox second-pass upload is explicit and disabled by default

## Testing

Added/updated tests for:
- secure credentials not being written to 
- prompt-context sensitivity detection
- prompt-context gating rules