### PR TITLE
feat: add configurable base URL for Alibaba Cloud Bailian ASR

### DIFF
--- a/Type4Me/ASR/BailianASRClient.swift
+++ b/Type4Me/ASR/BailianASRClient.swift
@@ -62,7 +62,7 @@ actor BailianASRClient: SpeechRecognizer {
         eventContinuation = continuation
         _events = stream
 
-        var request = URLRequest(url: BailianProtocol.endpoint)
+        var request = URLRequest(url: BailianProtocol.endpoint(for: bailianConfig))
         request.setValue("Bearer \(bailianConfig.apiKey)", forHTTPHeaderField: "Authorization")
 
         let taskID = UUID().uuidString.lowercased()

--- a/Type4Me/ASR/Providers/BailianASRConfig.swift
+++ b/Type4Me/ASR/Providers/BailianASRConfig.swift
@@ -40,12 +40,21 @@ struct BailianASRConfig: ASRProviderConfig, Sendable {
             isOptional: true,
             defaultValue: ""
         ),
+        CredentialField(
+            key: "baseURL",
+            label: "Base URL",
+            placeholder: "wss://dashscope.aliyuncs.com/api-ws/v1/inference",
+            isSecure: false,
+            isOptional: true,
+            defaultValue: ""
+        ),
     ]}
 
     let apiKey: String
     let model: String
     let languageHint: String
     let vocabularyId: String
+    let baseURL: String
 
     init?(credentials: [String: String]) {
         guard let apiKey = Self.sanitized(credentials["apiKey"]),
@@ -58,6 +67,7 @@ struct BailianASRConfig: ASRProviderConfig, Sendable {
         let rawLanguageHint = Self.sanitized(credentials["languageHint"])?.lowercased() ?? ""
         self.languageHint = Self.supportedLanguageHints.contains(rawLanguageHint) ? rawLanguageHint : ""
         self.vocabularyId = Self.sanitized(credentials["vocabularyId"]) ?? ""
+        self.baseURL = Self.sanitized(credentials["baseURL"]) ?? ""
     }
 
     func toCredentials() -> [String: String] {
@@ -66,6 +76,7 @@ struct BailianASRConfig: ASRProviderConfig, Sendable {
             "model": model,
             "languageHint": languageHint,
             "vocabularyId": vocabularyId,
+            "baseURL": baseURL,
         ]
     }
 

--- a/Type4Me/Protocol/BailianProtocol.swift
+++ b/Type4Me/Protocol/BailianProtocol.swift
@@ -30,7 +30,14 @@ enum BailianServerEvent: Sendable, Equatable {
 
 enum BailianProtocol {
 
-    static let endpoint = URL(string: "wss://dashscope.aliyuncs.com/api-ws/v1/inference")!
+    static let defaultEndpoint = URL(string: "wss://dashscope.aliyuncs.com/api-ws/v1/inference")!
+
+    static func endpoint(for config: BailianASRConfig) -> URL {
+        if !config.baseURL.isEmpty, let url = URL(string: config.baseURL) {
+            return url
+        }
+        return defaultEndpoint
+    }
 
     static func buildRunTaskMessage(
         config: BailianASRConfig,


### PR DESCRIPTION
## Summary

- Adds an optional **Base URL** credential field to the Alibaba Cloud Bailian ASR provider
- Falls back to the default China endpoint (`wss://dashscope.aliyuncs.com/api-ws/v1/inference`) when left empty
- Enables use of the international endpoint (`wss://dashscope-intl.aliyuncs.com/api-ws/v1/inference`) or any custom endpoint

## Motivation

Users outside mainland China need to use the DashScope international endpoint, which uses a different WebSocket URL. This follows the same pattern already used by LLM providers in this project.

## Changes

- `BailianASRConfig.swift` — added optional `baseURL` credential field and property
- `BailianProtocol.swift` — replaced hardcoded `endpoint` constant with `endpoint(for:)` that reads from config
- `BailianASRClient.swift` — passes config to `endpoint(for:)` when connecting

## Test plan

- [ ] Leave Base URL empty → connects to default China endpoint as before
- [ ] Set Base URL to `wss://dashscope-intl.aliyuncs.com/api-ws/v1/inference` → connects to international endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)