### PR TITLE
[codex] fix locale-dependent app state test

### DIFF
--- a/Type4MeTests/AppStateTests.swift
+++ b/Type4MeTests/AppStateTests.swift
@@ -98,7 +98,7 @@ final class AppStateTests: XCTestCase {
         appState.finalize(text: "测试文本", outcome: .copiedToClipboard)
 
         XCTAssertEqual(appState.barPhase, .done)
-        XCTAssertEqual(appState.feedbackMessage, "已粘贴到剪贴板")
+        XCTAssertEqual(appState.feedbackMessage, InjectionOutcome.copiedToClipboard.completionMessage)
         XCTAssertEqual(appState.transcriptionText, "测试文本")
     }
 


### PR DESCRIPTION
## Summary
- make `AppStateTests.testFinalizeShowsClipboardFallbackMessage` assert against `InjectionOutcome.copiedToClipboard.completionMessage`
- remove the test's implicit dependency on the current machine locale

## Why
The previous assertion hardcoded a Chinese string, while production code returns a localized completion message. On non-Chinese locales this caused `swift test` to fail even though the behavior was correct.

## Impact
- keeps the behavior check focused on the outcome contract
- makes the test suite stable across different system languages

## Validation
- `swift test --filter AppStateTests/testFinalizeShowsClipboardFallbackMessage`
- `swift test`
