### PR TITLE
feat(elevenlabs): align with latest realtime API (no_verbatim + keyterm limits)

### DIFF
--- a/Type4Me/Protocol/ElevenLabsProtocol.swift
+++ b/Type4Me/Protocol/ElevenLabsProtocol.swift
@@ -42,6 +42,7 @@ enum ElevenLabsProtocol {
         var queryItems = [
             URLQueryItem(name: "model_id", value: "scribe_v2_realtime"),
             URLQueryItem(name: "audio_format", value: "pcm_16000"),
+            URLQueryItem(name: "no_verbatim", value: "true"),
         ]
         if !config.language.isEmpty {
             queryItems.append(URLQueryItem(name: "language_code", value: config.language))

--- a/Type4Me/Protocol/ElevenLabsProtocol.swift
+++ b/Type4Me/Protocol/ElevenLabsProtocol.swift
@@ -47,11 +47,11 @@ enum ElevenLabsProtocol {
         if !config.language.isEmpty {
             queryItems.append(URLQueryItem(name: "language_code", value: config.language))
         }
-        // Keyterm prompting: ElevenLabs supports up to 1000 keyterms
+        // Keyterm prompting: ElevenLabs supports up to 50 keyterms, each ≤20 characters
         let keyterms = options.hotwords
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .prefix(1000)
+            .filter { !$0.isEmpty && $0.count <= 20 }
+            .prefix(50)
         for term in keyterms {
             queryItems.append(URLQueryItem(name: "keyterm", value: term))
         }


### PR DESCRIPTION
## 变更说明

两项更新，使 ElevenLabs 实时语音转文字与最新 API 规范保持一致：

### 1. 启用 `no_verbatim=true`
为 WebSocket 握手 URL 添加 `no_verbatim=true` 查询参数。启用后，API 返回格式化的转录结果（去除冗余填充词），而不是原始逐字输出。

参考：https://elevenlabs.io/docs/api-reference/speech-to-text/v-1-speech-to-text-realtime#request.query.no_verbatim

### 2. 修正热词（keyterms）数量与长度限制
- 最新 API 限制：最多 50 个 keyterms，每个不超过 20 个字符
- 原代码使用 `.prefix(1000)`，且无单词字符数限制
- 修正后：超过 20 字符的热词直接跳过（不截断，避免发送残缺词汇）

## 修改文件

- `Type4Me/Protocol/ElevenLabsProtocol.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)