### PR TITLE
新增「Mac 操作」内置模式：用语音直接触发 macOS 操作

### DIFF
--- a/Type4Me/ASR/SpeechRecognizer.swift
+++ b/Type4Me/ASR/SpeechRecognizer.swift
@@ -100,6 +100,9 @@ enum RecognitionEvent: Sendable {
     case processingResult(text: String)
     case processingLabelOverride(String)
     case finalized(text: String, injection: InjectionOutcome)
+    /// Mac Action mode: action result to surface in the floating bar with
+    /// status-specific icon and color, holding for ~3 seconds.
+    case macActionResult(message: String, status: MacActionResultStatus)
 }
 
 struct LLMConfig: Sendable {

--- a/Type4Me/Actions/ActionRegistry.swift
+++ b/Type4Me/Actions/ActionRegistry.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Central registry of macOS actions exposed to the LLM in Mac Action mode.
+enum ActionRegistry {
+
+    /// All actions available to the LLM. Add new actions here.
+    static let allActions: [any MacAction] = [
+        OpenAppAction(),
+        SetVolumeAction(),
+        SetBrightnessAction(),
+        ToggleDarkModeAction(),
+        ScreenshotAction(),
+        ClipboardWriteAction(),
+        LockScreenAction(),
+        SearchWebAction(),
+        GetBatteryAction(),
+    ]
+
+    /// Renders the JSON tool list block injected into the LLM system prompt.
+    static func toolsJSON() -> String {
+        let items: [[String: Any]] = allActions.map { action in
+            [
+                "name": action.name,
+                "description": action.description,
+                "parameters": action.parametersSchema,
+            ]
+        }
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: items,
+            options: [.prettyPrinted, .withoutEscapingSlashes]
+        ), let str = String(data: data, encoding: .utf8) else {
+            return "[]"
+        }
+        return str
+    }
+
+    /// Look up an action by name and execute it. Returns nil if no action with
+    /// the given name is registered.
+    static func dispatch(name: String, args: [String: Any]) async -> MacActionResult? {
+        guard let action = allActions.first(where: { $0.name == name }) else {
+            return nil
+        }
+        return await action.execute(args: args)
+    }
+}

--- a/Type4Me/Actions/ActionRegistry.swift
+++ b/Type4Me/Actions/ActionRegistry.swift
@@ -14,6 +14,12 @@ enum ActionRegistry {
         LockScreenAction(),
         SearchWebAction(),
         GetBatteryAction(),
+        MinimizeWindowAction(),
+        FullscreenWindowAction(),
+        CloseWindowAction(),
+        CreateReminderAction(),
+        ScrollDownAction(),
+        ScrollUpAction(),
     ]
 
     /// Renders the JSON tool list block injected into the LLM system prompt.

--- a/Type4Me/Actions/AppleScriptRunner.swift
+++ b/Type4Me/Actions/AppleScriptRunner.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+enum AppleScriptError: Error, LocalizedError {
+    case nonZeroExit(code: Int32, stderr: String)
+    case timeout
+    case launchFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .nonZeroExit(let code, let stderr):
+            return "Process exited \(code): \(stderr)"
+        case .timeout:
+            return "Action timed out"
+        case .launchFailed(let msg):
+            return "Failed to launch process: \(msg)"
+        }
+    }
+}
+
+/// Subprocess helper for running AppleScript and shell commands invoked by Mac actions.
+///
+/// IMPORTANT: shell commands here are only constructed by curated, in-app action
+/// implementations. The LLM never supplies a raw shell string — it can only
+/// pick a registered action and supply structured JSON args.
+enum AppleScriptRunner {
+
+    /// Run an AppleScript snippet via `osascript -e <script>` and return stdout.
+    static func runScript(_ script: String, timeoutSeconds: TimeInterval = 10) async throws -> String {
+        try await runProcess(
+            executableURL: URL(fileURLWithPath: "/usr/bin/osascript"),
+            arguments: ["-e", script],
+            timeoutSeconds: timeoutSeconds
+        )
+    }
+
+    /// Run a shell command via `/bin/sh -c <command>` and return stdout.
+    static func runShell(_ command: String, timeoutSeconds: TimeInterval = 10) async throws -> String {
+        try await runProcess(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", command],
+            timeoutSeconds: timeoutSeconds
+        )
+    }
+
+    private static func runProcess(
+        executableURL: URL,
+        arguments: [String],
+        timeoutSeconds: TimeInterval
+    ) async throws -> String {
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            throw AppleScriptError.launchFailed(error.localizedDescription)
+        }
+
+        let timeoutTask = Task {
+            try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            process.terminationHandler = { proc in
+                timeoutTask.cancel()
+                let stdoutData = (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data()
+                let stderrData = (try? stderrPipe.fileHandleForReading.readToEnd()) ?? Data()
+                let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
+                let stderr = String(data: stderrData, encoding: .utf8) ?? ""
+                if proc.terminationStatus == 0 {
+                    continuation.resume(returning: stdout.trimmingCharacters(in: .whitespacesAndNewlines))
+                } else {
+                    let trimmedErr = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                    continuation.resume(
+                        throwing: AppleScriptError.nonZeroExit(
+                            code: proc.terminationStatus,
+                            stderr: trimmedErr.isEmpty ? stdout : trimmedErr
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    /// Escapes a string for safe inclusion inside an AppleScript double-quoted literal.
+    static func escapeForAppleScript(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}

--- a/Type4Me/Actions/Implementations/ClipboardWriteAction.swift
+++ b/Type4Me/Actions/Implementations/ClipboardWriteAction.swift
@@ -1,0 +1,23 @@
+import AppKit
+import Foundation
+
+struct ClipboardWriteAction: MacAction {
+    let name = "clipboard_write"
+    let description = "Write text to the macOS clipboard so the user can paste it elsewhere."
+    let parametersSchema: [String: String] = [
+        "text": "The text to put on the clipboard"
+    ]
+
+    func execute(args: [String: Any]) async -> MacActionResult {
+        guard let text = args["text"] as? String, !text.isEmpty else {
+            return .failure(L("缺少文本内容", "Missing text"))
+        }
+        await MainActor.run {
+            let pb = NSPasteboard.general
+            pb.clearContents()
+            pb.setString(text, forType: .string)
+        }
+        let preview = text.count > 30 ? String(text.prefix(30)) + "…" : text
+        return .ok(L("已复制：\(preview)", "Copied: \(preview)"))
+    }
+}

--- a/Type4Me/Actions/Implementations/CloseWindowAction.swift
+++ b/Type4Me/Actions/Implementations/CloseWindowAction.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct CloseWindowAction: MacAction {
+    let name = "close_window"
+    let description = "Close the frontmost window of the active app (Cmd+W)."
+    let parametersSchema: [String: String] = [:]
+
+    func execute(args: [String: Any]) async -> MacActionResult {
+        let script = "tell application \"System Events\" to keystroke \"w\" using command down"
+        do {
+            _ = try await AppleScriptRunner.runScript(script)
+            return .ok(L("窗口已关闭", "Window closed"))
+        } catch {
+            return .failure(error.localizedDescription)
+        }
+    }
+}

--- a/Type4Me/Actions/Implementations/CreateReminderAction.swift
+++ b/Type4Me/Actions/Implementations/CreateReminderAction.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+struct CreateReminderAction: MacAction {
+    let name = "create_reminder"
+    let description = "Create a reminder in Apple Reminders. Optionally specify a due date/time and list name."
+    let parametersSchema: [String: String] = [
+        "title": "The reminder text (required)",
+        "due":   "Optional due date/time, e.g. \"in 2 minutes\", \"in 1 hour\", \"tomorrow 9am\", \"2025-06-01 09:00\"",
+        "list":  "Optional Reminders list name; defaults to the default Reminders list",
+    ]
+
+    func execute(args: [String: Any]) async -> MacActionResult {
+        guard let title = args["title"] as? String, !title.isEmpty else {
+            return .failure(L("缺少提醒内容", "Missing reminder title"))
+        }
+        let due  = (args["due"]  as? String) ?? ""
+        let list = (args["list"] as? String) ?? ""
+
+        let safeTitle = title.replacingOccurrences(of: "\"", with: "\\\"")
+        let safeList  = (list.isEmpty ? "Reminders" : list)
+            .replacingOccurrences(of: "\"", with: "\\\"")
+
+        var props = "name:\"\(safeTitle)\""
+        if !due.isEmpty {
+            props += ", due date:\(appleScriptDateExpression(from: due))"
+        }
+
+        let script = """
+        tell application "Reminders"
+            tell list "\(safeList)"
+                make new reminder with properties {\(props)}
+            end tell
+        end tell
+        """
+
+        do {
+            _ = try await AppleScriptRunner.runScript(script, timeoutSeconds: 20)
+            let preview = title.count > 30 ? String(title.prefix(30)) + "…" : title
+            return .ok(L("提醒已创建：\(preview)", "Reminder created: \(preview)"))
+        } catch {
+            return .failure(error.localizedDescription)
+        }
+    }
+
+    /// Converts a natural-language due string to an AppleScript date expression.
+    ///
+    /// - "in N minutes/hours/days/weeks" → `(current date) + <seconds>`
+    ///   This form is locale-safe because it avoids date string parsing entirely.
+    /// - Absolute phrasing ("tomorrow 9am", ISO dates) → NSDataDetector → formatted literal.
+    /// - Fallback: pass through as a raw date literal (best-effort).
+    private func appleScriptDateExpression(from due: String) -> String {
+        let lower = due.lowercased()
+
+        let relativeUnits: [(pattern: String, seconds: Int)] = [
+            (#"in (\d+) ?second"#, 1),
+            (#"in (\d+) ?minute"#, 60),
+            (#"in (\d+) ?hour"#, 3_600),
+            (#"in (\d+) ?day"#, 86_400),
+            (#"in (\d+) ?week"#, 604_800),
+        ]
+        for (pattern, perUnit) in relativeUnits {
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+                  let match = regex.firstMatch(in: lower, range: NSRange(lower.startIndex..., in: lower)),
+                  let numRange = Range(match.range(at: 1), in: lower),
+                  let n = Int(lower[numRange])
+            else { continue }
+            return "(current date) + \(n * perUnit)"
+        }
+
+        // Absolute natural-language date → NSDataDetector
+        if let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.date.rawValue),
+           let match = detector.firstMatch(in: due, range: NSRange(due.startIndex..., in: due)),
+           let date = match.date {
+            let fmt = DateFormatter()
+            fmt.locale = Locale(identifier: "en_US_POSIX")
+            fmt.dateFormat = "MM/dd/yyyy HH:mm:ss"
+            return "date \"\(fmt.string(from: date))\""
+        }
+
+        // Last resort: pass through (works if user typed an AppleScript-compatible string)
+        let safe = due.replacingOccurrences(of: "\"", with: "\\\"")
+        return "date \"\(safe)\""
+    }
+}

--- a/Type4Me/Actions/Implementations/FullscreenWindowAction.swift
+++ b/Type4Me/Actions/Implementations/FullscreenWindowAction.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct FullscreenWindowAction: MacAction {
+    let name = "fullscreen_window"
+    let description = "Toggle fullscreen for the frontmost window (Ctrl+Cmd+F)."
+    let parametersSchema: [String: String] = [:]
+
+    func execute(args: [String: Any]) async -> MacActionResult {
+        let script = """
+        tell application "System Events"
+            keystroke "f" using {command down, control down}
+        end tell
+        """
+        do {
+            _ = try await AppleScriptRunner.runScript(script)
+            return .ok(L("已切换全屏", "Toggled fullscreen"))
+        } catch {
+            return .failure(error.localizedDescription)
+        }
+    }
+}

--- a/Type4Me/Actions/Implementations/GetBatteryAction.swift
+++ b/Type4Me/Actions/Implementations/GetBatteryAction.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct GetBatteryAction: MacAction {
+    let name = "get_battery"
+    let description = "Get the current battery percentage and charging status."
+    let parametersSchema: [String: String] = [:]
+
+    func execute(args: [String: Any]) async -> MacActionResult {
+        do {
+            let output = try await AppleScriptRunner.runShell("/usr/bin/pmset -g batt")
+            // Sample output:
+            // "Now drawing from 'Battery Power'\n -InternalBattery-0 (id=...)  87%; discharging; ..."
+            if let percentRange = output.range(of: #"\d+%"#, options: .regularExpression) {
+                let percent = output[percentRange]
+                let charging = output.lowercased().contains("charging")
+                let status = charging
+                    ? L("（充电中）", " (charging)")
+                    : ""
+                return .ok(L("电量：\(percent)\(status)", "Battery: \(percent)\(status)"))
+            }
+            return .ok(output)
+        } catch {
+            return .failure(error.localizedDescription)
+        }
+    }
+}

--- a/Type4Me/Actions/Implementations/LockScreenAction.swift
+++ b/Type4Me/Actions/Implementations/LockScreenAction.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct LockScreenAction: MacAction {
+    let name = "lock_screen"
+    let description = "Lock the Mac screen immediately."
+    let parametersSchema: [String: String] = [:]
+
+    func execute(args: [String: Any]) async -> MacActionResult {
+        // /usr/bin/pmset displaysleepnow turns the display off, which on most
+        // Macs with "Require password immediately" effectively locks the screen.
+        // For an explicit lock, we use the System Events Cmd+Ctrl+Q shortcut.
+        let script = """
+        tell application "System Events" to key code 12 using {control down, command down}
+        """
+        do {
+            _ = try await AppleScriptRunner.runScript(script)
+            return .ok(L("屏幕已锁定", "Screen locked"))
+        } catch {
+            return .failure(error.localizedDescription)
+        }
+    }
+}

--- a/Type4Me/Actions/Implementations/MinimizeWindowAction.swift
+++ b/Type4Me/Actions/Implementations/MinimizeWindowAction.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct MinimizeWindowAction: MacAction {
+    let name = "minimize_window"
+    let description = "Minimize the frontmost window of the active app."
+    let parametersSchema: [String: String] = [:]
+
+    func execute(args: [String: Any]) async -> MacActionResult {
+        let script = "tell application \"System Events\" to keystroke \"m\" using command down"
+        do {
+            _ = try await AppleScriptRunner.runScript(script)
+            return .ok(L("窗口已最小化", "Window minimized"))
+        } catch {
+            return .failure(error.localizedDescription)
+        }
+    }
+}

--- a/Type4Me/Actions/Implementations/OpenAppAction.swift
+++ b/Type4Me/Actions/Implementations/OpenAppAction.swift
@@ -1,0 +1,37 @@
+import AppKit
+import Foundation
+
+struct OpenAppAction: MacAction {
+    let name = "open_app"
+    let description = "Open a macOS application by name (e.g. Safari, Notes, Terminal)."
+    let parametersSchema: [String: String] = [
+        "app": "Application name (without .app), e.g. \"Safari\" or \"Visual Studio Code\""
+    ]
+
+    func execute(args: [String: Any]) async -> MacActionResult {
+        guard let appName = (args["app"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !appName.isEmpty
+        else {
+            return .failure(L("缺少应用名称", "Missing app name"))
+        }
+
+        // NSWorkspace.fullPath(forApplication:) handles many casings + locales.
+        let workspace = NSWorkspace.shared
+        let candidate = workspace.fullPath(forApplication: appName)
+            ?? workspace.fullPath(forApplication: appName.capitalized)
+        guard let path = candidate else {
+            return .failure(L("找不到应用：\(appName)", "App not found: \(appName)"))
+        }
+
+        let url = URL(fileURLWithPath: path)
+        return await withCheckedContinuation { continuation in
+            workspace.openApplication(at: url, configuration: NSWorkspace.OpenConfiguration()) { _, error in
+                if let error {
+                    continuation.resume(returning: .failure(error.localizedDescription))
+                } else {
+                    continuation.resume(returning: .ok(L("已打开 \(appName)", "Opened \(appName)")))
+                }
+            }
+        }
+    }
+}

--- a/Type4Me/Actions/Implementations/ScreenshotAction.swift
+++ b/Type4Me/Actions/Implementations/ScreenshotAction.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct ScreenshotAction: MacAction {
+    let name = "screenshot"
+    let description = "Take a screenshot. Default is interactive selection saved to Desktop."
+    let parametersSchema: [String: String] = [
+        "mode": "Optional: \"selection\" (default, lets user drag), \"window\", or \"fullscreen\""
+    ]
+
+    func execute(args: [String: Any]) async -> MacActionResult {
+        let mode = (args["mode"] as? String)?.lowercased() ?? "selection"
+        let flag: String
+        switch mode {
+        case "window": flag = "-w"
+        case "fullscreen", "full": flag = ""
+        default: flag = "-i"          // interactive (drag-to-select)
+        }
+
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+        let path = "$HOME/Desktop/Screenshot-\(timestamp).png"
+        let command = flag.isEmpty
+            ? "/usr/sbin/screencapture \(path)"
+            : "/usr/sbin/screencapture \(flag) \(path)"
+
+        do {
+            // Interactive screenshots can wait indefinitely for user selection.
+            _ = try await AppleScriptRunner.runShell(command, timeoutSeconds: 60)
+            return .ok(L("截图已保存到桌面", "Screenshot saved to Desktop"))
+        } catch {
+            return .failure(error.localizedDescription)
+        }
+    }
+}

--- a/Type4Me/Actions/Implementations/ScrollAction.swift
+++ b/Type4Me/Actions/Implementations/ScrollAction.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct ScrollDownAction: MacAction {
+    let name = "scroll_down"
+    let description = "Scroll down in the frontmost window (Page Down). Works in browsers, documents, terminals."
+    let parametersSchema: [String: String] = [:]
+
+    func execute(args: [String: Any]) async -> MacActionResult {
+        // key code 121 = Page Down
+        let script = "tell application \"System Events\" to key code 121"
+        do {
+            _ = try await AppleScriptRunner.runScript(script)
+            return .ok(L("已向下滚动", "Scrolled down"))
+        } catch {
+            return .failure(error.localizedDescription)
+        }
+    }
+}
+
+struct ScrollUpAction: MacAction {
+    let name = "scroll_up"
+    let description = "Scroll up in the frontmost window (Page Up). Works in browsers, documents, terminals."
+    let parametersSchema: [String: String] = [:]
+
+    func execute(args: [String: Any]) async -> MacActionResult {
+        // key code 116 = Page Up
+        let script = "tell application \"System Events\" to key code 116"
+        do {
+            _ = try await AppleScriptRunner.runScript(script)
+            return .ok(L("已向上滚动", "Scrolled up"))
+        } catch {
+            return .failure(error.localizedDescription)
+        }
+    }
+}

--- a/Type4Me/Actions/Implementations/SearchWebAction.swift
+++ b/Type4Me/Actions/Implementations/SearchWebAction.swift
@@ -1,0 +1,28 @@
+import AppKit
+import Foundation
+
+struct SearchWebAction: MacAction {
+    let name = "search_web"
+    let description = "Open the default browser with a Google search for the given query."
+    let parametersSchema: [String: String] = [
+        "query": "The search query"
+    ]
+
+    func execute(args: [String: Any]) async -> MacActionResult {
+        guard let query = (args["query"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !query.isEmpty
+        else {
+            return .failure(L("缺少搜索内容", "Missing search query"))
+        }
+        let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
+        guard let url = URL(string: "https://www.google.com/search?q=\(encoded)") else {
+            return .failure(L("无效的查询", "Invalid query"))
+        }
+        let opened = await MainActor.run { NSWorkspace.shared.open(url) }
+        if opened {
+            return .ok(L("正在搜索：\(query)", "Searching: \(query)"))
+        } else {
+            return .failure(L("无法打开浏览器", "Failed to open browser"))
+        }
+    }
+}

--- a/Type4Me/Actions/Implementations/SetBrightnessAction.swift
+++ b/Type4Me/Actions/Implementations/SetBrightnessAction.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+struct SetBrightnessAction: MacAction {
+    let name = "set_brightness"
+    let description = "Set the display brightness to a specific level (0-100)."
+    let parametersSchema: [String: String] = [
+        "level": "Brightness level as an integer between 0 and 100"
+    ]
+
+    func execute(args: [String: Any]) async -> MacActionResult {
+        let raw = args["level"]
+        let level: Int
+        if let n = raw as? Int { level = n }
+        else if let d = raw as? Double { level = Int(d) }
+        else if let s = raw as? String, let n = Int(s) { level = n }
+        else {
+            return .failure(L("缺少亮度值", "Missing brightness level"))
+        }
+
+        let clamped = max(0, min(100, level))
+        // Try the Homebrew `brightness` CLI first; fall back to AppleScript via System Events.
+        if FileManager.default.isExecutableFile(atPath: "/opt/homebrew/bin/brightness") {
+            do {
+                let normalized = String(format: "%.2f", Double(clamped) / 100.0)
+                _ = try await AppleScriptRunner.runShell("/opt/homebrew/bin/brightness \(normalized)")
+                return .ok(L("亮度已设为 \(clamped)", "Brightness set to \(clamped)"))
+            } catch {
+                // Fall through to AppleScript fallback.
+            }
+        }
+
+        // AppleScript fallback: simulate brightness keys via System Events. Not
+        // an exact percentage but works on most Macs without extra tooling.
+        let upScript = """
+        tell application "System Events"
+            repeat \(clamped / 10) times
+                key code 144
+            end repeat
+        end tell
+        """
+        let downScript = """
+        tell application "System Events"
+            repeat \((100 - clamped) / 10) times
+                key code 145
+            end repeat
+        end tell
+        """
+        let script = clamped >= 50 ? upScript : downScript
+        do {
+            _ = try await AppleScriptRunner.runScript(script)
+            return .ok(L("亮度已调整", "Brightness adjusted"))
+        } catch {
+            return .failure(error.localizedDescription)
+        }
+    }
+}

--- a/Type4Me/Actions/Implementations/SetVolumeAction.swift
+++ b/Type4Me/Actions/Implementations/SetVolumeAction.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct SetVolumeAction: MacAction {
+    let name = "set_volume"
+    let description = "Set the system output volume to a specific level (0-100)."
+    let parametersSchema: [String: String] = [
+        "level": "Volume level as an integer between 0 and 100"
+    ]
+
+    func execute(args: [String: Any]) async -> MacActionResult {
+        let raw = args["level"]
+        let level: Int
+        if let n = raw as? Int { level = n }
+        else if let d = raw as? Double { level = Int(d) }
+        else if let s = raw as? String, let n = Int(s) { level = n }
+        else {
+            return .failure(L("缺少音量值", "Missing volume level"))
+        }
+
+        let clamped = max(0, min(100, level))
+        do {
+            _ = try await AppleScriptRunner.runScript("set volume output volume \(clamped)")
+            return .ok(L("音量已设为 \(clamped)", "Volume set to \(clamped)"))
+        } catch {
+            return .failure(error.localizedDescription)
+        }
+    }
+}

--- a/Type4Me/Actions/Implementations/ToggleDarkModeAction.swift
+++ b/Type4Me/Actions/Implementations/ToggleDarkModeAction.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct ToggleDarkModeAction: MacAction {
+    let name = "toggle_dark_mode"
+    let description = "Toggle macOS appearance between light mode and dark mode."
+    let parametersSchema: [String: String] = [:]
+
+    func execute(args: [String: Any]) async -> MacActionResult {
+        let script = """
+        tell application "System Events"
+            tell appearance preferences
+                set dark mode to not dark mode
+                return dark mode
+            end tell
+        end tell
+        """
+        do {
+            let output = try await AppleScriptRunner.runScript(script)
+            let isDark = output.lowercased() == "true"
+            return .ok(
+                isDark
+                    ? L("已切换到深色模式", "Switched to dark mode")
+                    : L("已切换到浅色模式", "Switched to light mode")
+            )
+        } catch {
+            return .failure(error.localizedDescription)
+        }
+    }
+}

--- a/Type4Me/Actions/MacAction.swift
+++ b/Type4Me/Actions/MacAction.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Result returned by a MacAction execution.
+struct MacActionResult: Sendable {
+    let success: Bool
+    let displayMessage: String       // Shown in the floating bar feedback
+    let errorMessage: String?
+
+    static func ok(_ message: String) -> MacActionResult {
+        MacActionResult(success: true, displayMessage: message, errorMessage: nil)
+    }
+
+    static func failure(_ message: String) -> MacActionResult {
+        MacActionResult(success: false, displayMessage: "", errorMessage: message)
+    }
+}
+
+/// Outcome of a Mac Action attempt, used to drive the floating-bar icon/colour.
+/// - success: tool_call dispatched and the action returned `success`.
+/// - failure: tool_call dispatched but the action failed, or the named action
+///   isn't registered. Renders as a red ✗.
+/// - unsure: the LLM didn't return a tool_call (e.g. NO_MATCH or freeform reply),
+///   meaning we don't know what the user wanted. Renders as a yellow ?.
+enum MacActionResultStatus: Sendable, Equatable {
+    case success
+    case failure
+    case unsure
+}
+
+/// A macOS action exposed to the LLM as a tool. The LLM picks one based on the
+/// user's voice intent and supplies arguments; the registry dispatches it.
+protocol MacAction: Sendable {
+    /// Stable identifier used in `<tool_call>{"name": ...}</tool_call>`.
+    var name: String { get }
+
+    /// Short description shown to the LLM in the system prompt.
+    var description: String { get }
+
+    /// Map of parameter name → human description, e.g. `["app": "application name"]`.
+    var parametersSchema: [String: String] { get }
+
+    /// Execute the action with arguments supplied by the LLM.
+    func execute(args: [String: Any]) async -> MacActionResult
+}

--- a/Type4Me/Actions/ToolCallParser.swift
+++ b/Type4Me/Actions/ToolCallParser.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+struct ParsedToolCall: Equatable {
+    let name: String
+    let arguments: [String: Any]
+
+    static func == (lhs: ParsedToolCall, rhs: ParsedToolCall) -> Bool {
+        guard lhs.name == rhs.name else { return false }
+        let lhsData = try? JSONSerialization.data(withJSONObject: lhs.arguments)
+        let rhsData = try? JSONSerialization.data(withJSONObject: rhs.arguments)
+        return lhsData == rhsData
+    }
+}
+
+/// Extracts a `<tool_call>{...}</tool_call>` block from raw LLM output and decodes the JSON.
+///
+/// Handles a few common variants:
+/// - Standard: `<tool_call>{"name": "x", "arguments": {...}}</tool_call>`
+/// - Wrapped in a fenced code block (```json ... ```)
+/// - Bare JSON when the model omits the XML tags
+enum ToolCallParser {
+
+    static func parse(_ rawLLMOutput: String) -> ParsedToolCall? {
+        let cleaned = rawLLMOutput.strippingThinkTags()
+
+        // Standard form: <tool_call>{...}</tool_call>
+        if let between = extractBetween(cleaned, start: "<tool_call>", end: "</tool_call>"),
+           let parsed = parseJSON(between) {
+            return parsed
+        }
+
+        // Tolerant form: <tool_call>{...}  (LLM omits the closing tag)
+        if let openRange = cleaned.range(of: "<tool_call>") {
+            let after = String(cleaned[openRange.upperBound...])
+            if let parsed = parseJSONPrefix(after) {
+                return parsed
+            }
+        }
+
+        if let fenced = extractCodeFenceJSON(cleaned),
+           let parsed = parseJSON(fenced) {
+            return parsed
+        }
+
+        // Bare JSON fallback: trim and try the whole reply.
+        let trimmed = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("{"), let parsed = parseJSONPrefix(trimmed) {
+            return parsed
+        }
+
+        return nil
+    }
+
+    // MARK: - Helpers
+
+    private static func extractBetween(_ text: String, start: String, end: String) -> String? {
+        guard let startRange = text.range(of: start),
+              let endRange = text.range(of: end, range: startRange.upperBound..<text.endIndex)
+        else { return nil }
+        return String(text[startRange.upperBound..<endRange.lowerBound])
+    }
+
+    private static func extractCodeFenceJSON(_ text: String) -> String? {
+        // Match ```json ... ``` or ``` ... ``` blocks
+        let pattern = #"```(?:json)?\s*([\s\S]*?)```"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+              let range = Range(match.range(at: 1), in: text)
+        else { return nil }
+        return String(text[range])
+    }
+
+    private static func parseJSON(_ jsonText: String) -> ParsedToolCall? {
+        let trimmed = jsonText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let data = trimmed.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let name = object["name"] as? String, !name.isEmpty
+        else { return nil }
+        let args = (object["arguments"] as? [String: Any]) ?? [:]
+        return ParsedToolCall(name: name, arguments: args)
+    }
+
+    /// Parse a JSON object from the start of the string, ignoring trailing junk.
+    /// Walks the input character-by-character tracking brace depth and string-literal
+    /// boundaries (with escape handling), then hands the matched substring to JSONSerialization.
+    /// Used when the LLM omits the closing `</tool_call>` tag.
+    private static func parseJSONPrefix(_ text: String) -> ParsedToolCall? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.first == "{" else { return nil }
+
+        var depth = 0
+        var inString = false
+        var escape = false
+        var endIndex: String.Index? = nil
+
+        for idx in trimmed.indices {
+            let ch = trimmed[idx]
+            if escape {
+                escape = false
+                continue
+            }
+            if inString {
+                if ch == "\\" {
+                    escape = true
+                } else if ch == "\"" {
+                    inString = false
+                }
+                continue
+            }
+            if ch == "\"" {
+                inString = true
+            } else if ch == "{" {
+                depth += 1
+            } else if ch == "}" {
+                depth -= 1
+                if depth == 0 {
+                    endIndex = trimmed.index(after: idx)
+                    break
+                }
+            }
+        }
+
+        guard let end = endIndex else { return nil }
+        return parseJSON(String(trimmed[trimmed.startIndex..<end]))
+    }
+}

--- a/Type4Me/LLM/PromptContext.swift
+++ b/Type4Me/LLM/PromptContext.swift
@@ -20,9 +20,9 @@ struct PromptContext: Sendable {
         return PromptContext(selectedText: selected, clipboardText: clipboard)
     }
 
-    /// Expand context variables (`{selected}`, `{clipboard}`) in a prompt string.
-    /// Uses single-pass replacement to prevent user content containing `{clipboard}`
-    /// or `{text}` from being expanded as variables.
+    /// Expand context variables (`{selected}`, `{clipboard}`, `{tools_json}`) in
+    /// a prompt string. Uses single-pass replacement to prevent user content
+    /// containing `{clipboard}` or `{text}` from being expanded as variables.
     func expandContextVariables(_ prompt: String) -> String {
         var result = ""
         var remaining = prompt[...]
@@ -37,6 +37,9 @@ struct PromptContext: Sendable {
             } else if remaining.hasPrefix("{clipboard}") {
                 result += clipboardText
                 remaining = remaining[remaining.index(remaining.startIndex, offsetBy: 11)...]
+            } else if remaining.hasPrefix("{tools_json}") {
+                result += ActionRegistry.toolsJSON()
+                remaining = remaining[remaining.index(remaining.startIndex, offsetBy: 12)...]
             } else {
                 result += "{"
                 remaining = remaining[remaining.index(after: remaining.startIndex)...]

--- a/Type4Me/Services/ModeStorage.swift
+++ b/Type4Me/Services/ModeStorage.swift
@@ -100,9 +100,17 @@ struct ModeStorage {
         }
 
         // Ensure required built-in modes always exist.
+        // direct + formalWriting (the original two) are inserted at their canonical positions
+        // for existing users who already have them; any newly-added builtin is appended at the
+        // end so it doesn't shove itself between the user's customized modes.
         let resultIds = Set(result.map { $0.id })
+        let originalBuiltinIds: Set<UUID> = [
+            ProcessingMode.directId,
+            ProcessingMode.formalWritingId,
+        ]
         for builtin in ProcessingMode.builtins where !resultIds.contains(builtin.id) {
-            if let idx = ProcessingMode.builtins.firstIndex(where: { $0.id == builtin.id }) {
+            if originalBuiltinIds.contains(builtin.id),
+               let idx = ProcessingMode.builtins.firstIndex(where: { $0.id == builtin.id }) {
                 let insertAt = min(idx, result.count)
                 result.insert(builtin, at: insertAt)
             } else {

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -527,6 +527,76 @@ actor RecognitionSession {
         DebugFileLogger.log("abortInjection: injection will be skipped")
     }
 
+    /// Parse a Mac Action LLM reply for a `<tool_call>{...}</tool_call>`, dispatch
+    /// the action via `ActionRegistry`, and return both the user-facing message
+    /// and a status. The floating bar uses the status to pick an icon/color
+    /// (✓ green / ✗ red / ? amber).
+    private func dispatchMacAction(llmReply: String) async -> (message: String, status: MacActionResultStatus) {
+        guard let toolCall = ToolCallParser.parse(llmReply) else {
+            DebugFileLogger.log("macAction: no tool_call in LLM reply: \(llmReply.prefix(120))")
+            return (L("未匹配到操作", "No matching action"), .unsure)
+        }
+        DebugFileLogger.log("macAction: dispatching \(toolCall.name) args=\(toolCall.arguments)")
+        guard let result = await ActionRegistry.dispatch(name: toolCall.name, args: toolCall.arguments) else {
+            DebugFileLogger.log("macAction: unknown action name \(toolCall.name)")
+            return (L("未知操作：\(toolCall.name)", "Unknown action: \(toolCall.name)"), .failure)
+        }
+        if result.success {
+            DebugFileLogger.log("macAction: success \(toolCall.name): \(result.displayMessage)")
+            return (result.displayMessage, .success)
+        } else {
+            DebugFileLogger.log("macAction: failed \(toolCall.name): \(result.errorMessage ?? "")")
+            return (result.errorMessage ?? L("操作失败", "Action failed"), .failure)
+        }
+    }
+
+    /// Persist history, emit floating-bar event + `.completed`, and reset
+    /// session state — the post-LLM finishing path used when Mac Action mode
+    /// dispatched (or attempted to dispatch) an action. This deliberately skips
+    /// the text-injection block that the normal post-LLM path runs.
+    private func completeMacAction(
+        message: String,
+        status: MacActionResultStatus,
+        rawText: String,
+        recordingStartTime: Date?,
+        activeProvider: ASRProvider,
+        myGeneration: Int
+    ) async {
+        let recordId = UUID().uuidString
+        let duration = recordingStartTime.map { Date().timeIntervalSince($0) } ?? 0
+        let historyStatus: String = {
+            switch status {
+            case .success: return "action_success"
+            case .failure: return "action_failed"
+            case .unsure:  return "action_unmatched"
+            }
+        }()
+        await historyStore.insert(HistoryRecord(
+            id: recordId,
+            createdAt: Date(),
+            durationSeconds: duration,
+            rawText: rawText,
+            processingMode: currentMode.name,
+            processedText: message,
+            finalText: message,
+            status: historyStatus,
+            characterCount: message.count,
+            asrProvider: activeProvider.displayName
+        ))
+
+        onASREvent?(.macActionResult(message: message, status: status))
+        onASREvent?(.completed)
+
+        if sessionGeneration == myGeneration, state != .idle {
+            state = .idle
+            hasEmittedReadyForCurrentSession = false
+            currentTranscript = .empty
+            warmUpASRConnection()
+        }
+        resetSpeculativeLLM()
+        SystemVolumeManager.restore()
+    }
+
     func stopRecording() async {
         let myGeneration = sessionGeneration
         guard state == .recording else {
@@ -857,6 +927,18 @@ actor RecognitionSession {
                 if let result = earlyResult, !result.isEmpty {
                     DebugFileLogger.log("stop: early LLM result received \(result.count) chars +\(ContinuousClock.now - stopT0)")
                     let cleaned = result.collapsingExtraSpaces
+                    if currentMode.id == ProcessingMode.macActionId {
+                        let action = await dispatchMacAction(llmReply: cleaned)
+                        await completeMacAction(
+                            message: action.message,
+                            status: action.status,
+                            rawText: rawText,
+                            recordingStartTime: recordingStartTime,
+                            activeProvider: activeProvider,
+                            myGeneration: myGeneration
+                        )
+                        return
+                    }
                     processedText = cleaned
                     finalText = cleaned
                     onASREvent?(.processingResult(text: cleaned))
@@ -906,6 +988,18 @@ actor RecognitionSession {
 
                     if let result = llmResult {
                         let cleaned = result.collapsingExtraSpaces
+                        if currentMode.id == ProcessingMode.macActionId {
+                            let action = await dispatchMacAction(llmReply: cleaned)
+                            await completeMacAction(
+                                message: action.message,
+                                status: action.status,
+                                rawText: rawText,
+                                recordingStartTime: recordingStartTime,
+                                activeProvider: activeProvider,
+                                myGeneration: myGeneration
+                            )
+                            return
+                        }
                         processedText = cleaned
                         finalText = cleaned
                         onASREvent?(.processingResult(text: cleaned))
@@ -1077,7 +1171,7 @@ actor RecognitionSession {
                 Task { await self.stopRecording() }
             }
 
-        case .processingResult, .processingLabelOverride, .finalized:
+        case .processingResult, .processingLabelOverride, .finalized, .macActionResult:
             break
         }
     }

--- a/Type4Me/Type4MeApp.swift
+++ b/Type4Me/Type4MeApp.swift
@@ -149,6 +149,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         appState.finalize(text: text, outcome: injection)
                         self.hotkeyManager.isProcessing = false
                         self.safeResetHotkeyState()
+                    case .macActionResult(let message, let status):
+                        appState.showMacActionResult(message: message, status: status)
+                        self.hotkeyManager.isProcessing = false
+                        self.safeResetHotkeyState()
                     case .error(let error):
                         appState.showError(self.userFacingMessage(for: error))
                         self.hotkeyManager.isProcessing = false

--- a/Type4Me/UI/AppState.swift
+++ b/Type4Me/UI/AppState.swift
@@ -501,6 +501,24 @@ struct ProcessingMode: Codable, Identifiable, Equatable, Hashable {
     用户："锁屏"
     输出：<tool_call>{"name":"lock_screen","arguments":{}}</tool_call>
 
+    用户："最小化窗口" / "minimize window"
+    输出：<tool_call>{"name":"minimize_window","arguments":{}}</tool_call>
+
+    用户："关闭窗口" / "close this window"
+    输出：<tool_call>{"name":"close_window","arguments":{}}</tool_call>
+
+    用户："提醒我明天早上九点开会" / "remind me to call John tomorrow at 9am"
+    输出：<tool_call>{"name":"create_reminder","arguments":{"title":"开会","due":"tomorrow 9am"}}</tool_call>
+
+    用户："提醒我两分钟后检查邮件" / "remind me to check emails in 2 minutes"
+    输出：<tool_call>{"name":"create_reminder","arguments":{"title":"检查邮件","due":"in 2 minutes"}}</tool_call>
+
+    用户："向下滚动" / "scroll down"
+    输出：<tool_call>{"name":"scroll_down","arguments":{}}</tool_call>
+
+    用户："向上滚动" / "scroll up"
+    输出：<tool_call>{"name":"scroll_up","arguments":{}}</tool_call>
+
     用户："今天天气怎么样"
     输出：NO_MATCH
 

--- a/Type4Me/UI/AppState.swift
+++ b/Type4Me/UI/AppState.swift
@@ -11,6 +11,16 @@ enum FloatingBarPhase: Equatable {
     case error
 }
 
+/// Visual variant of the floating-bar feedback. Lets the bar prepend a status
+/// icon (and tint the border) without introducing additional phases — the phase
+/// machine still drives layout, this just modulates the look of `.done`/`.error`.
+enum FeedbackKind: Equatable {
+    case standard
+    case macActionSuccess
+    case macActionFailure
+    case macActionUnsure
+}
+
 // MARK: - Transcription Segment
 
 struct TranscriptionSegment: Identifiable, Equatable {
@@ -97,6 +107,7 @@ struct ProcessingMode: Codable, Identifiable, Equatable, Hashable {
     static let directId = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
     static let smartDirectId = UUID(uuidString: "00000000-0000-0000-0000-000000000006")!
     static let translateId = UUID(uuidString: "00000000-0000-0000-0000-000000000003")!
+    static let macActionId = UUID(uuidString: "00000000-0000-0000-0000-000000000008")!
     static var direct: ProcessingMode {
         ProcessingMode(
             id: directId,
@@ -449,6 +460,65 @@ struct ProcessingMode: Codable, Identifiable, Equatable, Hashable {
         )
     }
 
+    static let macActionPromptTemplate = #"""
+    你是一个 macOS 操作助手。用户通过语音口述了一个意图，你必须严格按格式调用工具，不要解释。
+
+    # 可用工具
+
+    <tools>
+    {tools_json}
+    </tools>
+
+    # 输出格式（极其重要）
+
+    匹配到工具时，**仅**输出一行，**必须**包含开始和结束标签：
+    <tool_call>{"name":"tool_name","arguments":{"key":"value"}}</tool_call>
+
+    不匹配任何工具时，**仅**输出：NO_MATCH
+
+    禁止输出任何其它文字、解释、代码块标记。
+
+    # 示例
+
+    用户："打开 Safari" / "Open Safari" / "open up Safari"
+    输出：<tool_call>{"name":"open_app","arguments":{"app":"Safari"}}</tool_call>
+
+    用户："打开微信"
+    输出：<tool_call>{"name":"open_app","arguments":{"app":"WeChat"}}</tool_call>
+
+    用户："音量调到 30" / "set volume to 30"
+    输出：<tool_call>{"name":"set_volume","arguments":{"level":30}}</tool_call>
+
+    用户："切换深色模式" / "toggle dark mode"
+    输出：<tool_call>{"name":"toggle_dark_mode","arguments":{}}</tool_call>
+
+    用户："截图" / "take a screenshot"
+    输出：<tool_call>{"name":"screenshot","arguments":{}}</tool_call>
+
+    用户："搜一下 swiftui 教程" / "search swiftui tutorial"
+    输出：<tool_call>{"name":"search_web","arguments":{"query":"swiftui 教程"}}</tool_call>
+
+    用户："锁屏"
+    输出：<tool_call>{"name":"lock_screen","arguments":{}}</tool_call>
+
+    用户："今天天气怎么样"
+    输出：NO_MATCH
+
+    # 用户语音
+    {text}
+    """#
+
+    static var macAction: ProcessingMode {
+        ProcessingMode(
+            id: macActionId,
+            name: L("Mac 操作", "Mac Action"),
+            prompt: macActionPromptTemplate,
+            isBuiltin: true,
+            processingLabel: L("执行中", "Executing"),
+            hotkeyCode: 23, hotkeyModifiers: 524288, hotkeyStyle: .toggle
+        )
+    }
+
     static let agentModePromptTemplate = #"""
     # Role
     你是一个"直接交付"型 AI 助手。用户通过语音口述一个需求，你的任务是**直接给出最终成品**，让用户能立即粘贴到目标场景使用。
@@ -599,8 +669,8 @@ struct ProcessingMode: Codable, Identifiable, Equatable, Hashable {
         )
     }
 
-    static var builtins: [ProcessingMode] { [.direct, .formalWriting] }
-    static var defaults: [ProcessingMode] { [.direct, .formalWriting, .promptOptimize, .translate, .agentMode, .commandMode] }
+    static var builtins: [ProcessingMode] { [.direct, .formalWriting, .macAction] }
+    static var defaults: [ProcessingMode] { [.direct, .formalWriting, .promptOptimize, .translate, .agentMode, .commandMode, .macAction] }
 }
 
 // MARK: - Audio Level (isolated from @Observable to avoid high-frequency view invalidation)
@@ -626,6 +696,7 @@ final class AppState {
     var recordingStartDate: Date?
     var availableModes: [ProcessingMode]
     var feedbackMessage: String = L("已完成", "Done")
+    var feedbackKind: FeedbackKind = .standard
     var processingLabelOverride: String?
     var processingFinishTime: Date?
     var isQwen3OnlyMode: Bool {
@@ -675,6 +746,7 @@ final class AppState {
         audioLevel.current = 0
         recordingStartDate = nil
         feedbackMessage = L("已完成", "Done")
+        feedbackKind = .standard
         processingLabelOverride = nil
         barPhase = .preparing
         onShowPanel?()
@@ -774,6 +846,31 @@ final class AppState {
         recordingStartDate = nil
         barPhase = .done
         scheduleAutoHide(for: .done, delay: .seconds(0.8))
+    }
+
+    /// Display a Mac Action result in the floating bar with status-specific
+    /// icon/color and a 3-second hold (instead of the usual 0.5s `.done`).
+    /// `.failure` routes through `.error` to inherit the red gradient background;
+    /// `.success` and `.unsure` reuse `.done` and rely on `feedbackKind` to
+    /// differentiate (green check vs amber question mark).
+    func showMacActionResult(message: String, status: MacActionResultStatus) {
+        segments = []
+        audioLevel.current = 0
+        recordingStartDate = nil
+        feedbackMessage = message
+        switch status {
+        case .success:
+            feedbackKind = .macActionSuccess
+            barPhase = .done
+        case .failure:
+            feedbackKind = .macActionFailure
+            barPhase = .error
+        case .unsure:
+            feedbackKind = .macActionUnsure
+            barPhase = .done
+        }
+        onShowPanel?()
+        scheduleAutoHide(for: barPhase, delay: .seconds(3))
     }
 
     // MARK: Computed

--- a/Type4Me/UI/FloatingBar/FloatingBarView.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarView.swift
@@ -12,6 +12,7 @@ protocol FloatingBarState: AnyObject, Observable {
     var audioLevel: AudioLevelMeter { get }
     var currentMode: ProcessingMode { get }
     var feedbackMessage: String { get }
+    var feedbackKind: FeedbackKind { get }
     var processingFinishTime: Date? { get }
     var transcriptionText: String { get }
     var recordingStartDate: Date? { get }
@@ -236,17 +237,36 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 
     private var doneContent: some View {
-        ZStack {
-            Text(state.feedbackMessage)
-                .font(.system(size: 14, weight: .medium))
-                .foregroundStyle(.white)
+        Group {
+            if let icon = feedbackIcon {
+                HStack(spacing: 10) {
+                    Image(systemName: icon.symbol)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(icon.color)
+                    Text(state.feedbackMessage)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                }
+                .padding(.horizontal, 14)
+            } else {
+                Text(state.feedbackMessage)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+            }
         }
-        .frame(maxWidth: .infinity)
     }
 
     private var errorContent: some View {
         HStack(spacing: 10) {
-            ErrorDot()
+            if let icon = feedbackIcon {
+                Image(systemName: icon.symbol)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(icon.color)
+            } else {
+                ErrorDot()
+            }
 
             Text(state.feedbackMessage)
                 .font(.system(size: 14, weight: .medium))
@@ -254,6 +274,21 @@ struct FloatingBarView<S: FloatingBarState>: View {
                 .lineLimit(1)
         }
         .padding(.horizontal, 14)
+    }
+
+    /// SF Symbol + tint for the current feedback kind, or nil for the standard
+    /// look (no leading icon, centered text — the existing `.done`/`.error` UI).
+    private var feedbackIcon: (symbol: String, color: Color)? {
+        switch state.feedbackKind {
+        case .standard:
+            return nil
+        case .macActionSuccess:
+            return ("checkmark.circle.fill", TF.success)
+        case .macActionFailure:
+            return ("xmark.circle.fill", TF.settingsAccentRed)
+        case .macActionUnsure:
+            return ("questionmark.circle.fill", TF.amber)
+        }
     }
 
     // MARK: - Background & Border
@@ -301,7 +336,12 @@ struct FloatingBarView<S: FloatingBarState>: View {
         case .processing:
             .white.opacity(0.07)
         case .done:
-            TF.success.opacity(doneGlow ? 0.3 : 0.08)
+            switch state.feedbackKind {
+            case .macActionUnsure:
+                TF.amber.opacity(0.30)
+            case .macActionSuccess, .macActionFailure, .standard:
+                TF.success.opacity(doneGlow ? 0.3 : 0.08)
+            }
         case .error:
             TF.settingsAccentRed.opacity(0.22)
         case .hidden:
@@ -352,7 +392,9 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 
     private func feedbackWidth(for message: String) -> CGFloat {
-        measureText(message) + 66.0
+        // Reserve extra room when an SF Symbol icon is shown (icon + spacing).
+        let iconExtra: CGFloat = feedbackIcon == nil ? 0 : 26
+        return measureText(message) + 66.0 + iconExtra
     }
 
     /// Measure actual rendered width using the same font as the floating bar text.

--- a/Type4Me/UI/Settings/ModesSettingsTab.swift
+++ b/Type4Me/UI/Settings/ModesSettingsTab.swift
@@ -407,6 +407,18 @@ struct ModesSettingsTab: View {
              L("用浏览器搜索", "Open a web search")),
             (L("查看电量", "Check battery"),
              L("显示当前电量", "Show battery status")),
+            (L("最小化窗口", "Minimize window"),
+             L("最小化当前窗口", "Minimize the frontmost window")),
+            (L("全屏", "Fullscreen"),
+             L("切换当前窗口全屏", "Toggle fullscreen for frontmost window")),
+            (L("关闭窗口", "Close window"),
+             L("关闭当前窗口", "Close the frontmost window")),
+            (L("提醒我两分钟后检查邮件", "Remind me to check emails in 2 minutes"),
+             L("创建 Apple 提醒", "Create an Apple Reminder")),
+            (L("向下滚动", "Scroll down"),
+             L("向下翻页", "Page down")),
+            (L("向上滚动", "Scroll up"),
+             L("向上翻页", "Page up")),
         ]
     }
 

--- a/Type4Me/UI/Settings/ModesSettingsTab.swift
+++ b/Type4Me/UI/Settings/ModesSettingsTab.swift
@@ -306,7 +306,7 @@ struct ModesSettingsTab: View {
     private func builtinModeDetail(_ mode: ProcessingMode) -> some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack(spacing: 6) {
-                Image(systemName: mode.id == ProcessingMode.formalWritingId ? "wand.and.stars" : "bolt.fill")
+                Image(systemName: builtinIcon(for: mode))
                     .font(.system(size: 14))
                     .foregroundStyle(TF.settingsAccentAmber)
                 Text(mode.name)
@@ -320,14 +320,94 @@ struct ModesSettingsTab: View {
                     .background(Capsule().fill(TF.settingsCardAlt))
             }
 
-            Text(L("直接使用语音识别 API，识别完成后不做处理、直接粘贴。适合非正式场合、无需纠正口头表达的场景，输入流程更丝滑。",
-                     "Uses the ASR API directly, pastes raw output without post-processing. Best for informal contexts where oral expressions don't need correction."))
+            if mode.id == ProcessingMode.macActionId {
+                macActionDescription
+            } else {
+                Text(L("直接使用语音识别 API，识别完成后不做处理、直接粘贴。适合非正式场合、无需纠正口头表达的场景，输入流程更丝滑。",
+                         "Uses the ASR API directly, pastes raw output without post-processing. Best for informal contexts where oral expressions don't need correction."))
+                    .font(.system(size: 12))
+                    .foregroundStyle(TF.settingsTextSecondary)
+                    .lineSpacing(3)
+            }
+
+            Spacer()
+        }
+    }
+
+    private func builtinIcon(for mode: ProcessingMode) -> String {
+        switch mode.id {
+        case ProcessingMode.formalWritingId: return "wand.and.stars"
+        case ProcessingMode.macActionId: return "command.circle.fill"
+        default: return "bolt.fill"
+        }
+    }
+
+    private var macActionDescription: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(L(
+                "用语音直接触发 macOS 操作，不再粘贴文本。需要先在「高级 → LLM」中配置 LLM 提供商。",
+                "Trigger macOS actions by voice instead of typing text. Requires an LLM provider configured under Advanced → LLM."
+            ))
                 .font(.system(size: 12))
                 .foregroundStyle(TF.settingsTextSecondary)
                 .lineSpacing(3)
 
-            Spacer()
+            VStack(alignment: .leading, spacing: 6) {
+                Text(L("支持的操作", "Supported actions"))
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(TF.settingsText)
+                ForEach(macActionExamples, id: \.0) { phrase, action in
+                    HStack(alignment: .top, spacing: 8) {
+                        Text("•")
+                            .font(.system(size: 11))
+                            .foregroundStyle(TF.settingsTextTertiary)
+                        Text("\u{201C}\(phrase)\u{201D}")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(TF.settingsText)
+                        Text("→")
+                            .font(.system(size: 11))
+                            .foregroundStyle(TF.settingsTextTertiary)
+                        Text(action)
+                            .font(.system(size: 11))
+                            .foregroundStyle(TF.settingsTextSecondary)
+                    }
+                }
+            }
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(RoundedRectangle(cornerRadius: 8).fill(TF.settingsCardAlt))
+
+            Text(L(
+                "首次使用某些操作时，macOS 可能弹出「辅助功能 / 自动化」授权请求。未匹配到任何操作时会提示，不会粘贴任何文本。",
+                "macOS may ask for Accessibility/Automation permission the first time you use certain actions. When no action matches, you'll see a notice and nothing is typed."
+            ))
+                .font(.system(size: 11))
+                .foregroundStyle(TF.settingsTextTertiary)
+                .lineSpacing(2)
         }
+    }
+
+    private var macActionExamples: [(String, String)] {
+        [
+            (L("打开 Safari", "Open Safari"),
+             L("启动应用", "Launch an app")),
+            (L("音量调到 30", "Set volume to 30"),
+             L("调节系统音量", "Adjust system volume")),
+            (L("亮度调到 80", "Set brightness to 80"),
+             L("调节屏幕亮度", "Adjust screen brightness")),
+            (L("切换深色模式", "Toggle dark mode"),
+             L("切换深色/浅色外观", "Switch dark/light appearance")),
+            (L("截图", "Take a screenshot"),
+             L("启动框选截图", "Start interactive screen capture")),
+            (L("复制 hello 到剪贴板", "Copy hello to clipboard"),
+             L("写入剪贴板", "Write to clipboard")),
+            (L("锁屏", "Lock screen"),
+             L("锁定屏幕", "Lock the screen")),
+            (L("搜一下 swiftui 教程", "Search SwiftUI tutorial"),
+             L("用浏览器搜索", "Open a web search")),
+            (L("查看电量", "Check battery"),
+             L("显示当前电量", "Show battery status")),
+        ]
     }
 
     @AppStorage("tf_shortTextExemption") private var shortTextExemption = "0"

--- a/Type4Me/UI/Setup/DemoState.swift
+++ b/Type4Me/UI/Setup/DemoState.swift
@@ -14,6 +14,7 @@ final class DemoState {
     @ObservationIgnored let audioLevel = AudioLevelMeter()
     var currentMode: ProcessingMode = .direct
     var feedbackMessage: String = L("已完成", "Done")
+    var feedbackKind: FeedbackKind = .standard
     var processingFinishTime: Date?
     var recordingStartDate: Date?
 


### PR DESCRIPTION
关联 Issue：close #71
灵感来源：[RunanywhereAI/RCLI](https://github.com/RunanywhereAI/RCLI)

---

## 功能概述

新增内置模式「Mac 操作 / Mac Action」（默认快捷键 ⌥+5）。用户通过语音口述意图，LLM 识别后触发 macOS 操作，**不粘贴任何文本**。

## 演示

<!-- 截图 -->
> 📷 **截图**
<img width="1170" height="574" alt="image" src="https://github.com/user-attachments/assets/e0e68d72-3f62-42ca-84f7-9c389f6be12b" />


<!-- 视频 -->
> 🎬 **演示视频**

https://github.com/user-attachments/assets/764d92f5-0b9f-4ce4-9476-9cd073b022c5


---

## 架构

```
语音 → ASR（任意供应商）→ LLM（任意供应商，纯文本 in/out）
   → ToolCallParser 解析 <tool_call>{...}</tool_call>
   → ActionRegistry.dispatch(name, args)
   → 执行 AppleScript / NSWorkspace / Shell
   → 浮动栏显示结果（3 秒），不注入文本
```

**核心设计**：无需修改 `LLMClient` 协议，所有现有 LLM 供应商（Claude、豆包、OpenAI 兼容）均通过 Prompt 驱动的工具调用，无需 SDK Function Calling API。

## 支持的操作（9 个）

| 操作名 | 说明 | 示例语音 |
|--------|------|----------|
| `open_app` | 打开应用 | 「打开 Safari」 |
| `set_volume` | 调节音量 | 「音量调到 30」 |
| `set_brightness` | 调节亮度 | 「亮度调到 80」 |
| `toggle_dark_mode` | 切换深色模式 | 「切换深色模式」 |
| `screenshot` | 截图（框选） | 「截图」 |
| `clipboard_write` | 写入剪贴板 | 「复制 hello 到剪贴板」 |
| `lock_screen` | 锁屏 | 「锁屏」 |
| `search_web` | 浏览器搜索 | 「搜一下 SwiftUI 教程」 |
| `get_battery` | 查看电量 | 「查看电量」 |

## 浮动栏反馈（3 秒显示）

| 图标 | 颜色 | 含义 |
|------|------|------|
| ✓ `checkmark.circle.fill` | 绿色 | 操作成功 |
| ✗ `xmark.circle.fill` | 红色 | 操作失败 / 未知操作名 |
| ? `questionmark.circle.fill` | 琥珀色 | LLM 返回 NO_MATCH，意图未识别 |

## 主要改动文件

**新增（`Type4Me/Actions/`）**
- `MacAction.swift` — 协议定义 + `MacActionResult` + `MacActionResultStatus`
- `ActionRegistry.swift` — 动作注册与分发 + `{tools_json}` 渲染
- `ToolCallParser.swift` — 容错 XML+JSON 解析（支持缺少 `</tool_call>` 的情况）
- `AppleScriptRunner.swift` — osascript / shell 子进程（10 秒超时）
- `Implementations/` — 9 个操作实现

**修改**
- `AppState.swift` — 新增 `FeedbackKind` 枚举、`showMacActionResult()`、Mac Action 模式定义
- `SpeechRecognizer.swift` — 新增 `RecognitionEvent.macActionResult(message:status:)`
- `RecognitionSession.swift` — 新增 `dispatchMacAction` + `completeMacAction`，绕过注入路径
- `Type4MeApp.swift` — 路由 `.macActionResult` 事件
- `FloatingBarView.swift` — `FeedbackKind` 驱动的图标 + 边框颜色
- `ModesSettingsTab.swift` — Mac Action 专属说明面板（含操作列表与示例）
- `ModeStorage.swift` — 新内置模式末尾追加（不插队）
- `PromptContext.swift` — `{tools_json}` 模板变量扩展

## 测试检查清单

- [ ] 「打开 Safari」→ Safari 启动，浮动栏显示绿色 ✓ 3 秒
- [ ] 「音量调到 50」→ 系统音量变化
- [ ] 「截图」→ `screencapture -i` 启动框选
- [ ] 「今天天气怎么样」→ 浮动栏显示琥珀色 ? + 「未匹配到操作」
- [ ] 切换回快速模式，正常文本注入无回归

🤖 Generated with [Claude Code](https://claude.ai/claude-code)