### PR TITLE
Remove unsupported OpenAI GPT-5.4 nano option

### DIFF
--- a/Type4Me/LLM/LLMProvider.swift
+++ b/Type4Me/LLM/LLMProvider.swift
@@ -91,7 +91,6 @@ enum LLMProvider: String, CaseIterable, Codable, Sendable {
             ]
         case .openai:
             return [
-                FieldOption(value: "gpt-5.4-nano", label: "gpt-5.4-nano"),
                 FieldOption(value: "gpt-5.4-mini", label: "gpt-5.4-mini"),
                 FieldOption(value: "gpt-5.4", label: "gpt-5.4"),
                 FieldOption(value: "gpt-4.1-nano", label: "gpt-4.1-nano"),


### PR DESCRIPTION
## Summary

- remove `gpt-5.4-nano` from the default OpenAI LLM model picker
- keep `gpt-5.4-mini` and `gpt-5.4` as default OpenAI options

## Why

OpenAI's Codex models page lists `gpt-5.4-mini` and `gpt-5.4`, but does not list `gpt-5.4-nano`. Keeping `gpt-5.4-nano` as a default OpenAI option can be misleading for users who expect it to be an officially supported OpenAI/Codex model.

Users can still enter custom model names through the existing custom model path when using an OpenAI-compatible gateway that supports additional aliases.

Closes #152.

## Test

- `swift build`