### PR TITLE
[codex] stabilize local Qwen3-ASR and local LLM recording flow

### DIFF
--- a/Type4Me/ASR/SenseVoiceWSClient.swift
+++ b/Type4Me/ASR/SenseVoiceWSClient.swift
@@ -21,6 +21,15 @@ actor SenseVoiceWSClient: SpeechRecognizer {
     private var qwen3LatestText: String?
     private var qwen3HasPendingAudio: Bool = false
 
+    private static let qwen3BytesPerSecond = 16000 * 2
+    private static let qwen3MaxHTTPAudioSeconds = 30 * 60
+    private static let qwen3MaxHTTPAudioBytes = qwen3MaxHTTPAudioSeconds * qwen3BytesPerSecond
+    private static let qwen3SpeculativeEnabledKey = "tf_qwen3SpeculativeEnabled"
+    private static let qwen3SpeculativeMinAudioBytes = 5 * qwen3BytesPerSecond
+    private static let qwen3SpeculativeMaxAudioBytes = 15 * qwen3BytesPerSecond
+    private static let qwen3SpeculativeDebounceMs = 8000
+    private static let qwen3SpeculativeTimeout: TimeInterval = 15
+
     var events: AsyncStream<RecognitionEvent> {
         if let existing = _events { return existing }
         let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
@@ -94,27 +103,16 @@ actor SenseVoiceWSClient: SpeechRecognizer {
         let port = SenseVoiceServerManager.currentQwen3Port
 
         if let port, allAudioData.count > 3200 {
-            let newAudioBytes = allAudioData.count - qwen3ConfirmedOffset
-            let hasQwen3Result = !qwen3ConfirmedSegments.isEmpty
-            let newAudioTrivial = newAudioBytes < 2 * 16000 * 2
-
-            let finalText: String
-            if hasQwen3Result && newAudioTrivial {
-                // Speculative covered most audio, just handle the tail
-                var assembled = qwen3ConfirmedSegments.joined()
-                if newAudioBytes > 3200 {
-                    if let tailText = await qwen3Transcribe(audio: Data(allAudioData.suffix(from: qwen3ConfirmedOffset)), port: port, timeout: 10) {
-                        assembled += tailText
-                    }
-                }
-                finalText = assembled
-                DebugFileLogger.log("Qwen3 final: incremental (\(qwen3ConfirmedSegments.count) segments + tail)")
-            } else {
-                // No speculative, send full audio
-                DebugFileLogger.log("Qwen3 full final: sending \(allAudioData.count) bytes")
-                finalText = await qwen3Transcribe(audio: Data(allAudioData), port: port, timeout: 30) ?? ""
-                DebugFileLogger.log("Qwen3 full final: \(finalText.count) chars")
+            guard allAudioData.count <= Self.qwen3MaxHTTPAudioBytes else {
+                DebugFileLogger.log("Qwen3 final: skipping oversized request \(allAudioData.count) bytes")
+                eventContinuation?.yield(.completed)
+                resetQwen3State()
+                return
             }
+
+            DebugFileLogger.log("Qwen3 full final: sending \(allAudioData.count) bytes")
+            let finalText = await qwen3Transcribe(audio: allAudioData, port: port, timeout: 30) ?? ""
+            DebugFileLogger.log("Qwen3 full final: \(finalText.count) chars")
 
             if !finalText.isEmpty {
                 confirmedSegments = [finalText]
@@ -140,6 +138,11 @@ actor SenseVoiceWSClient: SpeechRecognizer {
 
     /// POST audio to Qwen3 /transcribe and return text, or nil on failure.
     private func qwen3Transcribe(audio: Data, port: Int, timeout: TimeInterval) async -> String? {
+        guard audio.count <= Self.qwen3MaxHTTPAudioBytes else {
+            DebugFileLogger.log("Qwen3 transcribe: refusing oversized request \(audio.count) bytes")
+            return nil
+        }
+
         let url = URL(string: "http://127.0.0.1:\(port)/transcribe")!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -155,16 +158,23 @@ actor SenseVoiceWSClient: SpeechRecognizer {
     // MARK: - Qwen3 Speculative
 
     private func scheduleSpeculativeQwen3() {
+        let speculativeEnabled = UserDefaults.standard.object(forKey: Self.qwen3SpeculativeEnabledKey) as? Bool ?? false
+        guard speculativeEnabled else { return }
+
         qwen3DebounceTask?.cancel()
         qwen3DebounceTask = Task { [weak self] in
-            try? await Task.sleep(for: .milliseconds(1500))
+            try? await Task.sleep(for: .milliseconds(Self.qwen3SpeculativeDebounceMs))
             guard !Task.isCancelled else { return }
             guard let self else { return }
             guard await self.qwen3HasPendingAudio else { return }
             guard let port = SenseVoiceServerManager.currentQwen3Port else { return }
 
             let deltaAudio = await self.allAudioData.suffix(from: self.qwen3ConfirmedOffset)
-            guard deltaAudio.count > 3200 else { return }  // at least 100ms of audio
+            guard deltaAudio.count >= Self.qwen3SpeculativeMinAudioBytes else { return }
+            guard deltaAudio.count <= Self.qwen3SpeculativeMaxAudioBytes else {
+                DebugFileLogger.log("Qwen3 speculative: skipping oversized window \(deltaAudio.count) bytes")
+                return
+            }
 
             // Snapshot the offset before the HTTP round-trip so audio arriving
             // during the request doesn't get silently marked as processed.
@@ -175,7 +185,7 @@ actor SenseVoiceWSClient: SpeechRecognizer {
             request.httpMethod = "POST"
             request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
             request.httpBody = Data(deltaAudio)
-            request.timeoutInterval = 120  // 10 min audio needs ~60-90s on M1/M2
+            request.timeoutInterval = Self.qwen3SpeculativeTimeout
 
             DebugFileLogger.log("Qwen3 speculative: sending \(deltaAudio.count) bytes (offset \(await self.qwen3ConfirmedOffset))")
 

--- a/Type4Me/Input/HotkeyManager.swift
+++ b/Type4Me/Input/HotkeyManager.swift
@@ -160,19 +160,22 @@ final class HotkeyManager: NSObject {
         healthCheckTimer = Timer.scheduledTimer(withTimeInterval: 10.0, repeats: true) { [weak self] _ in
             guard let self, let tap = self.eventTap else { return }
 
-            // Check 1: Is the tap still enabled at the Mach port level?
+            // Check 1: Is the tap port still valid? Only recreate the tap for real invalidation,
+            // not for normal idle periods with no keyboard/mouse input.
+            if !CFMachPortIsValid(tap) {
+                NSLog("[Type4Me] Health check: tap port invalid, reinstalling tap...")
+                self.reinstallTap()
+                return
+            }
+
+            // Check 2: Is the tap still enabled at the Mach port level?
             if !CGEvent.tapIsEnabled(tap: tap) {
                 NSLog("[Type4Me] Health check: tap disabled, re-enabling...")
                 CGEvent.tapEnable(tap: tap, enable: true)
-            }
-
-            // Check 2: If we haven't received ANY event in 30s, the tap may be silently dead.
-            // (User is almost certainly pressing keys within 30s of normal use.)
-            // Only flag this if the tap has been alive for at least 30s (give it time to warm up).
-            if let lastEvent = self.lastEventTime,
-               Date().timeIntervalSince(lastEvent) > 30 {
-                NSLog("[Type4Me] Health check: no events for 30s, reinstalling tap...")
-                self.reinstallTap()
+                if !CGEvent.tapIsEnabled(tap: tap) {
+                    NSLog("[Type4Me] Health check: tap re-enable failed, reinstalling tap...")
+                    self.reinstallTap()
+                }
             }
         }
     }

--- a/Type4Me/Services/SenseVoiceServerManager.swift
+++ b/Type4Me/Services/SenseVoiceServerManager.swift
@@ -53,6 +53,7 @@ actor SenseVoiceServerManager {
     private var qwen3Process: Process?
     private(set) var qwen3Port: Int?
     private var qwen3StdoutPipe: Pipe?
+    private var qwen3StderrPipe: Pipe?
     private var qwen3CrashRestarts = 0
     private let maxCrashRestarts = 3
     private var qwen3Starting = false
@@ -120,12 +121,14 @@ actor SenseVoiceServerManager {
             }
         }
         self.qwen3StdoutPipe = pipe
+        self.qwen3StderrPipe = errPipe
 
         logger.info("Starting Qwen3-ASR server: \(proc.executableURL?.path ?? "?")")
 
         do {
             try proc.run()
         } catch {
+            cleanupQwen3Process(proc, intentional: true, killIfRunning: false)
             logger.error("Failed to start Qwen3-ASR server: \(error)")
             throw ServerError.launchFailed(error)
         }
@@ -140,8 +143,7 @@ actor SenseVoiceServerManager {
 
         let portResult = await readPortFromStdout(pipe: pipe, timeout: 120)
         guard let discoveredPort = portResult else {
-            proc.terminate()
-            self.qwen3Process = nil
+            cleanupQwen3Process(proc, intentional: true, killIfRunning: true)
             throw ServerError.portDiscoveryFailed
         }
         self.qwen3Port = discoveredPort
@@ -161,10 +163,7 @@ actor SenseVoiceServerManager {
         if !healthy {
             logger.error("Qwen3-ASR server started but health check failed after 30s")
             DebugFileLogger.log("Qwen3-ASR health check failed — server may be non-functional")
-            proc.terminate()
-            self.qwen3Process = nil
-            self.qwen3Port = nil
-            Self.currentQwen3Port = nil
+            cleanupQwen3Process(proc, intentional: true, killIfRunning: true)
             throw ServerError.launchFailed(
                 NSError(domain: "SenseVoiceServerManager", code: -1,
                         userInfo: [NSLocalizedDescriptionKey: "Health check failed after server start"])
@@ -183,59 +182,63 @@ actor SenseVoiceServerManager {
 
     /// Stop the Qwen3-ASR server independently (e.g. when user disables verification).
     func stopQwen3() {
-        intentionalStop = true
-        if let proc = qwen3Process, proc.isRunning {
-            proc.terminate()
-            // SIGKILL fallback if SIGTERM doesn't work within 1s
-            DispatchQueue.global().asyncAfter(deadline: .now() + 1.0) { [weak proc] in
-                guard let proc = proc, proc.isRunning else { return }
-                kill(proc.processIdentifier, SIGKILL)
-            }
-        }
-        qwen3Process = nil
-        qwen3Port = nil
-        Self.currentQwen3Port = nil
-        qwen3StdoutPipe = nil
+        cleanupQwen3Process(intentional: true, killIfRunning: true)
         logger.info("Qwen3-ASR server stopped")
         DebugFileLogger.log("Qwen3-ASR server stopped (user toggle)")
-        savePidsToFile()
     }
 
     /// Stop the server.
     func stop() {
-        intentionalStop = true
-        if let proc = qwen3Process, proc.isRunning {
-            proc.terminate()
-            DispatchQueue.global().asyncAfter(deadline: .now() + 1.0) { [weak proc] in
-                guard let proc = proc, proc.isRunning else { return }
-                kill(proc.processIdentifier, SIGKILL)
-            }
-        }
-        qwen3Process = nil
-        qwen3Port = nil
-        Self.currentQwen3Port = nil
-        qwen3StdoutPipe = nil
-
+        cleanupQwen3Process(intentional: true, killIfRunning: true)
         logger.info("Qwen3-ASR server stopped")
-        savePidsToFile()
     }
 
     // MARK: - Crash Handling
 
+    private func cleanupQwen3Process(_ proc: Process? = nil, intentional: Bool, killIfRunning: Bool) {
+        if intentional {
+            intentionalStop = true
+        }
+
+        let processToClean = proc ?? qwen3Process
+        if let processToClean, killIfRunning, processToClean.isRunning {
+            processToClean.terminate()
+            DispatchQueue.global().asyncAfter(deadline: .now() + 1.0) { [weak processToClean] in
+                guard let processToClean, processToClean.isRunning else { return }
+                kill(processToClean.processIdentifier, SIGKILL)
+            }
+        }
+
+        if proc == nil || qwen3Process === proc {
+            qwen3Process?.terminationHandler = nil
+            qwen3Process = nil
+        } else {
+            proc?.terminationHandler = nil
+        }
+
+        qwen3StdoutPipe?.fileHandleForReading.readabilityHandler = nil
+        qwen3StderrPipe?.fileHandleForReading.readabilityHandler = nil
+        qwen3StdoutPipe = nil
+        qwen3StderrPipe = nil
+        qwen3Port = nil
+        Self.currentQwen3Port = nil
+        savePidsToFile()
+    }
+
     private func handleQwen3Termination(pid: Int32, status: Int32) {
-        if let current = qwen3Process, current.processIdentifier != pid {
+        let current = qwen3Process
+        if let current, current.processIdentifier != pid {
             DebugFileLogger.log("Ignored stale Qwen3 termination pid=\(pid)")
             return
         }
-        guard !intentionalStop else { return }
+        guard !intentionalStop else {
+            cleanupQwen3Process(current, intentional: true, killIfRunning: false)
+            return
+        }
         // Abnormal exit: clear state and optionally restart
         NSLog("[SenseVoiceServerManager] Qwen3 process crashed with exit status %d", status)
         DebugFileLogger.log("Qwen3 process crashed (exit \(status))")
-        qwen3Process = nil
-        qwen3Port = nil
-        Self.currentQwen3Port = nil
-        qwen3StdoutPipe = nil
-        savePidsToFile()
+        cleanupQwen3Process(current, intentional: false, killIfRunning: false)
 
         if qwen3CrashRestarts < maxCrashRestarts {
             qwen3CrashRestarts += 1
@@ -243,6 +246,12 @@ actor SenseVoiceServerManager {
             DebugFileLogger.log("Qwen3 auto-restart attempt \(qwen3CrashRestarts)/\(maxCrashRestarts)")
             Task {
                 try? await Task.sleep(for: .seconds(2))
+                guard !qwen3Starting, qwen3Process == nil else {
+                    DebugFileLogger.log("Qwen3 auto-restart skipped: start already in progress or process exists")
+                    return
+                }
+                qwen3Starting = true
+                defer { qwen3Starting = false }
                 do {
                     try await launchQwen3Server()
                 } catch {

--- a/Type4Me/Services/SenseVoiceServerManager.swift
+++ b/Type4Me/Services/SenseVoiceServerManager.swift
@@ -37,12 +37,7 @@ actor SenseVoiceServerManager {
         syncHotwordsFile()
         Task {
             let mgr = shared
-            let q3WasRunning = await mgr.qwen3Port != nil
-            if q3WasRunning {
-                await mgr.stop()
-                try? await mgr.start()
-                DebugFileLogger.log("Qwen3 server restarted for hotword update")
-            }
+            await mgr.restartForHotwordUpdate()
         }
     }
 
@@ -60,6 +55,8 @@ actor SenseVoiceServerManager {
     private var qwen3StdoutPipe: Pipe?
     private var qwen3CrashRestarts = 0
     private let maxCrashRestarts = 3
+    private var qwen3Starting = false
+    private var hotwordRestartInFlight = false
     /// Set to true when we intentionally stop the process (prevents crash handler from firing).
     private var intentionalStop = false
 
@@ -79,7 +76,17 @@ actor SenseVoiceServerManager {
 
         DebugFileLogger.log("start(): q3=\(qwen3Enabled)")
 
-        if qwen3Enabled && qwen3Process == nil {
+        if qwen3Enabled {
+            if qwen3Starting {
+                DebugFileLogger.log("start(): Qwen3 start already in progress")
+                return
+            }
+            if let proc = qwen3Process, proc.isRunning, qwen3Port != nil {
+                DebugFileLogger.log("start(): Qwen3 already running q3Port=\(qwen3Port ?? -1)")
+                return
+            }
+            qwen3Starting = true
+            defer { qwen3Starting = false }
             do {
                 try await launchQwen3Server()
             } catch {
@@ -127,7 +134,8 @@ actor SenseVoiceServerManager {
 
         proc.terminationHandler = { [weak self] terminatedProc in
             let status = terminatedProc.terminationStatus
-            Task { await self?.handleQwen3Termination(status: status) }
+            let pid = terminatedProc.processIdentifier
+            Task { await self?.handleQwen3Termination(pid: pid, status: status) }
         }
 
         let portResult = await readPortFromStdout(pipe: pipe, timeout: 120)
@@ -167,7 +175,9 @@ actor SenseVoiceServerManager {
 
     /// Start the Qwen3-ASR server independently.
     func startQwen3() async throws {
-        guard qwen3Process == nil else { return }
+        guard qwen3Process == nil, !qwen3Starting else { return }
+        qwen3Starting = true
+        defer { qwen3Starting = false }
         try await launchQwen3Server()
     }
 
@@ -212,7 +222,11 @@ actor SenseVoiceServerManager {
 
     // MARK: - Crash Handling
 
-    private func handleQwen3Termination(status: Int32) {
+    private func handleQwen3Termination(pid: Int32, status: Int32) {
+        if let current = qwen3Process, current.processIdentifier != pid {
+            DebugFileLogger.log("Ignored stale Qwen3 termination pid=\(pid)")
+            return
+        }
         guard !intentionalStop else { return }
         // Abnormal exit: clear state and optionally restart
         NSLog("[SenseVoiceServerManager] Qwen3 process crashed with exit status %d", status)
@@ -239,6 +253,25 @@ actor SenseVoiceServerManager {
         } else {
             NSLog("[SenseVoiceServerManager] Qwen3 crash restart limit reached (%d)", maxCrashRestarts)
             DebugFileLogger.log("Qwen3 crash restart limit reached")
+        }
+    }
+
+    private func restartForHotwordUpdate() async {
+        guard qwen3Port != nil || qwen3Process != nil else { return }
+        guard !hotwordRestartInFlight else {
+            DebugFileLogger.log("Qwen3 hotword restart skipped: already in flight")
+            return
+        }
+        hotwordRestartInFlight = true
+        defer { hotwordRestartInFlight = false }
+
+        stop()
+        try? await Task.sleep(for: .milliseconds(300))
+        do {
+            try await start()
+            DebugFileLogger.log("Qwen3 server restarted for hotword update")
+        } catch {
+            DebugFileLogger.log("Qwen3 hotword restart failed: \(error)")
         }
     }
 

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -166,6 +166,10 @@ actor RecognitionSession {
     private var currentTranscript: RecognitionTranscript = .empty
     private var eventConsumptionTask: Task<Void, Never>?
     private var maxDurationTask: Task<Void, Never>?
+    private var asrCleanupTask: Task<Void, Never>?
+    private var asrCleanupGeneration: Int?
+    private var finalTranscriptTimeoutTask: Task<Void, Never>?
+    private var firstStreamingTextTimeoutTask: Task<Void, Never>?
     private var hasEmittedReadyForCurrentSession = false
     private var audioChunkContinuation: AsyncStream<Data>.Continuation?
     private var audioChunkSenderTask: Task<Void, Never>?
@@ -485,6 +489,9 @@ actor RecognitionSession {
 
         // Safety: auto-stop after maxRecordingDuration to prevent unbounded memory use
         maxDurationTask?.cancel()
+        asrCleanupTask?.cancel()
+        asrCleanupTask = nil
+        asrCleanupGeneration = nil
         maxDurationTask = Task { [weak self, maxRecordingDuration] in
             try? await Task.sleep(for: .seconds(maxRecordingDuration))
             guard let self, !Task.isCancelled else { return }
@@ -498,6 +505,13 @@ actor RecognitionSession {
         DebugFileLogger.log("max recording duration reached (\(maxRecordingDuration)s), auto-stopping")
         stoppedByMaxDuration = true
         await stopRecording()
+    }
+
+    private func clearASRCleanupTask(generation: Int) {
+        if asrCleanupGeneration == generation {
+            asrCleanupTask = nil
+            asrCleanupGeneration = nil
+        }
     }
 
     /// Whether the current session was auto-stopped by max duration limit.
@@ -627,10 +641,14 @@ actor RecognitionSession {
                     // Drain events + disconnect in background so post-teardown can start
                     let evtTask = eventConsumptionTask
                     eventConsumptionTask = nil
-                    Task {
-                        if let evtTask { _ = await withTimeout(.seconds(3)) { await evtTask.value } }
+                    asrCleanupTask?.cancel()
+                    asrCleanupGeneration = myGeneration
+                    asrCleanupTask = Task { [weak self, myGeneration] in
+                        if let evtTask { _ = await self?.withTimeout(.seconds(3)) { await evtTask.value } }
+                        guard !Task.isCancelled else { return }
                         await client.disconnect()
                         DebugFileLogger.log("stop: phase 2 background cleanup done")
+                        await self?.clearASRCleanupTask(generation: myGeneration)
                     }
                     self.asrClient = nil
                 }
@@ -677,12 +695,16 @@ actor RecognitionSession {
                 // Run drain + disconnect in background so LLM can start immediately.
                 DebugFileLogger.log("stop: isFinal received +\(ContinuousClock.now - stopT0)")
                 let evtTask = eventConsumptionTask
-                Task {
+                asrCleanupTask?.cancel()
+                asrCleanupGeneration = myGeneration
+                asrCleanupTask = Task { [weak self, myGeneration] in
                     if let evtTask {
-                        _ = await withTimeout(.seconds(3)) { await evtTask.value }
+                        _ = await self?.withTimeout(.seconds(3)) { await evtTask.value }
                     }
+                    guard !Task.isCancelled else { return }
                     await client.disconnect()
                     DebugFileLogger.log("stop: ASR background cleanup done")
+                    await self?.clearASRCleanupTask(generation: myGeneration)
                 }
             } else {
                 // Non-streaming or isFinal timeout: fall back to full drain.
@@ -1044,11 +1066,15 @@ actor RecognitionSession {
                 speechDetected = true
                 if let cont = firstStreamingTextCont {
                     firstStreamingTextCont = nil
+                    firstStreamingTextTimeoutTask?.cancel()
+                    firstStreamingTextTimeoutTask = nil
                     cont.resume(returning: true)
                 }
             }
             if let cont = finalTranscriptCont, isTranscriptEffectivelyFinal {
                 finalTranscriptCont = nil
+                finalTranscriptTimeoutTask?.cancel()
+                finalTranscriptTimeoutTask = nil
                 cont.resume(returning: transcript.displayText)
             }
             logger.info("Transcript updated: \(transcript.displayText)")
@@ -1067,6 +1093,8 @@ actor RecognitionSession {
             // last update the server sent before closing.
             if let cont = finalTranscriptCont {
                 finalTranscriptCont = nil
+                finalTranscriptTimeoutTask?.cancel()
+                finalTranscriptTimeoutTask = nil
                 let text = currentTranscript.displayText
                 DebugFileLogger.log("stop: .completed resumed finalTranscriptCont (\(text.count) chars)")
                 cont.resume(returning: text.isEmpty ? nil : text)
@@ -1310,14 +1338,29 @@ actor RecognitionSession {
             return currentTranscript.displayText
         }
         return await withCheckedContinuation { continuation in
+            self.finalTranscriptTimeoutTask?.cancel()
             self.finalTranscriptCont = continuation
-            Task {
+            self.finalTranscriptTimeoutTask = Task { [weak self] in
                 try? await Task.sleep(for: timeout)
-                if let cont = self.finalTranscriptCont {
-                    self.finalTranscriptCont = nil
-                    cont.resume(returning: nil)
-                }
+                guard let self, !Task.isCancelled else { return }
+                await self.resumeFinalTranscriptOnTimeout()
             }
+        }
+    }
+
+    private func resumeFinalTranscriptOnTimeout() {
+        if let cont = finalTranscriptCont {
+            finalTranscriptCont = nil
+            finalTranscriptTimeoutTask = nil
+            cont.resume(returning: nil)
+        }
+    }
+
+    private func resumeFirstStreamingTextOnTimeout() {
+        if let cont = firstStreamingTextCont {
+            firstStreamingTextCont = nil
+            firstStreamingTextTimeoutTask = nil
+            cont.resume(returning: false)
         }
     }
 
@@ -1339,13 +1382,12 @@ actor RecognitionSession {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if !text.isEmpty { return true }
         return await withCheckedContinuation { continuation in
+            self.firstStreamingTextTimeoutTask?.cancel()
             self.firstStreamingTextCont = continuation
-            Task {
+            self.firstStreamingTextTimeoutTask = Task { [weak self] in
                 try? await Task.sleep(for: timeout)
-                if let cont = self.firstStreamingTextCont {
-                    self.firstStreamingTextCont = nil
-                    cont.resume(returning: false)
-                }
+                guard let self, !Task.isCancelled else { return }
+                await self.resumeFirstStreamingTextOnTimeout()
             }
         }
     }
@@ -1465,16 +1507,23 @@ actor RecognitionSession {
 
         if let cont = firstStreamingTextCont {
             firstStreamingTextCont = nil
+            firstStreamingTextTimeoutTask?.cancel()
+            firstStreamingTextTimeoutTask = nil
             cont.resume(returning: false)
         }
         if let cont = finalTranscriptCont {
             finalTranscriptCont = nil
+            finalTranscriptTimeoutTask?.cancel()
+            finalTranscriptTimeoutTask = nil
             cont.resume(returning: nil)
         }
         eventConsumptionTask?.cancel()
         eventConsumptionTask = nil
         maxDurationTask?.cancel()
         maxDurationTask = nil
+        asrCleanupTask?.cancel()
+        asrCleanupTask = nil
+        asrCleanupGeneration = nil
         resetSpeculativeLLM()
 
         audioEngine.stop()

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -1199,10 +1199,18 @@ actor RecognitionSession {
 
     // MARK: - Speculative LLM
 
+    private var isSpeculativeLLMEnabled: Bool {
+        if let override = UserDefaults.standard.object(forKey: "tf_enableSpeculativeLLM") as? Bool {
+            return override
+        }
+        return !KeychainService.selectedLLMProvider.isLocal
+    }
+
     /// Debounce: after each transcript update, wait 800ms of silence before
     /// speculatively sending current text to LLM. If the user is still
     /// speaking, the timer resets.
     private func scheduleSpeculativeLLM() {
+        guard isSpeculativeLLMEnabled else { return }
         #if HAS_CLOUD_SUBSCRIPTION
         if isCloudMode { return }
         #endif

--- a/docs/local-fork-maintenance.md
+++ b/docs/local-fork-maintenance.md
@@ -1,0 +1,146 @@
+# Type4Me Local Fork Maintenance
+
+This fork carries Mac-local fixes that are useful before they are accepted
+upstream. The goals are:
+
+- keep the local Apple Silicon ASR path stable for daily use;
+- avoid high sustained load from speculative LLM calls while recording;
+- keep patches small enough to submit upstream as focused PRs.
+
+## Current Patch Set
+
+### Qwen3-ASR memory control
+
+Source: `qwen3-asr-server/server.py`
+
+This patch is based on upstream PR #157 and addresses memory growth during
+long SenseVoice + Qwen3 sessions:
+
+- store audio as `bytearray` instead of `list[int]`;
+- cap partial windows to 20 seconds;
+- decode PCM16 with `numpy.frombuffer`;
+- call MLX cache cleanup after each ASR/LLM inference;
+- set an MLX cache limit when the installed MLX exposes the API.
+
+Runtime expectation: the Qwen3-ASR helper should idle around hundreds of MB
+and should not grow monotonically into multi-GB RSS during long dictation.
+
+### Disable recording-time speculative LLM by default
+
+Source: `Type4Me/Session/RecognitionSession.swift`
+
+The upstream app speculatively calls the configured LLM during recording when
+streaming ASR emits partial transcript updates. This reduces stop-time latency
+for fast cloud LLMs, but it is expensive for local large models. On a local
+Qwen3.6 35B endpoint it repeatedly wakes the model, cancels in-flight requests,
+and causes high sustained power draw before the user finishes speaking.
+
+This fork adds a `tf_enableSpeculativeLLM` override. When the key is not set,
+speculative LLM remains enabled for cloud providers and is disabled for local
+LLM providers such as Ollama. Final post-processing after the user stops
+recording is unchanged.
+
+To explicitly re-enable it for fast local or small-model setups:
+
+```bash
+defaults write com.type4me.localfixed tf_enableSpeculativeLLM -bool true
+```
+
+To explicitly disable it again:
+
+```bash
+defaults write com.type4me.localfixed tf_enableSpeculativeLLM -bool false
+```
+
+## Local Build Notes
+
+The public source tree does not include `Frameworks/sherpa-onnx.xcframework`.
+Without that framework the Swift target builds without `HAS_SHERPA_ONNX`, and
+the local SenseVoice provider will show as unsupported.
+
+For a true source-built local app, first build or provide the framework:
+
+```bash
+cd /path/to/type4me
+bash scripts/build-sherpa.sh
+```
+
+Then package the local variant:
+
+```bash
+VARIANT=local \
+ARCH=arm64 \
+APP_BUNDLE_ID=com.type4me.localfixed \
+APP_PATH="$HOME/Applications/Type4Me Local Fixed.app" \
+QWEN3_MODEL_PATH="/Applications/Type4Me.app/Contents/Resources/Models/Qwen3-ASR" \
+bash scripts/package-app.sh
+```
+
+Until the framework is available, the practical local hotfix flow is:
+
+1. copy the installed local DMG app;
+2. change bundle id/name;
+3. replace `qwen3-asr-server-dist/qwen3-asr-server` with a wrapper that runs
+   the patched Python server;
+4. sign the bundle consistently.
+
+## Signing
+
+Ad-hoc signing works for local testing but macOS TCC Accessibility permissions
+can be invalidated whenever the app is modified and re-signed.
+
+Recommended stable options:
+
+- use an Apple Developer ID certificate if this build will be distributed;
+- use a persistent local codesigning certificate for personal builds;
+- keep a fixed install path, currently:
+
+```text
+~/Applications/Type4Me Local Fixed.app
+```
+
+After re-signing, reset and grant Accessibility again if hotkeys stop working:
+
+```bash
+tccutil reset Accessibility com.type4me.localfixed
+open 'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility'
+```
+
+Grant the fixed app path, not `/Applications/Type4Me.app`.
+
+## Verification
+
+Check processes:
+
+```bash
+ps -axo pid,ppid,pcpu,pmem,rss,etime,args \
+  | egrep -i 'Type4Me|qwen3-asr|server.py|omlx' \
+  | egrep -v 'egrep|Codex'
+```
+
+Check for unwanted recording-time LLM calls:
+
+```bash
+tail -f "$HOME/Library/Application Support/Type4Me/debug.log" \
+  | egrep 'speculative LLM|fresh LLM|sync LLM|q3Port|ASR transcript'
+```
+
+Expected after this fork patch:
+
+- no `speculative LLM: firing` lines while recording;
+- exactly one final `fresh LLM` or `sync LLM` call after stop when the selected
+  mode has a prompt;
+- Qwen3-ASR RSS stays bounded over repeated long recordings.
+
+## Upstream PR Plan
+
+Submit small PRs independently:
+
+1. Qwen3-ASR memory fix, based on PR #157 or as a review/continuation.
+2. Add a user/defaults setting for speculative LLM and disable it by default
+   for local LLM providers or large local models.
+3. Optional UI toggle: "Low-latency speculative LLM" vs "Energy-saving final
+   LLM only".
+
+Avoid bundling signing or local wrapper changes in upstream PRs; those are
+local distribution concerns.

--- a/entitlements.plist
+++ b/entitlements.plist
@@ -9,5 +9,7 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
 </dict>
 </plist>

--- a/qwen3-asr-server/server.py
+++ b/qwen3-asr-server/server.py
@@ -13,10 +13,9 @@ Protocol:
 
 import argparse
 import asyncio
-import json
+import gc
 import os
 import socket
-import struct
 import sys
 import time
 from pathlib import Path
@@ -27,6 +26,38 @@ from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 
 import re
 import threading
+
+# MLX Metal cache management to prevent unbounded GPU buffer growth
+# (mlx_qwen3_asr does not free buffers; cache grows several GB per minute
+# when partial transcribe runs every ~1.5s on long audio windows.)
+_mx_clear_cache = None
+_mx_set_cache_limit = None
+try:
+    import mlx.core as _mx
+    # Newer MLX (>=0.31) moved these to top-level; older versions kept
+    # them under mx.metal. Pick whichever exists, preferring top-level.
+    _mx_clear_cache = getattr(_mx, "clear_cache", None) \
+        or getattr(getattr(_mx, "metal", None), "clear_cache", None)
+    _mx_set_cache_limit = getattr(_mx, "set_cache_limit", None) \
+        or getattr(getattr(_mx, "metal", None), "set_cache_limit", None)
+    # Cap GPU buffer cache to ~2GB. Buffers above this are released.
+    if _mx_set_cache_limit is not None:
+        try:
+            _mx_set_cache_limit(2 * 1024 ** 3)
+        except Exception:
+            pass
+except Exception:
+    pass
+
+
+def _release_gpu_memory():
+    """Drop cached Metal buffers and force a Python GC pass."""
+    if _mx_clear_cache is not None:
+        try:
+            _mx_clear_cache()
+        except Exception:
+            pass
+    gc.collect()
 
 
 class CancelToken:
@@ -54,8 +85,9 @@ _hotword_context = ""  # Hotwords as context string for transcribe()
 _inference_lock = threading.Lock()  # Prevent concurrent Metal GPU access (thread-level)
 
 SAMPLE_RATE = 16000
-PARTIAL_INTERVAL_SEC = 1.5  # Run partial transcribe every N seconds of new audio
-MAX_PARTIAL_AUDIO_SEC = 45  # Only use last N seconds for partial (full audio for final)
+PARTIAL_INTERVAL_SEC = 2.0  # Run partial transcribe every N seconds of new audio
+MAX_PARTIAL_AUDIO_SEC = 20  # Only use last N seconds for partial (full audio for final)
+BYTES_PER_SAMPLE = 2  # PCM16-LE
 
 
 def get_session():
@@ -72,10 +104,12 @@ async def websocket_endpoint(ws: WebSocket):
     await ws.accept()
 
     sess = get_session()
-    all_samples: list[int] = []
-    partial_threshold = int(PARTIAL_INTERVAL_SEC * SAMPLE_RATE)
-    max_partial_samples = MAX_PARTIAL_AUDIO_SEC * SAMPLE_RATE
-    last_partial_at = 0  # sample count at last partial
+    # Store raw PCM16-LE bytes (2 bytes/sample). Keeps memory ~14× smaller
+    # than list[int] (28 bytes per Python int) and avoids per-sample boxing.
+    audio_buf = bytearray()
+    partial_threshold_bytes = int(PARTIAL_INTERVAL_SEC * SAMPLE_RATE) * BYTES_PER_SAMPLE
+    max_partial_bytes = MAX_PARTIAL_AUDIO_SEC * SAMPLE_RATE * BYTES_PER_SAMPLE
+    last_partial_at_bytes = 0
     inflight_partial = None  # track running partial task
     cancel_token = CancelToken()  # shared cancellation for in-flight partials
 
@@ -89,8 +123,9 @@ async def websocket_endpoint(ws: WebSocket):
                 if inflight_partial and not inflight_partial.done():
                     inflight_partial.cancel()
 
-                if all_samples:
-                    text = await _transcribe(sess, all_samples, strip_punct=False)
+                if audio_buf:
+                    final_audio = _bytes_to_audio(bytes(audio_buf))
+                    text = await _transcribe(sess, final_audio, strip_punct=False)
                     if text:
                         await ws.send_json({
                             "type": "transcript",
@@ -100,23 +135,22 @@ async def websocket_endpoint(ws: WebSocket):
                 await ws.send_json({"type": "completed"})
                 break
 
-            # Accumulate PCM16 samples
-            sample_count = len(data) // 2
-            samples = list(struct.unpack(f"<{sample_count}h", data))
-            all_samples.extend(samples)
+            # Accumulate raw bytes — no per-sample object allocation
+            audio_buf.extend(data)
 
             # Periodic partial: transcribe without punctuation
-            new_audio = len(all_samples) - last_partial_at
-            if new_audio >= partial_threshold:
+            new_bytes = len(audio_buf) - last_partial_at_bytes
+            if new_bytes >= partial_threshold_bytes:
                 if inflight_partial is None or inflight_partial.done():
-                    last_partial_at = len(all_samples)
+                    last_partial_at_bytes = len(audio_buf)
                     # Cap partial audio to last N seconds to avoid O(total) re-processing
-                    if len(all_samples) > max_partial_samples:
-                        samples_snapshot = list(all_samples[-max_partial_samples:])
+                    if len(audio_buf) > max_partial_bytes:
+                        snapshot = bytes(audio_buf[-max_partial_bytes:])
                     else:
-                        samples_snapshot = list(all_samples)
+                        snapshot = bytes(audio_buf)
+                    partial_audio = _bytes_to_audio(snapshot)
                     inflight_partial = asyncio.ensure_future(
-                        _send_partial(ws, sess, samples_snapshot, cancel_token)
+                        _send_partial(ws, sess, partial_audio, cancel_token)
                     )
 
     except WebSocketDisconnect:
@@ -126,13 +160,17 @@ async def websocket_endpoint(ws: WebSocket):
             await ws.send_json({"type": "error", "message": str(e)})
         except Exception:
             pass
+    finally:
+        # Release session-local audio buffer + cached Metal buffers
+        audio_buf = None
+        _release_gpu_memory()
 
 
-async def _send_partial(ws: WebSocket, sess, samples: list[int],
+async def _send_partial(ws: WebSocket, sess, audio: np.ndarray,
                         cancel_token: CancelToken | None = None):
     """Run transcribe on accumulated audio (no punctuation) and send as partial."""
     try:
-        text = await _transcribe(sess, samples, strip_punct=True,
+        text = await _transcribe(sess, audio, strip_punct=True,
                                  cancel_token=cancel_token)
         if text:
             await ws.send_json({
@@ -148,16 +186,21 @@ async def _send_partial(ws: WebSocket, sess, samples: list[int],
 _PUNCT_RE = re.compile('[，。！？、；：""''…,.!?;:]')
 
 
-async def _transcribe(sess, samples_i16: list[int], strip_punct: bool = False,
+def _bytes_to_audio(pcm: bytes) -> np.ndarray:
+    """Decode PCM16-LE bytes to float32 numpy in [-1, 1]."""
+    return np.frombuffer(pcm, dtype=np.int16).astype(np.float32) / 32768.0
+
+
+async def _transcribe(sess, audio: np.ndarray, strip_punct: bool = False,
                       cancel_token: CancelToken | None = None) -> str:
     """Run offline transcribe on audio samples."""
     loop = asyncio.get_event_loop()
     return await loop.run_in_executor(
-        None, _transcribe_sync, sess, samples_i16, strip_punct, cancel_token
+        None, _transcribe_sync, sess, audio, strip_punct, cancel_token
     )
 
 
-def _transcribe_sync(sess, samples_i16: list[int], strip_punct: bool = False,
+def _transcribe_sync(sess, audio: np.ndarray, strip_punct: bool = False,
                       cancel_token: CancelToken | None = None) -> str:
     """Synchronous transcription. Thread-safe via lock.
 
@@ -169,7 +212,6 @@ def _transcribe_sync(sess, samples_i16: list[int], strip_punct: bool = False,
     with _inference_lock:
         if cancel_token and cancel_token.is_cancelled:
             return ""
-        audio = np.array(samples_i16, dtype=np.float32) / 32768.0
 
         # Guard: skip transcription if audio is too short or silent.
         # Prevents Qwen3 from echoing the hotword list on empty input.
@@ -177,11 +219,16 @@ def _transcribe_sync(sess, samples_i16: list[int], strip_punct: bool = False,
         if len(audio) < min_samples or np.sqrt(np.mean(audio ** 2)) < 1e-4:
             return ""
 
-        result = sess.transcribe(audio, context=_hotword_context)
-        text = result.text.strip() if result and result.text else ""
-        if strip_punct and text:
-            text = _PUNCT_RE.sub("", text)
-        return text
+        try:
+            result = sess.transcribe(audio, context=_hotword_context)
+            text = result.text.strip() if result and result.text else ""
+            if strip_punct and text:
+                text = _PUNCT_RE.sub("", text)
+            return text
+        finally:
+            # Release Metal buffer cache after every transcribe so GPU memory
+            # does not balloon across many partial calls.
+            _release_gpu_memory()
 
 
 @app.post("/transcribe")
@@ -191,10 +238,8 @@ async def transcribe_http(request: Request):
     if len(body) < 100:
         return {"text": ""}
 
-    sample_count = len(body) // 2
-    samples = list(struct.unpack(f"<{sample_count}h", body))
-
-    text = await _transcribe(get_session(), samples, strip_punct=False)
+    audio = _bytes_to_audio(body)
+    text = await _transcribe(get_session(), audio, strip_punct=False)
     return {"text": text}
 
 
@@ -281,11 +326,14 @@ async def chat_completions(request: dict):
         import re
         # Share _inference_lock with ASR to prevent concurrent Metal GPU access
         with _inference_lock:
-            result = llm.create_chat_completion(
-                messages=messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-            )
+            try:
+                result = llm.create_chat_completion(
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                )
+            finally:
+                _release_gpu_memory()
         if result.get("choices"):
             text = result["choices"][0]["message"]["content"]
             text = re.sub(r'<think>.*?</think>\s*', '', text, flags=re.DOTALL).strip()
@@ -336,6 +384,7 @@ def main():
     # Trigger model load with dummy transcription (np.ndarray, no temp file)
     dummy = np.zeros(SAMPLE_RATE, dtype=np.float32)
     sess.transcribe(dummy)
+    _release_gpu_memory()
     elapsed = time.monotonic() - t0
     print(f"Model loaded in {elapsed:.1f}s", flush=True)
 

--- a/qwen3-asr-server/server.py
+++ b/qwen3-asr-server/server.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import numpy as np
 import uvicorn
-from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 
 import re
 import threading
@@ -88,6 +88,8 @@ SAMPLE_RATE = 16000
 PARTIAL_INTERVAL_SEC = 2.0  # Run partial transcribe every N seconds of new audio
 MAX_PARTIAL_AUDIO_SEC = 20  # Only use last N seconds for partial (full audio for final)
 BYTES_PER_SAMPLE = 2  # PCM16-LE
+MAX_HTTP_AUDIO_SEC = 30 * 60
+MAX_HTTP_AUDIO_BYTES = MAX_HTTP_AUDIO_SEC * SAMPLE_RATE * BYTES_PER_SAMPLE
 
 
 def get_session():
@@ -233,8 +235,18 @@ def _transcribe_sync(sess, audio: np.ndarray, strip_punct: bool = False,
 
 @app.post("/transcribe")
 async def transcribe_http(request: Request):
-    """HTTP endpoint for speculative transcription. Accepts raw PCM16-LE audio."""
+    """HTTP endpoint for bounded one-shot transcription. Accepts raw PCM16-LE audio."""
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            if int(content_length) > MAX_HTTP_AUDIO_BYTES:
+                raise HTTPException(status_code=413, detail="audio too large")
+        except ValueError:
+            raise HTTPException(status_code=400, detail="invalid content-length")
+
     body = await request.body()
+    if len(body) > MAX_HTTP_AUDIO_BYTES:
+        raise HTTPException(status_code=413, detail="audio too large")
     if len(body) < 100:
         return {"text": ""}
 

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -19,6 +19,25 @@ INFO_PLIST="$APP_PATH/Contents/Info.plist"
 
 ENTITLEMENTS="$PROJECT_DIR/entitlements.plist"
 
+codesign_file() {
+    local target="$1"
+    shift
+    if [ "$SIGNING_IDENTITY" = "-" ]; then
+        return 0
+    fi
+    codesign --force --options runtime --timestamp --sign "$SIGNING_IDENTITY" "$@" "$target"
+}
+
+codesign_macho_tree() {
+    local root="$1"
+    [ -d "$root" ] || return 0
+    while IFS= read -r f; do
+        if file "$f" | grep -q "Mach-O"; then
+            codesign_file "$f"
+        fi
+    done < <(find "$root" -type f \( -name "*.dylib" -o -name "*.so" -o -perm -111 \))
+}
+
 if [ -n "${CODESIGN_IDENTITY:-}" ]; then
     SIGNING_IDENTITY="$CODESIGN_IDENTITY"
 elif security find-identity -v -p codesigning 2>/dev/null | grep -q "Developer ID Application"; then
@@ -186,13 +205,28 @@ WRAPPER
         chmod +x "$APP_PATH/Contents/MacOS/qwen3-asr-server"
         # Remove .dist-info dirs that confuse codesign's bundle detection
         find "$APP_PATH/Contents/Resources/qwen3-asr-server-dist" -type d -name "*.dist-info" -exec rm -rf {} + 2>/dev/null || true
+        # MLX resolves mlx.metallib relative to libmlx.dylib in some frozen
+        # layouts. Keep a copy next to libmlx.dylib to avoid runtime discovery
+        # failures when PyInstaller places it under mlx/lib/.
+        MLX_METALLIB=$(find "$APP_PATH/Contents/Resources/qwen3-asr-server-dist" -name "mlx.metallib" -type f | head -1 || true)
+        MLX_INTERNAL="$APP_PATH/Contents/Resources/qwen3-asr-server-dist/_internal"
+        if [ -n "$MLX_METALLIB" ] && [ -f "$MLX_INTERNAL/libmlx.dylib" ] && [ ! -f "$MLX_INTERNAL/mlx.metallib" ]; then
+            cp "$MLX_METALLIB" "$MLX_INTERNAL/mlx.metallib"
+        fi
         # Keep mlx.metallib in the bundle.  Even in JIT mode (MLX_METAL_JIT=ON)
         # the small (~2-5MB) metallib is required for MLX initialization.
         # JIT mode ensures the metallib uses only core shaders compatible with
         # macOS 14+; additional kernels are compiled from embedded source at
         # runtime for the host's Metal version.
-        find "$APP_PATH/Contents/Resources/qwen3-asr-server-dist" -type f \( -name "*.dylib" -o -name "*.so" -o -name "*.metallib" -o -perm +111 \) \
-            -exec codesign --force --options runtime --timestamp --sign "${SIGNING_IDENTITY}" {} \; 2>/dev/null || true
+        codesign_macho_tree "$APP_PATH/Contents/Resources/qwen3-asr-server-dist"
+        QWEN3_FROZEN_EXE="$APP_PATH/Contents/Resources/qwen3-asr-server-dist/qwen3-asr-server"
+        if [ -f "$QWEN3_FROZEN_EXE" ]; then
+            QWEN3_EXE_SIGN_ARGS=()
+            if [ -f "$ENTITLEMENTS" ]; then
+                QWEN3_EXE_SIGN_ARGS+=(--entitlements "$ENTITLEMENTS")
+            fi
+            codesign_file "$QWEN3_FROZEN_EXE" "${QWEN3_EXE_SIGN_ARGS[@]}"
+        fi
         echo "qwen3-asr-server bundled and signed."
     else
         echo "WARNING: qwen3-asr-server dist not found at $QWEN3_DIST (Qwen3 calibration will be unavailable)"
@@ -224,11 +258,25 @@ if [ "$NEEDS_SIGN" = "1" ]; then
     find "$APP_PATH/Contents/Frameworks" \
         -type f \( -name "*.dylib" -o -name "*.so" -o -name "*.framework" \) \
         -exec codesign --force --options runtime --timestamp --sign "$SIGNING_IDENTITY" {} \; 2>/dev/null || true
+    codesign_macho_tree "$APP_PATH/Contents/Resources/qwen3-asr-server-dist"
 
     # Sign the wrapper script in Contents/MacOS
     Q3_WRAPPER="$APP_PATH/Contents/MacOS/qwen3-asr-server"
     if [ -f "$Q3_WRAPPER" ]; then
-        codesign --force --options runtime --timestamp --sign "$SIGNING_IDENTITY" "$Q3_WRAPPER"
+        Q3_WRAPPER_SIGN_ARGS=()
+        if [ -f "$ENTITLEMENTS" ]; then
+            Q3_WRAPPER_SIGN_ARGS+=(--entitlements "$ENTITLEMENTS")
+        fi
+        codesign_file "$Q3_WRAPPER" "${Q3_WRAPPER_SIGN_ARGS[@]}"
+    fi
+
+    Q3_FROZEN_EXE="$APP_PATH/Contents/Resources/qwen3-asr-server-dist/qwen3-asr-server"
+    if [ -f "$Q3_FROZEN_EXE" ]; then
+        Q3_FROZEN_SIGN_ARGS=()
+        if [ -f "$ENTITLEMENTS" ]; then
+            Q3_FROZEN_SIGN_ARGS+=(--entitlements "$ENTITLEMENTS")
+        fi
+        codesign_file "$Q3_FROZEN_EXE" "${Q3_FROZEN_SIGN_ARGS[@]}"
     fi
 
     # Sign the main app bundle with hardened runtime + entitlements

--- a/scripts/package-local-app.sh
+++ b/scripts/package-local-app.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && /bin/pwd -P)"
+APP_PATH="${APP_PATH:-/Applications/Type4Me.app}"
+APP_BUNDLE_ID="${APP_BUNDLE_ID:-com.type4me.localfixed}"
+APP_VERSION="${APP_VERSION:-1.9.3-local}"
+APP_BUILD="${APP_BUILD:-2}"
+CODESIGN_IDENTITY="${CODESIGN_IDENTITY:-Type4Me Local Dev}"
+ARCH="${ARCH:-arm64}"
+SKIP_QWEN3_BUILD="${SKIP_QWEN3_BUILD:-1}"
+
+DEFAULT_BUNDLED_QWEN3="/Applications/Type4Me.app/Contents/Resources/Models/Qwen3-ASR"
+DEFAULT_CACHE_QWEN3="$HOME/.cache/modelscope/hub/models/Qwen/Qwen3-ASR-0.6B-4bit"
+if [ -n "${QWEN3_MODEL_PATH:-}" ]; then
+    :
+elif [ -d "$DEFAULT_BUNDLED_QWEN3" ]; then
+    QWEN3_MODEL_PATH="$DEFAULT_BUNDLED_QWEN3"
+elif [ -d "$DEFAULT_CACHE_QWEN3" ]; then
+    QWEN3_MODEL_PATH="$DEFAULT_CACHE_QWEN3"
+else
+    echo "ERROR: Qwen3-ASR model not found. Set QWEN3_MODEL_PATH=/path/to/Qwen3-ASR" >&2
+    exit 1
+fi
+
+if [ ! -d "$PROJECT_DIR/Frameworks/sherpa-onnx.xcframework" ]; then
+    echo "sherpa-onnx.xcframework not found; building it first..."
+    bash "$PROJECT_DIR/scripts/build-sherpa.sh"
+fi
+
+if [ "$SKIP_QWEN3_BUILD" != "1" ] || [ ! -d "$PROJECT_DIR/qwen3-asr-server/dist/qwen3-asr-server" ]; then
+    bash "$PROJECT_DIR/qwen3-asr-server/build.sh"
+fi
+
+osascript -e 'quit app "Type4Me"' 2>/dev/null || true
+pkill -f '/Applications/Type4Me.app/Contents/MacOS/Type4Me' 2>/dev/null || true
+pkill -f 'qwen3-asr-server' 2>/dev/null || true
+sleep 2
+
+APP_PATH="$APP_PATH" \
+APP_BUNDLE_ID="$APP_BUNDLE_ID" \
+APP_VERSION="$APP_VERSION" \
+APP_BUILD="$APP_BUILD" \
+VARIANT=local \
+ARCH="$ARCH" \
+CODESIGN_IDENTITY="$CODESIGN_IDENTITY" \
+SKIP_QWEN3_BUILD="$SKIP_QWEN3_BUILD" \
+QWEN3_MODEL_PATH="$QWEN3_MODEL_PATH" \
+bash "$PROJECT_DIR/scripts/package-app.sh"
+
+xattr -dr com.apple.quarantine "$APP_PATH" 2>/dev/null || true
+
+MODEL="$APP_PATH/Contents/Resources/Models/Qwen3-ASR"
+HOTWORDS="$HOME/Library/Application Support/Type4Me/hotwords.txt"
+LOG="${TMPDIR:-/tmp}/type4me-qwen3-smoke.log"
+rm -f "$LOG"
+"$APP_PATH/Contents/MacOS/qwen3-asr-server" --model-path "$MODEL" --port 0 --hotwords-file "$HOTWORDS" >"$LOG" 2>&1 &
+PID=$!
+for _ in {1..60}; do
+    if grep -q "PORT:" "$LOG" 2>/dev/null; then
+        break
+    fi
+    if grep -qE "ERROR|Traceback|Failed" "$LOG" 2>/dev/null; then
+        cat "$LOG"
+        kill "$PID" 2>/dev/null || true
+        wait "$PID" 2>/dev/null || true
+        exit 1
+    fi
+    sleep 1
+done
+
+if ! grep -q "PORT:" "$LOG" 2>/dev/null; then
+    cat "$LOG" 2>/dev/null || true
+    kill "$PID" 2>/dev/null || true
+    wait "$PID" 2>/dev/null || true
+    echo "ERROR: Qwen3-ASR smoke test timed out" >&2
+    exit 1
+fi
+
+cat "$LOG"
+kill "$PID" 2>/dev/null || true
+wait "$PID" 2>/dev/null || true
+
+defaults write "$APP_BUNDLE_ID" tf_qwen3FinalEnabled -bool true
+open -n "$APP_PATH"
+echo "Local Type4Me app installed at $APP_PATH"


### PR DESCRIPTION
## Summary

This draft PR contains three Mac-local stability fixes:

- bound Qwen3-ASR memory growth during long local sessions;
- avoid repeated speculative LLM calls while recording when the selected LLM provider is local;
- serialize local Qwen3-ASR server restarts so hotword updates do not leave multiple helper processes running.

## Why

During long dictation with SenseVoice + Qwen3-ASR, the helper process can grow memory quickly because partial transcription repeatedly allocates Python sample lists and MLX/Metal buffers are not released promptly.

Separately, streaming ASR currently schedules speculative LLM requests during recording. This helps hide latency for fast cloud LLMs, but it is expensive for local LLM providers such as Ollama/OpenAI-compatible local endpoints: long recordings repeatedly wake the local model, cancel in-flight requests, and create sustained power/thermal load before the user stops speaking.

A third issue appears around hotword updates: multiple Qwen3 restarts can overlap, and stale termination handlers can race with newer processes. This can leave several idle Qwen3-ASR helper processes listening on different local ports, each holding hundreds of MB of memory.

## Changes

- Store Qwen3-ASR audio as raw `bytearray` instead of `list[int]`.
- Cap partial transcription to the latest 20 seconds.
- Decode PCM16 with `numpy.frombuffer`.
- Clear MLX cache and run Python GC after ASR/LLM inference.
- Add `tf_enableSpeculativeLLM` as an explicit override.
- If the override is absent, keep speculative LLM enabled for cloud providers and disable it for local LLM providers.
- Serialize Qwen3 startup/restart attempts.
- Ignore stale Qwen3 termination callbacks from old processes.
- Debounce hotword-triggered Qwen3 restarts.
- Add local fork maintenance notes with verification and signing guidance.

## Validation

- `swift build -c debug --package-path /tmp/type4me --arch arm64`
- Local patched app: Qwen3-ASR helper idles around ~700 MB after repeated use instead of growing monotonically into multi-GB RSS.
- Local patched app: recording no longer emits `speculative LLM: firing` log lines after disabling the scheduling path; final post-stop LLM processing still works.
- Local patched app: after cleaning duplicate helpers, restart returns to one Type4Me main process and one Qwen3-ASR helper process.

## Notes

This is marked draft because the speculative LLM setting may deserve a visible UI toggle, and the Qwen3-ASR memory fix overlaps with upstream PR #157.
