### PR TITLE
feat: thinking mode toggle

### DIFF
--- a/Type4Me/LLM/DoubaoChatClient.swift
+++ b/Type4Me/LLM/DoubaoChatClient.swift
@@ -48,7 +48,15 @@ actor DoubaoChatClient: LLMClient {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = 30
 
-        let disableField = provider.thinkingDisableField
+        // tf_disableThinking: true (default) = disable thinking to save tokens;
+        // false = let the model use its default thinking behavior.
+        let disableThinking: Bool = {
+            guard let obj = UserDefaults.standard.object(forKey: "tf_disableThinking") else {
+                return true  // default: thinking disabled
+            }
+            return obj as? Bool ?? true
+        }()
+        let disableField = disableThinking ? provider.thinkingDisableField : nil
         let body = ChatRequest(
             model: config.model,
             messages: [ChatMessage(role: "user", content: finalPrompt)],

--- a/Type4Me/UI/Settings/LLMSettingsCard.swift
+++ b/Type4Me/UI/Settings/LLMSettingsCard.swift
@@ -16,6 +16,9 @@ struct LLMSettingsCard: View, SettingsCardHelpers {
     @State private var testTask: Task<Void, Never>?
     /// Tracks which credential fields are in "custom input" mode (value not in preset options).
     @State private var customModeFields: Set<String> = []
+    @State private var disableThinking: Bool = UserDefaults.standard.object(forKey: "tf_disableThinking") == nil
+        ? true
+        : UserDefaults.standard.bool(forKey: "tf_disableThinking")
 
     private var currentLLMFields: [CredentialField] {
         LLMProviderRegistry.configType(for: selectedLLMProvider)?.credentialFields ?? []
@@ -49,6 +52,26 @@ struct LLMSettingsCard: View, SettingsCardHelpers {
                 credentialSummaryCard(rows: llmSummaryRows)
             } else {
                 dynamicCredentialFields
+            }
+
+            SettingsDivider()
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(L("禁用思考模式", "Disable Thinking"))
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(TF.settingsText)
+                    Text(L("关闭后可节省 token 并加快响应", "Off saves tokens and speeds up response"))
+                        .font(.system(size: 10))
+                        .foregroundStyle(TF.settingsTextTertiary)
+                }
+                Spacer()
+                Toggle("", isOn: $disableThinking)
+                    .toggleStyle(.switch)
+                    .labelsHidden()
+                    .controlSize(.small)
+                    .onChange(of: disableThinking) { _, newValue in
+                        UserDefaults.standard.set(newValue, forKey: "tf_disableThinking")
+                    }
             }
 
             HStack(spacing: 8) {


### PR DESCRIPTION
## Summary

Add a toggle in LLM settings to enable/disable thinking/reasoning mode. When disabled, the request omits thinking parameters, saving tokens on providers that support it (Doubao, Kimi, DeepSeek, Bailian/Qwen, Zhipu/GLM, Ollama).

## Changes

- `LLMProvider.swift` — add `thinkingDisableField` property per provider
- `LLMSettingsCard.swift` — add toggle switch in the LLM settings card
- `DoubaoChatClient.swift` / `ClaudeChatClient.swift` — respect the disable flag when building API requests

## Test plan

- [ ] Open Settings → LLM, verify toggle appears
- [ ] Enable toggle → confirm API request does not include thinking parameters
- [ ] Disable toggle → confirm thinking parameters are included (default behavior)