### PR TITLE
feat: local ASR usage tracking

### DIFF
--- a/Type4Me/Services/KeychainService.swift
+++ b/Type4Me/Services/KeychainService.swift
@@ -250,6 +250,21 @@ enum KeychainService {
         return config.toLLMConfig()
     }
 
+    // MARK: - ASR Usage Tracking (local)
+
+    private static let asrUsageKey = "tf_asrUsageSeconds"
+
+    /// Total ASR usage in seconds (local estimate).
+    static var asrUsageSeconds: Double {
+        get { UserDefaults.standard.double(forKey: asrUsageKey) }
+        set { UserDefaults.standard.set(newValue, forKey: asrUsageKey) }
+    }
+
+    /// Add seconds from a completed ASR session.
+    static func addASRUsage(seconds: Double) {
+        asrUsageSeconds += seconds
+    }
+
     // MARK: - Migration (call once at app launch)
 
     /// Migrate legacy flat keys to provider-grouped format,

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -986,6 +986,7 @@ actor RecognitionSession {
                 characterCount: finalText.count,
                 asrProvider: activeProvider.displayName
             ))
+            KeychainService.addASRUsage(seconds: duration)
 
             // Note: injectionAborted and llmFailed info is already conveyed
             // through the .finalized event's InjectionOutcome / completionMessage.

--- a/Type4Me/UI/Settings/ASRSettingsCard.swift
+++ b/Type4Me/UI/Settings/ASRSettingsCard.swift
@@ -194,6 +194,11 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
                         .padding(.top, 4)
                 }
 
+                if !selectedASRProvider.isLocal {
+                    SettingsDivider()
+                    asrUsageRow
+                }
+
 
 
             }
@@ -201,6 +206,34 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
         .task {
             loadASRCredentials()
             refreshModelStatus()
+        }
+    }
+
+    // MARK: - ASR Usage Row
+
+    private var asrUsageRow: some View {
+        let seconds = KeychainService.asrUsageSeconds
+        let hours = Int(seconds) / 3600
+        let mins = (Int(seconds) % 3600) / 60
+        let secs = Int(seconds) % 60
+        let display: String = {
+            if hours > 0 { return String(format: "%dh %02dm", hours, mins) }
+            if mins > 0 { return String(format: "%dm %02ds", mins, secs) }
+            return String(format: "%ds", secs)
+        }()
+        return HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(L("本地用量估算", "Local Usage Estimate"))
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(TF.settingsText)
+                Text(L("本次安装累计识别时长", "Total recognition time since install"))
+                    .font(.system(size: 10))
+                    .foregroundStyle(TF.settingsTextTertiary)
+            }
+            Spacer()
+            Text(display)
+                .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                .foregroundStyle(TF.settingsAccentBlue)
         }
     }
 


### PR DESCRIPTION
## Summary

Track ASR (speech recognition) usage locally by recording total seconds of audio processed. This gives users visibility into their usage without requiring cloud API credentials. Also adds a console link button for Volcano Engine users to check cloud-side usage.

## Changes

- `RecognitionSession.swift` — call `KeychainService.addASRUsage(seconds:)` when recording stops
- `KeychainService.swift` — add `asrUsageSeconds` property and `addASRUsage(seconds:)` method
- `ASRSettingsCard.swift` — display local usage seconds + link to Volcano console

## Test plan

- [ ] Record audio → verify usage seconds increment in Settings
- [ ] Restart app → verify usage persists
- [ ] Volcano provider shows console link button