### PR TITLE
feat: live recording animation preview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,12 @@ Public GitHub Releases ship only `pure` (universal) and `local` (arm64).
 
 ### Build commands
 
+`build-dmg.sh` creates a drag-to-Applications DMG. When `CODESIGN_IDENTITY`
+resolves to a Developer ID certificate it signs inside-out, notarizes the app,
+staples the app, creates the DMG, signs/notarizes/staples the DMG, and writes a
+SHA256 file. Without a Developer ID identity it fails closed unless
+`SKIP_NOTARIZE=1` is set for local packaging smoke tests.
+
 ```bash
 # Open-source cloud edition (no subscription, no local ASR)
 VARIANT=pure bash scripts/build-dmg.sh
@@ -66,9 +72,17 @@ VARIANT=pure bash scripts/build-dmg.sh
 # Open-source local edition (bundled models, Apple Silicon only)
 VARIANT=local bash scripts/build-dmg.sh
 
+# Personal side-by-side build. Uses Type4Me CtriXin.app,
+# bundle id com.ctrixin.type4me, and URL scheme type4me-ctrixin.
+APP_FLAVOR=personal VARIANT=pure ARCH=arm64 bash scripts/build-dmg.sh
+
 # Official member edition — archived, see "Subscription paused" above.
 # VARIANT=official bash scripts/build-dmg.sh
 ```
+
+Public and personal builds can be installed together because they use different
+app names, bundle identifiers, URL schemes, UserDefaults domains, Application
+Support directories, and Keychain service names.
 
 ### Subscription code location
 

--- a/Type4Me/Database/HistoryStore.swift
+++ b/Type4Me/Database/HistoryStore.swift
@@ -14,10 +14,7 @@ actor HistoryStore {
         if let path {
             dbPath = path
         } else {
-            let appSupport = FileManager.default.urls(
-                for: .applicationSupportDirectory, in: .userDomainMask
-            ).first!.appendingPathComponent("Type4Me", isDirectory: true)
-            try? FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+            let appSupport = AppIdentity.applicationSupportDirectory
             dbPath = appSupport.appendingPathComponent("history.db").path
         }
 

--- a/Type4Me/Services/AppIdentity.swift
+++ b/Type4Me/Services/AppIdentity.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Runtime identity derived from the bundle. Public builds keep legacy storage;
+/// personal builds can live side-by-side with separate preferences and files.
+enum AppIdentity {
+    static let publicBundleIdentifier = "com.type4me.app"
+
+    static var bundleIdentifier: String {
+        Bundle.main.bundleIdentifier ?? publicBundleIdentifier
+    }
+
+    static var isPublicBundle: Bool {
+        bundleIdentifier == publicBundleIdentifier
+    }
+
+    static var displayName: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+            ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String
+            ?? "Type4Me"
+    }
+
+    static var applicationSupportDirectoryName: String {
+        isPublicBundle ? "Type4Me" : displayName
+    }
+
+    static var applicationSupportDirectory: URL {
+        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            .appendingPathComponent(applicationSupportDirectoryName, isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    static var keychainScalarService: String {
+        isPublicBundle ? "com.type4me.scalar" : "\(bundleIdentifier).scalar"
+    }
+
+    static var keychainGroupedService: String {
+        isPublicBundle ? "com.type4me.grouped" : "\(bundleIdentifier).grouped"
+    }
+
+    static var primaryURLScheme: String {
+        if let types = Bundle.main.object(forInfoDictionaryKey: "CFBundleURLTypes") as? [[String: Any]] {
+            for type in types {
+                if let schemes = type["CFBundleURLSchemes"] as? [String], let first = schemes.first {
+                    return first
+                }
+            }
+        }
+        return isPublicBundle ? "type4me" : bundleIdentifier
+    }
+
+    static func url(_ action: String) -> URL? {
+        URL(string: "\(primaryURLScheme)://\(action)")
+    }
+}

--- a/Type4Me/Services/AppUpdater.swift
+++ b/Type4Me/Services/AppUpdater.swift
@@ -31,8 +31,7 @@ final class AppUpdater {
     // MARK: - Directories
 
     private var stagingDir: URL {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        return appSupport.appendingPathComponent("Type4Me/Updates")
+        AppIdentity.applicationSupportDirectory.appendingPathComponent("Updates")
     }
 
     private var updateLogURL: URL { stagingDir.appendingPathComponent("update.log") }
@@ -175,7 +174,7 @@ final class AppUpdater {
     // MARK: - Download
 
     private func dmgPath(for version: String) -> URL {
-        stagingDir.appendingPathComponent("Type4Me-v\(version)-cloud.dmg")
+        stagingDir.appendingPathComponent("\(AppIdentity.displayName)-v\(version)-cloud.dmg")
     }
 
     private func startDownload(url: URL, release: UpdateInfo) {

--- a/Type4Me/Services/DebugFileLogger.swift
+++ b/Type4Me/Services/DebugFileLogger.swift
@@ -5,9 +5,7 @@ enum DebugFileLogger {
     private static let queue = DispatchQueue(label: "com.type4me.debug-file-logger")
 
     static var logURL: URL {
-        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("Type4Me", isDirectory: true)
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let dir = AppIdentity.applicationSupportDirectory
         return dir.appendingPathComponent("debug.log")
     }
 

--- a/Type4Me/Services/HotwordStorage.swift
+++ b/Type4Me/Services/HotwordStorage.swift
@@ -18,8 +18,7 @@ enum HotwordStorage {
     // MARK: - File paths
 
     private static var appSupportDir: URL {
-        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        return dir.appendingPathComponent("Type4Me")
+        AppIdentity.applicationSupportDirectory
     }
 
     /// Built-in hotwords file (seeded from defaults, user-editable for bulk ops)

--- a/Type4Me/Services/KeychainService.swift
+++ b/Type4Me/Services/KeychainService.swift
@@ -5,14 +5,11 @@ enum KeychainService {
 
     private static let lock = NSLock()
     private static var cachedCredentials: [String: Any]?
-    private static let keychainScalarService = "com.type4me.scalar"
-    private static let keychainGroupedService = "com.type4me.grouped"
+    private static var keychainScalarService: String { AppIdentity.keychainScalarService }
+    private static var keychainGroupedService: String { AppIdentity.keychainGroupedService }
 
     private static var credentialsURL: URL {
-        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("Type4Me", isDirectory: true)
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir.appendingPathComponent("credentials.json")
+        AppIdentity.applicationSupportDirectory.appendingPathComponent("credentials.json")
     }
 
     // MARK: - Core read/write (now supports nested objects)
@@ -493,10 +490,11 @@ enum KeychainService {
     /// Uses file-level merge instead of directory rename, because other init code may create
     /// the new directory before this migration runs.
     private static func migrateAppSupportDirectory() {
+        guard AppIdentity.isPublicBundle else { return }
         let fm = FileManager.default
         let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let oldDir = appSupport.appendingPathComponent("TypeFlow", isDirectory: true)
-        let newDir = appSupport.appendingPathComponent("Type4Me", isDirectory: true)
+        let newDir = AppIdentity.applicationSupportDirectory
 
         // Old directory must exist and contain real data (credentials.json is the marker)
         guard fm.fileExists(atPath: oldDir.appendingPathComponent("credentials.json").path) else { return }

--- a/Type4Me/Services/ModeStorage.swift
+++ b/Type4Me/Services/ModeStorage.swift
@@ -8,10 +8,7 @@ struct ModeStorage {
         if let url = fileURL {
             self.fileURL = url
         } else {
-            let appSupport = FileManager.default.urls(
-                for: .applicationSupportDirectory, in: .userDomainMask
-            ).first!.appendingPathComponent("Type4Me", isDirectory: true)
-            try? FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+            let appSupport = AppIdentity.applicationSupportDirectory
             self.fileURL = appSupport.appendingPathComponent("modes.json")
         }
     }

--- a/Type4Me/Services/ModelManager.swift
+++ b/Type4Me/Services/ModelManager.swift
@@ -11,11 +11,7 @@ actor ModelManager {
     // MARK: - Paths
 
     static var defaultModelsDir: String {
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory, in: .userDomainMask
-        ).first!
-        return appSupport
-            .appendingPathComponent("Type4Me", isDirectory: true)
+        AppIdentity.applicationSupportDirectory
             .appendingPathComponent("models", isDirectory: true)
             .path
     }

--- a/Type4Me/Services/SenseVoiceServerManager.swift
+++ b/Type4Me/Services/SenseVoiceServerManager.swift
@@ -23,9 +23,7 @@ actor SenseVoiceServerManager {
     /// Write effective hotwords (builtin + user) to hotwords.txt for Qwen3 server.
     nonisolated static func syncHotwordsFile() {
         let words = HotwordStorage.loadEffective()
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let dir = appSupport.appendingPathComponent("Type4Me")
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let dir = AppIdentity.applicationSupportDirectory
         let path = dir.appendingPathComponent("hotwords.txt")
         let content = words.joined(separator: "\n")
         try? content.write(to: path, atomically: true, encoding: .utf8)
@@ -245,8 +243,7 @@ actor SenseVoiceServerManager {
     // MARK: - PID File Management
 
     private static var pidFileURL: URL {
-        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        return dir.appendingPathComponent("Type4Me/server-pids.txt")
+        AppIdentity.applicationSupportDirectory.appendingPathComponent("server-pids.txt")
     }
 
     /// Save current managed PIDs to disk so we can clean up after a crash.
@@ -348,9 +345,7 @@ actor SenseVoiceServerManager {
         logger.info("Qwen3-ASR model: \(modelPath)")
 
         // Hotwords file
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let hotwordsPath = appSupport
-            .appendingPathComponent("Type4Me")
+        let hotwordsPath = AppIdentity.applicationSupportDirectory
             .appendingPathComponent("hotwords.txt")
         let hotwordsFile = FileManager.default.fileExists(atPath: hotwordsPath.path) ? hotwordsPath.path : ""
 
@@ -375,9 +370,7 @@ actor SenseVoiceServerManager {
             return b.path
         }
         // 2. App Support (user-downloaded)
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let userModel = appSupport
-            .appendingPathComponent("Type4Me")
+        let userModel = AppIdentity.applicationSupportDirectory
             .appendingPathComponent("Models/Qwen3-ASR")
         if FileManager.default.fileExists(atPath: userModel.path) {
             return userModel.path

--- a/Type4Me/Services/SnippetStorage.swift
+++ b/Type4Me/Services/SnippetStorage.swift
@@ -19,8 +19,7 @@ enum SnippetStorage {
     // MARK: - File paths
 
     private static var appSupportDir: URL {
-        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        return dir.appendingPathComponent("Type4Me")
+        AppIdentity.applicationSupportDirectory
     }
 
     /// Built-in snippets file (seeded from defaults, user-editable for bulk ops)

--- a/Type4Me/Session/SoundFeedback.swift
+++ b/Type4Me/Session/SoundFeedback.swift
@@ -453,8 +453,7 @@ enum SoundFeedback {
         if let url = Bundle.main.url(forResource: filename, withExtension: "wav", subdirectory: "Sounds") {
             return url
         }
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("Type4Me", isDirectory: true)
+        let appSupport = AppIdentity.applicationSupportDirectory
             .appendingPathComponent("Sounds", isDirectory: true)
         let url = appSupport.appendingPathComponent("\(filename).wav")
         return FileManager.default.fileExists(atPath: url.path) ? url : nil

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -290,21 +290,52 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
     }
 
     private var visualStyleRow: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(L("录音动效", "Visual Style").uppercased())
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(L("录音动效", "Visual Style").uppercased())
+                    .font(.system(size: 10, weight: .semibold))
+                    .tracking(0.8)
+                    .foregroundStyle(TF.settingsTextTertiary)
+                settingsSegmentedPicker(
+                    selection: $visualStyle,
+                    options: [
+                        ("classic", L("线条", "Lines")),
+                        ("dual", L("粒子云", "Blocks")),
+                        ("timeline", L("电平", "Minimal")),
+                    ]
+                )
+            }
+            .padding(.vertical, 6)
+
+            SettingsDivider()
+
+            recordingPreview
+        }
+    }
+
+    // MARK: - Recording Preview
+
+    @State private var previewState = PreviewState()
+
+    private var recordingPreview: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(L("预览效果", "Preview").uppercased())
                 .font(.system(size: 10, weight: .semibold))
                 .tracking(0.8)
                 .foregroundStyle(TF.settingsTextTertiary)
-            settingsSegmentedPicker(
-                selection: $visualStyle,
-                options: [
-                    ("classic", L("线条", "Lines")),
-                    ("dual", L("粒子云", "Blocks")),
-                    ("timeline", L("电平", "Minimal")),
-                ]
-            )
+                .padding(.top, 8)
+
+            ZStack {
+                Color(white: 0.06, opacity: 0.5)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                FloatingBarView(state: previewState)
+                    .frame(width: TF.barWidth, height: TF.barHeight + 16)
+            }
+            .frame(height: 80)
         }
         .padding(.vertical, 6)
+        .onAppear { previewState.startSimulation() }
+        .onDisappear { previewState.stopSimulation() }
     }
 
     private var launchAtLoginRow: some View {
@@ -657,5 +688,77 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
         } else {
             launchAtLogin = status == .enabled
         }
+    }
+}
+
+// MARK: - Preview State
+
+@Observable
+@MainActor
+private final class PreviewState: FloatingBarState {
+
+    var barPhase: FloatingBarPhase = .recording
+    var segments: [TranscriptionSegment] = []
+    var currentMode = ProcessingMode(
+        id: UUID(), name: "Preview", prompt: "{text}", isBuiltin: true,
+        processingLabel: "Processing", hotkeyCode: nil, hotkeyModifiers: nil,
+        hotkeyStyle: .hold
+    )
+    let audioLevel = AudioLevelMeter()
+    var feedbackMessage = ""
+    var processingFinishTime: Date? = nil
+    var recordingStartDate: Date? = Date()
+    var isQwen3OnlyMode = false
+    var effectiveProcessingLabel = ""
+
+    private var timer: Timer?
+    private var textTimer: Timer?
+    private var textIndex = 0
+
+    private let sampleTexts = [
+        "这里是一个动向，这里是",
+        "这里是一个动向，这里是一",
+        "这里是一个动向，这里是两个动向，",
+        "这里是一个动向，这里是两个动向，这里是",
+        "这里是一个动向，这里是两个动向，这里是一个。",
+    ]
+
+    var transcriptionText: String {
+        segments.map(\.text).joined()
+    }
+
+    func startSimulation() {
+        stopSimulation()
+        barPhase = .recording
+        recordingStartDate = Date()
+        segments = [TranscriptionSegment(text: sampleTexts[0], isConfirmed: false)]
+        textIndex = 0
+
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0 / 30.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.tick() }
+        }
+
+        textTimer = Timer.scheduledTimer(withTimeInterval: 1.2, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.advanceText() }
+        }
+    }
+
+    func stopSimulation() {
+        timer?.invalidate()
+        timer = nil
+        textTimer?.invalidate()
+        textTimer = nil
+    }
+
+    private func tick() {
+        let t = Date().timeIntervalSinceReferenceDate
+        let base = Float(sin(t * 0.9) * 0.5 + 0.5)
+        let detail = Float(sin(t * 5.7) * 0.12 + sin(t * 3.1) * 0.08)
+        audioLevel.current = max(0, min(1, base + detail))
+    }
+
+    private func advanceText() {
+        textIndex = (textIndex + 1) % sampleTexts.count
+        segments = [TranscriptionSegment(text: sampleTexts[textIndex], isConfirmed: false)]
     }
 }

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -309,22 +309,71 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
 
             SettingsDivider()
 
-            recordingPreview
+            recordingPreviewDisclosure
         }
     }
 
     // MARK: - Recording Preview
 
     @State private var previewState = PreviewState()
+    @State private var isRecordingPreviewExpanded = false
+
+    private var recordingPreviewDisclosure: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button {
+                withAnimation(TF.springSnappy) {
+                    isRecordingPreviewExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: isRecordingPreviewExpanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(TF.settingsTextTertiary)
+                        .frame(width: 12)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(L("预览效果", "Preview").uppercased())
+                            .font(.system(size: 10, weight: .semibold))
+                            .tracking(0.8)
+                            .foregroundStyle(TF.settingsTextTertiary)
+                        Text(isRecordingPreviewExpanded
+                             ? L("点击隐藏预览", "Click to hide preview")
+                             : L("点击展开预览；默认关闭以降低 CPU 占用", "Click to expand; off by default to reduce CPU usage"))
+                            .font(.system(size: 10))
+                            .foregroundStyle(TF.settingsTextTertiary)
+                    }
+
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if isRecordingPreviewExpanded {
+                recordingPreview
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .padding(.vertical, 6)
+        .onAppear {
+            if isRecordingPreviewExpanded {
+                previewState.startSimulation()
+            }
+        }
+        .onChange(of: isRecordingPreviewExpanded) { _, expanded in
+            if expanded {
+                previewState.startSimulation()
+            } else {
+                previewState.stopSimulation()
+            }
+        }
+        .onDisappear {
+            previewState.stopSimulation()
+        }
+    }
 
     private var recordingPreview: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(L("预览效果", "Preview").uppercased())
-                .font(.system(size: 10, weight: .semibold))
-                .tracking(0.8)
-                .foregroundStyle(TF.settingsTextTertiary)
-                .padding(.top, 8)
-
             ZStack {
                 Color(white: 0.06, opacity: 0.5)
                     .clipShape(RoundedRectangle(cornerRadius: 10))
@@ -333,9 +382,6 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
             }
             .frame(height: 80)
         }
-        .padding(.vertical, 6)
-        .onAppear { previewState.startSimulation() }
-        .onDisappear { previewState.stopSimulation() }
     }
 
     private var launchAtLoginRow: some View {

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -716,11 +716,11 @@ private final class PreviewState: FloatingBarState {
     private var textIndex = 0
 
     private let sampleTexts = [
-        "这里是一个动向，这里是",
-        "这里是一个动向，这里是一",
-        "这里是一个动向，这里是两个动向，",
-        "这里是一个动向，这里是两个动向，这里是",
-        "这里是一个动向，这里是两个动向，这里是一个。",
+        "今天天气不错，我们",
+        "今天天气不错，我们去",
+        "今天天气不错，我们去公园",
+        "今天天气不错，我们去公园走走",
+        "今天天气不错，我们去公园走走吧。",
     ]
 
     var transcriptionText: String {

--- a/Type4Me/UI/Settings/SmartCorrectionSheet.swift
+++ b/Type4Me/UI/Settings/SmartCorrectionSheet.swift
@@ -669,7 +669,7 @@ struct SmartCorrectionSheet: View {
         }
         HotwordStorage.save(currentHotwords)
 
-        if let url = URL(string: "type4me://reload-vocabulary") {
+        if let url = AppIdentity.url("reload-vocabulary") {
             NSWorkspace.shared.open(url)
         }
 

--- a/Type4MeTests/KeychainServiceTests.swift
+++ b/Type4MeTests/KeychainServiceTests.swift
@@ -4,8 +4,9 @@ import XCTest
 final class KeychainServiceTests: XCTestCase {
 
     private var originalProvider: ASRProvider!
-    private let appSupportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        .appendingPathComponent("Type4Me", isDirectory: true)
+    private var appSupportDir: URL {
+        AppIdentity.applicationSupportDirectory
+    }
     private var credentialsURL: URL {
         appSupportDir.appendingPathComponent("credentials.json")
     }

--- a/packaging/macos-signing.env.example
+++ b/packaging/macos-signing.env.example
@@ -1,0 +1,17 @@
+# Copy to a local untracked env file if desired. Do not store passwords here.
+CODESIGN_IDENTITY='Developer ID Application: xin song (2HJP9YYL3H)'
+TEAM_ID='2HJP9YYL3H'
+NOTARY_PROFILE='AC_NOTARY'
+TIMESTAMP_URL='http://timestamp.apple.com/ts01'
+
+# Public release identity (default)
+APP_FLAVOR='public'
+APP_NAME='Type4Me'
+APP_BUNDLE_ID='com.type4me.app'
+URL_SCHEME='type4me'
+
+# Personal side-by-side identity
+# APP_FLAVOR='personal'
+# APP_NAME='Type4Me CtriXin'
+# APP_BUNDLE_ID='com.ctrixin.type4me'
+# URL_SCHEME='type4me-ctrixin'

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -3,62 +3,90 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && /bin/pwd -P)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && /bin/pwd -P)"
-APP_NAME="Type4Me"
 APP_VERSION="${APP_VERSION:-1.9.3}"
-VARIANT="${VARIANT:-pure}"     # pure, official, or local
-ARCH="${ARCH:-}"               # arm64 or universal (default: universal for pure/official, arm64 for local)
+APP_FLAVOR="${APP_FLAVOR:-public}"  # public or personal
+VARIANT="${VARIANT:-pure}"          # pure, official, local, or cloud(alias pure)
+ARCH="${ARCH:-}"                    # arm64 or universal (default: universal for pure/official, arm64 for local)
 DIST_DIR="${DIST_DIR:-$PROJECT_DIR/dist}"
-VOLUME_NAME="${VOLUME_NAME:-$APP_NAME}"
-STAGING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/type4me-dmg.XXXXXX")"
+NOTARY_PROFILE="${NOTARY_PROFILE:-AC_NOTARY}"
+TIMESTAMP_URL="${TIMESTAMP_URL:-http://timestamp.apple.com/ts01}"
+SKIP_NOTARIZE="${SKIP_NOTARIZE:-0}"
+KEEP_OUT_DIR="${KEEP_OUT_DIR:-0}"
 
-# Variant validation
+case "$APP_FLAVOR" in
+    public)
+        APP_NAME="${APP_NAME:-Type4Me}"
+        APP_BUNDLE_ID="${APP_BUNDLE_ID:-com.type4me.app}"
+        URL_SCHEME="${URL_SCHEME:-type4me}"
+        ;;
+    personal)
+        APP_NAME="${APP_NAME:-Type4Me CtriXin}"
+        APP_BUNDLE_ID="${APP_BUNDLE_ID:-com.ctrixin.type4me}"
+        URL_SCHEME="${URL_SCHEME:-type4me-ctrixin}"
+        ;;
+    *) echo "ERROR: Unknown APP_FLAVOR=$APP_FLAVOR (expected public or personal)"; exit 1 ;;
+esac
+
 case "$VARIANT" in
     pure|local) ;;
     official)
-        # Subscription development is paused (2026-04). The marker is archived,
-        # so building official would silently produce a binary without
-        # HAS_CLOUD_SUBSCRIPTION. Fail loudly with re-enable instructions
-        # instead of letting that happen.
         if [ ! -f "$PROJECT_DIR/Type4Me/CloudSubscription/marker" ]; then
             echo "ERROR: official variant is archived (subscription paused)."
-            echo "       To re-enable, restore the marker file:"
-            echo "         mv Type4Me/CloudSubscription/marker.archived-no-subscription \\"
-            echo "            Type4Me/CloudSubscription/marker"
-            echo "         swift package clean"
+            echo "       To re-enable, restore Type4Me/CloudSubscription/marker first."
             exit 1
         fi
         ;;
-    cloud) VARIANT="pure" ;; # backwards compat
-    *) echo "ERROR: Unknown VARIANT=$VARIANT (expected pure or local)"; exit 1 ;;
+    cloud) VARIANT="pure" ;;
+    *) echo "ERROR: Unknown VARIANT=$VARIANT (expected pure, official, or local)"; exit 1 ;;
 esac
 
-# Default ARCH based on variant
 if [ -z "$ARCH" ]; then
     if [ "$VARIANT" = "local" ]; then
-        ARCH="arm64"   # Local ASR (MLX) requires Apple Silicon
+        ARCH="arm64"
     else
         ARCH="universal"
     fi
 fi
 
-# Build DMG filename
-ARCH_SUFFIX=""
-if [ "$ARCH" = "arm64" ]; then
-    ARCH_SUFFIX="-apple-silicon"
+if [ -n "${CODESIGN_IDENTITY:-}" ]; then
+    SIGNING_IDENTITY="$CODESIGN_IDENTITY"
+elif security find-identity -v -p codesigning 2>/dev/null | grep -q "Developer ID Application"; then
+    SIGNING_IDENTITY=$(security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)"/\1/')
+else
+    SIGNING_IDENTITY="-"
 fi
-DMG_NAME="${DMG_NAME:-${APP_NAME}-v${APP_VERSION}-${VARIANT}${ARCH_SUFFIX}.dmg}"
-DMG_PATH="$DIST_DIR/$DMG_NAME"
 
-echo "=== Building ${VARIANT} DMG (${ARCH}) ==="
+if [ "$SKIP_NOTARIZE" != "1" ] && [ "$SIGNING_IDENTITY" = "-" ]; then
+    echo "ERROR: Notarized DMG builds require a Developer ID Application identity."
+    echo "       Set CODESIGN_IDENTITY or use SKIP_NOTARIZE=1 for local smoke tests."
+    exit 1
+fi
+
+APP_BUNDLE="${APP_NAME}.app"
+SLUG=$(printf '%s-%s-%s' "$APP_NAME" "$VARIANT" "$ARCH" | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9._-')
+OUT_DIR="${OUT_DIR:-$DIST_DIR/notarized/${SLUG}-$(date +%Y%m%d-%H%M%S)}"
+APP="$OUT_DIR/$APP_BUNDLE"
+VOLUME_NAME="${VOLUME_NAME:-$APP_NAME}"
+DMG_BASENAME="${DMG_NAME:-${APP_NAME}-v${APP_VERSION}-${VARIANT}-${ARCH}}"
+DMG_TMP="$OUT_DIR/${DMG_BASENAME}.dmg"
+if [ "$SKIP_NOTARIZE" = "1" ]; then
+    DMG="$OUT_DIR/${DMG_BASENAME}-signed.dmg"
+else
+    DMG="$OUT_DIR/${DMG_BASENAME}-notarized.dmg"
+fi
+APP_ENTITLEMENTS="${APP_ENTITLEMENTS:-$PROJECT_DIR/entitlements.plist}"
+HELPER_ENTITLEMENTS="${HELPER_ENTITLEMENTS:-}"
+APP_ZIP="$OUT_DIR/app-notary.zip"
+STAGE="$OUT_DIR/dmg-stage"
 
 cleanup() {
-    rm -rf "$STAGING_DIR"
-    # Restore sherpa-onnx framework if it was hidden
+    if [ "$KEEP_OUT_DIR" != "1" ] && [ "$SKIP_NOTARIZE" = "1" ]; then
+        : # Keep dry-run output so local validation can inspect it.
+    fi
     if [ -f "$PROJECT_DIR/Frameworks/sherpa-onnx.xcframework/Info.plist.cloud-hidden" ]; then
         mv "$PROJECT_DIR/Frameworks/sherpa-onnx.xcframework/Info.plist.cloud-hidden" \
            "$PROJECT_DIR/Frameworks/sherpa-onnx.xcframework/Info.plist"
     fi
-    # Restore CloudSubscription marker if it was hidden
     if [ -f "$PROJECT_DIR/Type4Me/CloudSubscription/marker.hidden" ]; then
         mv "$PROJECT_DIR/Type4Me/CloudSubscription/marker.hidden" \
            "$PROJECT_DIR/Type4Me/CloudSubscription/marker"
@@ -66,18 +94,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$DIST_DIR"
+mkdir -p "$OUT_DIR" "$DIST_DIR"
 
-# Determine feature flags for this variant
-#   pure:     no sherpa, no subscription
-#   official: no sherpa, has subscription
-#   local:    has sherpa, no subscription
 NEEDS_SHERPA=0
 NEEDS_SUBSCRIPTION=0
-if [ "$VARIANT" = "local" ]; then NEEDS_SHERPA=1; fi
-if [ "$VARIANT" = "official" ]; then NEEDS_SUBSCRIPTION=1; fi
+[ "$VARIANT" = "local" ] && NEEDS_SHERPA=1
+[ "$VARIANT" = "official" ] && NEEDS_SUBSCRIPTION=1
 
-# Clean build cache when feature flag state doesn't match last build.
 SHERPA_AVAILABLE="no"
 [ -f "$PROJECT_DIR/Frameworks/sherpa-onnx.xcframework/Info.plist" ] && SHERPA_AVAILABLE="yes"
 SUB_AVAILABLE="no"
@@ -89,66 +112,132 @@ if [ -f "$LAST_STATE_FILE" ] && [ "$(cat "$LAST_STATE_FILE")" != "$BUILD_STATE" 
     swift package clean 2>/dev/null || true
 fi
 
-# Hide sherpa-onnx for non-local builds
 if [ "$NEEDS_SHERPA" = "0" ] && [ -f "$PROJECT_DIR/Frameworks/sherpa-onnx.xcframework/Info.plist" ]; then
     echo "Hiding sherpa-onnx framework for ${VARIANT} build..."
     mv "$PROJECT_DIR/Frameworks/sherpa-onnx.xcframework/Info.plist" \
        "$PROJECT_DIR/Frameworks/sherpa-onnx.xcframework/Info.plist.cloud-hidden"
 fi
 
-# Hide CloudSubscription marker for non-official builds
 if [ "$NEEDS_SUBSCRIPTION" = "0" ] && [ -f "$PROJECT_DIR/Type4Me/CloudSubscription/marker" ]; then
     echo "Hiding CloudSubscription for ${VARIANT} build..."
     mv "$PROJECT_DIR/Type4Me/CloudSubscription/marker" \
        "$PROJECT_DIR/Type4Me/CloudSubscription/marker.hidden"
 fi
 
-VARIANT="$VARIANT" ARCH="$ARCH" APP_VERSION="$APP_VERSION" \
-    APP_PATH="$STAGING_DIR/${APP_NAME}.app" bash "$SCRIPT_DIR/package-app.sh"
+cat > "$OUT_DIR/build-info.txt" <<INFO
+app_name=$APP_NAME
+app_bundle_id=$APP_BUNDLE_ID
+url_scheme=$URL_SCHEME
+app_flavor=$APP_FLAVOR
+variant=$VARIANT
+arch=$ARCH
+notary_profile=$NOTARY_PROFILE
+signing_identity=$SIGNING_IDENTITY
+INFO
 
-# Record build state for next build's cache invalidation
+APP_FLAVOR="$APP_FLAVOR" \
+APP_NAME="$APP_NAME" \
+APP_BUNDLE_ID="$APP_BUNDLE_ID" \
+URL_SCHEME="$URL_SCHEME" \
+VARIANT="$VARIANT" \
+ARCH="$ARCH" \
+APP_VERSION="$APP_VERSION" \
+CODESIGN_IDENTITY="$SIGNING_IDENTITY" \
+APP_PATH="$APP" \
+bash "$SCRIPT_DIR/package-app.sh"
+
 mkdir -p "$PROJECT_DIR/.build"
 echo "$BUILD_STATE" > "$LAST_STATE_FILE"
-ln -s /Applications "$STAGING_DIR/Applications"
+xattr -cr "$APP"
 
-# Check signing identity before staging dir might get cleaned up
-SIGNED_WITH_DEVID=0
-CODESIGN_INFO=$(codesign -dvv "$STAGING_DIR/${APP_NAME}.app" 2>&1 || true)
-if echo "$CODESIGN_INFO" | grep -q "Developer ID"; then
-    SIGNED_WITH_DEVID=1
-    echo "Verified: signed with Developer ID"
+COMMON=(--force --options runtime --timestamp="$TIMESTAMP_URL" --sign "$SIGNING_IDENTITY")
+if [ "$SIGNING_IDENTITY" != "-" ]; then
+    echo "Re-signing nested code inside-out..."
+
+    if [ -d "$APP/Contents/Frameworks" ]; then
+        while IFS= read -r -d '' item; do
+            codesign "${COMMON[@]}" --deep "$item"
+        done < <(find "$APP/Contents/Frameworks" -mindepth 1 -maxdepth 1 -print0)
+    fi
+
+    if [ -d "$APP/Contents/PlugIns" ]; then
+        while IFS= read -r -d '' item; do
+            codesign "${COMMON[@]}" --deep "$item"
+        done < <(find "$APP/Contents/PlugIns" -mindepth 1 -maxdepth 1 -print0)
+    fi
+
+    while IFS= read -r -d '' file; do
+        [ "$file" = "$APP/Contents/MacOS/Type4Me" ] && continue
+        if file "$file" | grep -q 'Mach-O'; then
+            if [ -n "$HELPER_ENTITLEMENTS" ] && [ -f "$HELPER_ENTITLEMENTS" ]; then
+                codesign "${COMMON[@]}" --entitlements "$HELPER_ENTITLEMENTS" "$file"
+            else
+                codesign "${COMMON[@]}" "$file"
+            fi
+        fi
+    done < <(find "$APP/Contents" -type f -print0)
+
+    APP_SIGN_ARGS=("${COMMON[@]}")
+    if [ -f "$APP_ENTITLEMENTS" ]; then
+        APP_SIGN_ARGS+=(--entitlements "$APP_ENTITLEMENTS")
+    fi
+    codesign "${APP_SIGN_ARGS[@]}" "$APP"
 fi
 
-rm -f "$DMG_PATH"
-echo "Creating DMG at $DMG_PATH..."
-hdiutil create \
-    -volname "$VOLUME_NAME" \
-    -srcfolder "$STAGING_DIR" \
-    -ov \
-    -format UDZO \
-    "$DMG_PATH"
+codesign --verify --deep --strict --verbose=2 "$APP"
 
-DMG_SIZE=$(du -h "$DMG_PATH" | cut -f1)
-
-# Notarize and staple if Developer ID signing was used
-NOTARY_PROFILE="${NOTARY_PROFILE:-type4me-notary}"
-if [ "$SIGNED_WITH_DEVID" = "1" ]; then
-    echo ""
-    echo "=== Notarizing DMG ==="
-    xcrun notarytool submit "$DMG_PATH" \
+if [ "$SKIP_NOTARIZE" != "1" ] && [ "$SIGNING_IDENTITY" != "-" ]; then
+    echo "Submitting app for notarization..."
+    ditto -c -k --keepParent "$APP" "$APP_ZIP"
+    xcrun notarytool submit "$APP_ZIP" \
         --keychain-profile "$NOTARY_PROFILE" \
-        --wait
-
-    echo "Stapling notarization ticket..."
-    xcrun stapler staple "$DMG_PATH"
-    echo "Notarization complete."
+        --wait --timeout 45m \
+        --no-s3-acceleration \
+        --output-format json | tee "$OUT_DIR/app-notary.json"
+    xcrun stapler staple "$APP"
+    xcrun stapler validate "$APP"
 else
-    echo "(Skipping notarization: not signed with Developer ID)"
+    echo "Skipping app notarization (SKIP_NOTARIZE=$SKIP_NOTARIZE, SIGNING_IDENTITY=$SIGNING_IDENTITY)."
 fi
 
-echo ""
-echo "=== DMG ready ==="
-echo "  Path: $DMG_PATH"
-echo "  Size: $DMG_SIZE"
-echo "  Variant: $VARIANT"
-echo "  Arch: $ARCH"
+rm -rf "$STAGE" "$DMG_TMP" "$DMG"
+mkdir -p "$STAGE"
+ditto "$APP" "$STAGE/$APP_BUNDLE"
+ln -s /Applications "$STAGE/Applications"
+
+hdiutil create -volname "$VOLUME_NAME" -srcfolder "$STAGE" -ov -format UDZO "$DMG_TMP"
+
+if [ "$SIGNING_IDENTITY" != "-" ]; then
+    codesign --force --timestamp="$TIMESTAMP_URL" --sign "$SIGNING_IDENTITY" "$DMG_TMP"
+    codesign --verify --verbose=2 "$DMG_TMP"
+fi
+
+if [ "$SKIP_NOTARIZE" != "1" ] && [ "$SIGNING_IDENTITY" != "-" ]; then
+    echo "Submitting DMG for notarization..."
+    xcrun notarytool submit "$DMG_TMP" \
+        --keychain-profile "$NOTARY_PROFILE" \
+        --wait --timeout 45m \
+        --no-s3-acceleration \
+        --output-format json | tee "$OUT_DIR/dmg-notary.json"
+    cp "$DMG_TMP" "$DMG"
+    xcrun stapler staple "$DMG"
+    xcrun stapler validate "$DMG"
+else
+    cp "$DMG_TMP" "$DMG"
+    echo "Skipping DMG notarization (SKIP_NOTARIZE=$SKIP_NOTARIZE, SIGNING_IDENTITY=$SIGNING_IDENTITY)."
+fi
+
+shasum -a 256 "$DMG" | tee "$OUT_DIR/SHA256SUMS.txt"
+
+cat <<DONE
+
+=== DMG ready ===
+  App: $APP
+  DMG: $DMG
+  SHA256: $OUT_DIR/SHA256SUMS.txt
+  Flavor: $APP_FLAVOR
+  Bundle ID: $APP_BUNDLE_ID
+  URL scheme: $URL_SCHEME
+  Variant: $VARIANT
+  Arch: $ARCH
+DONE

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -2,11 +2,28 @@
 set -euo pipefail
 
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && /bin/pwd -P)"
-APP_PATH="${APP_PATH:-$PROJECT_DIR/dist/Type4Me.app}"
-APP_NAME="Type4Me"
-APP_EXECUTABLE="Type4Me"
-APP_ICON_NAME="AppIcon"
-APP_BUNDLE_ID="${APP_BUNDLE_ID:-com.type4me.app}"
+APP_FLAVOR="${APP_FLAVOR:-public}"  # public or personal
+
+case "$APP_FLAVOR" in
+    public)
+        APP_NAME="${APP_NAME:-Type4Me}"
+        APP_BUNDLE_ID="${APP_BUNDLE_ID:-com.type4me.app}"
+        URL_SCHEME="${URL_SCHEME:-type4me}"
+        ;;
+    personal)
+        APP_NAME="${APP_NAME:-Type4Me CtriXin}"
+        APP_BUNDLE_ID="${APP_BUNDLE_ID:-com.ctrixin.type4me}"
+        URL_SCHEME="${URL_SCHEME:-type4me-ctrixin}"
+        ;;
+    *)
+        echo "ERROR: Unknown APP_FLAVOR=$APP_FLAVOR (expected public or personal)"
+        exit 1
+        ;;
+esac
+
+APP_PATH="${APP_PATH:-$PROJECT_DIR/dist/${APP_NAME}.app}"
+APP_EXECUTABLE="${APP_EXECUTABLE:-Type4Me}"
+APP_ICON_NAME="${APP_ICON_NAME:-AppIcon}"
 APP_VERSION="${APP_VERSION:-1.9.3}"
 APP_BUILD="${APP_BUILD:-1}"
 MIN_SYSTEM_VERSION="${MIN_SYSTEM_VERSION:-14.0}"
@@ -38,11 +55,32 @@ else
     swift build -c release --package-path "$PROJECT_DIR" --arch arm64 --arch x86_64 2>&1 | grep -E "Build complete|Build succeeded|error:|warning:" || true
 fi
 
-if [ -f "$PROJECT_DIR/.build/apple/Products/Release/Type4Me" ]; then
-    BINARY="$PROJECT_DIR/.build/apple/Products/Release/Type4Me"
-elif [ -f "$PROJECT_DIR/.build/release/Type4Me" ]; then
-    BINARY="$PROJECT_DIR/.build/release/Type4Me"
+BINARY=""
+if [ "$ARCH" = "arm64" ]; then
+    # arm64 builds can leave a stale universal artifact under .build/apple.
+    for candidate in \
+        "$PROJECT_DIR/.build/arm64-apple-macosx/release/Type4Me" \
+        "$PROJECT_DIR/.build/release/Type4Me" \
+        "$PROJECT_DIR/.build/apple/Products/Release/Type4Me"
+    do
+        if [ -f "$candidate" ]; then
+            BINARY="$candidate"
+            break
+        fi
+    done
 else
+    for candidate in \
+        "$PROJECT_DIR/.build/apple/Products/Release/Type4Me" \
+        "$PROJECT_DIR/.build/release/Type4Me"
+    do
+        if [ -f "$candidate" ]; then
+            BINARY="$candidate"
+            break
+        fi
+    done
+fi
+
+if [ -z "$BINARY" ]; then
     BINARY="$(find "$PROJECT_DIR/.build" -path '*/release/Type4Me' -type f -not -path '*/x86_64/*' -not -path '*/arm64/*' | head -n 1)"
 fi
 
@@ -107,7 +145,7 @@ cat >"$INFO_PLIST" <<EOF
             <string>${APP_BUNDLE_ID}</string>
             <key>CFBundleURLSchemes</key>
             <array>
-                <string>type4me</string>
+                <string>${URL_SCHEME}</string>
             </array>
         </dict>
     </array>
@@ -240,7 +278,7 @@ if [ "$NEEDS_SIGN" = "1" ]; then
     codesign --verify --strict "$APP_PATH" && echo "Signature verified." || { echo "ERROR: Signature verification failed"; exit 1; }
 fi
 
-echo "Variant: $VARIANT | Arch: $ARCH"
+echo "Flavor: $APP_FLAVOR | Variant: $VARIANT | Arch: $ARCH"
 
 # Remove quarantine flag that macOS adds to downloaded apps.
 # This flag can silently prevent Accessibility permission from working.

--- a/scripts/test_app_bundle.sh
+++ b/scripts/test_app_bundle.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 
 APP_PATH="${1:-${APP_PATH:-/Applications/Type4Me.app}}"
+EXPECTED_BUNDLE_ID="${EXPECTED_BUNDLE_ID:-com.type4me.app}"
+EXPECTED_APP_NAME="${EXPECTED_APP_NAME:-Type4Me}"
+EXPECTED_APP_VERSION="${EXPECTED_APP_VERSION:-1.0.0}"
+EXPECTED_APP_BUILD="${EXPECTED_APP_BUILD:-1}"
 INFO_PLIST="$APP_PATH/Contents/Info.plist"
 
 fail() {
@@ -20,12 +24,12 @@ read_plist() {
 [ -f "$APP_PATH/Contents/Resources/AppIcon.icns" ] || fail "app icon missing"
 
 [ "$(read_plist CFBundleExecutable)" = "Type4Me" ] || fail "CFBundleExecutable should be Type4Me"
-[ "$(read_plist CFBundleIdentifier)" = "com.type4me.app" ] || fail "CFBundleIdentifier should be com.type4me.app"
-[ "$(read_plist CFBundleName)" = "Type4Me" ] || fail "CFBundleName should be Type4Me"
-[ "$(read_plist CFBundleDisplayName)" = "Type4Me" ] || fail "CFBundleDisplayName should be Type4Me"
+[ "$(read_plist CFBundleIdentifier)" = "$EXPECTED_BUNDLE_ID" ] || fail "CFBundleIdentifier should be $EXPECTED_BUNDLE_ID"
+[ "$(read_plist CFBundleName)" = "$EXPECTED_APP_NAME" ] || fail "CFBundleName should be $EXPECTED_APP_NAME"
+[ "$(read_plist CFBundleDisplayName)" = "$EXPECTED_APP_NAME" ] || fail "CFBundleDisplayName should be $EXPECTED_APP_NAME"
 [ "$(read_plist CFBundlePackageType)" = "APPL" ] || fail "CFBundlePackageType should be APPL"
-[ "$(read_plist CFBundleShortVersionString)" = "1.0.0" ] || fail "CFBundleShortVersionString should be 1.0.0"
-[ "$(read_plist CFBundleVersion)" = "1" ] || fail "CFBundleVersion should be 1"
+[ "$(read_plist CFBundleShortVersionString)" = "$EXPECTED_APP_VERSION" ] || fail "CFBundleShortVersionString should be $EXPECTED_APP_VERSION"
+[ "$(read_plist CFBundleVersion)" = "$EXPECTED_APP_BUILD" ] || fail "CFBundleVersion should be $EXPECTED_APP_BUILD"
 [ "$(read_plist CFBundleIconFile)" = "AppIcon" ] || fail "CFBundleIconFile should be AppIcon"
 [ "$(read_plist LSMinimumSystemVersion)" = "14.0" ] || fail "LSMinimumSystemVersion should be 14.0"
 [ -n "$(read_plist NSMicrophoneUsageDescription)" ] || fail "NSMicrophoneUsageDescription should be present"


### PR DESCRIPTION
## Summary

Add a live preview of the recording animation in Settings -> General, so users can see how each visual style looks before enabling it.

This update also fixes the CPU regression from the live preview: the preview is now collapsed by default and its simulation only runs while the user expands it.

## Changes

- `GeneralSettingsTab.swift` — add the recording animation preview behind a collapsible disclosure so Canvas/TimelineView simulation does not run continuously.
- `scripts/build-dmg.sh` — use the cmux-style macOS pipeline: sign inside-out, notarize/staple the app, create drag-to-Applications DMG, sign/notarize/staple the DMG, and write SHA256 output.
- `scripts/package-app.sh` — add `APP_FLAVOR=public|personal` and fix arm64 packaging to avoid stale universal build artifacts.
- `AppIdentity.swift` — derive app support path, Keychain service, and URL scheme from the bundle identity so public and personal builds can coexist.
- Storage paths now use `AppIdentity.applicationSupportDirectory`; public builds keep the existing `Type4Me` data, personal builds use `Type4Me CtriXin`.

## Side-by-side builds

- Public: `Type4Me.app`, bundle id `com.type4me.app`, URL scheme `type4me`.
- Personal: `Type4Me CtriXin.app`, bundle id `com.ctrixin.type4me`, URL scheme `type4me-ctrixin`.
- They can be installed together because app name, bundle id, URL scheme, Application Support directory, UserDefaults domain, and Keychain services differ.

## Test plan

- [x] `bash -n scripts/package-app.sh scripts/build-dmg.sh scripts/test_app_bundle.sh`
- [x] `swift build --package-path .`
- [x] `swift test --package-path .` (161 tests)
- [x] Public app smoke: `APP_FLAVOR=public VARIANT=pure ARCH=arm64 CODESIGN_IDENTITY=- APP_PATH=/tmp/type4me-public-app-smoke.app APP_VERSION=1.9.3 APP_BUILD=1 bash scripts/package-app.sh`
- [x] Public app metadata/codesign verify: `scripts/test_app_bundle.sh`, URL scheme `type4me`, `codesign --verify --deep --strict`
- [x] Personal DMG smoke: `APP_FLAVOR=personal VARIANT=pure ARCH=arm64 CODESIGN_IDENTITY=- SKIP_NOTARIZE=1 OUT_DIR=/tmp/type4me-personal-dmg-smoke APP_VERSION=1.9.3 bash scripts/build-dmg.sh`
- [x] Personal app metadata: bundle id `com.ctrixin.type4me`, app name `Type4Me CtriXin`, URL scheme `type4me-ctrixin`
- [x] Personal DMG mount check contains `Type4Me CtriXin.app` and `Applications`
- [x] `git diff --check`

## Packaging notes

- Real shareable builds should use `CODESIGN_IDENTITY='Developer ID Application: ...'` and `NOTARY_PROFILE=AC_NOTARY`.
- Local smoke builds should set `SKIP_NOTARIZE=1`.
- The script now fails closed if notarization is requested without a Developer ID identity.
