### PR TITLE
feat: custom OpenAI-compatible LLM provider

### DIFF
--- a/Type4Me/LLM/LLMProvider.swift
+++ b/Type4Me/LLM/LLMProvider.swift
@@ -15,6 +15,7 @@ enum LLMProvider: String, CaseIterable, Codable, Sendable {
     case zhipu
     case claude
     case ollama
+    case custom
 
     var displayName: String {
         switch self {
@@ -30,6 +31,7 @@ enum LLMProvider: String, CaseIterable, Codable, Sendable {
         case .zhipu:       return L("智谱 (GLM)", "Zhipu (GLM)")
         case .claude:      return "Claude (Anthropic)"
         case .ollama:      return L("Ollama (本地模型)", "Ollama (Local)")
+        case .custom:      return L("自定义 (OpenAI 兼容)", "Custom (OpenAI Compatible)")
         }
     }
 
@@ -47,6 +49,7 @@ enum LLMProvider: String, CaseIterable, Codable, Sendable {
         case .zhipu:       return "https://open.bigmodel.cn/api/paas/v4"
         case .claude:      return "https://api.anthropic.com/v1"
         case .ollama:      return "http://localhost:11434/v1"
+        case .custom:      return ""
         }
     }
 
@@ -130,7 +133,7 @@ enum LLMProvider: String, CaseIterable, Codable, Sendable {
                 FieldOption(value: "claude-haiku-4-5-20251001", label: "claude-haiku-4-5-20251001"),
                 FieldOption(value: "claude-sonnet-4-5-20250929", label: "claude-sonnet-4-5-20250929"),
             ]
-        case .openrouter, .ollama:
+        case .openrouter, .ollama, .custom:
             return []
         }
     }

--- a/Type4Me/LLM/LLMProviderRegistry.swift
+++ b/Type4Me/LLM/LLMProviderRegistry.swift
@@ -15,6 +15,7 @@ enum LLMProviderRegistry {
         .zhipu:       OpenAICompatibleLLMConfig<ZhipuLLMTag>.self,
         .claude:      ClaudeLLMConfig.self,
         .ollama:      OpenAICompatibleLLMConfig<OllamaLLMTag>.self,
+        .custom:      OpenAICompatibleLLMConfig<CustomLLMTag>.self,
     ]
 
     static func configType(for provider: LLMProvider) -> (any LLMProviderConfig.Type)? {

--- a/Type4Me/LLM/Providers/OpenAICompatibleLLMConfig.swift
+++ b/Type4Me/LLM/Providers/OpenAICompatibleLLMConfig.swift
@@ -21,6 +21,7 @@ enum GeminiLLMTag:      OpenAICompatibleLLMTag { static let provider = LLMProvid
 enum DeepSeekLLMTag:    OpenAICompatibleLLMTag { static let provider = LLMProvider.deepseek }
 enum ZhipuLLMTag:       OpenAICompatibleLLMTag { static let provider = LLMProvider.zhipu }
 enum OllamaLLMTag:      OpenAICompatibleLLMTag { static let provider = LLMProvider.ollama }
+enum CustomLLMTag:      OpenAICompatibleLLMTag { static let provider = LLMProvider.custom }
 
 // MARK: - Generic Config
 
@@ -31,6 +32,12 @@ struct OpenAICompatibleLLMConfig<Tag: OpenAICompatibleLLMTag>: LLMProviderConfig
     static var credentialFields: [CredentialField] {
         let p = Tag.provider
         let models = p.modelOptions
+        let baseURLPlaceholder: String = {
+            if p == .custom {
+                return L("https://your-api.com/v1", "https://your-api.com/v1")
+            }
+            return p.defaultBaseURL
+        }()
         return [
             CredentialField(
                 key: "apiKey", label: "API Key",
@@ -40,13 +47,13 @@ struct OpenAICompatibleLLMConfig<Tag: OpenAICompatibleLLMTag>: LLMProviderConfig
             CredentialField(
                 key: "model", label: L("模型", "Model"),
                 placeholder: L("模型名称或 endpoint ID", "Model name or endpoint ID"),
-                isSecure: false, isOptional: false,
+                isSecure: false, isOptional: p == .custom,
                 defaultValue: models.first?.value ?? "",
                 options: models, allowCustomInput: true
             ),
             CredentialField(
                 key: "baseURL", label: "Base URL",
-                placeholder: p.defaultBaseURL,
+                placeholder: baseURLPlaceholder,
                 isSecure: false, isOptional: true, defaultValue: p.defaultBaseURL
             ),
         ]
@@ -61,8 +68,10 @@ struct OpenAICompatibleLLMConfig<Tag: OpenAICompatibleLLMTag>: LLMProviderConfig
         if Tag.provider.requiresAPIKey {
             guard !key.isEmpty else { return nil }
         }
-        guard let model = credentials["model"], !model.isEmpty
-        else { return nil }
+        let model = credentials["model"] ?? ""
+        if Tag.provider != .custom {
+            guard !model.isEmpty else { return nil }
+        }
         self.apiKey = key
         self.model = model
         let url = credentials["baseURL"]?.isEmpty == false


### PR DESCRIPTION
## Summary

Add a "Custom (OpenAI Compatible)" option to the LLM provider list, allowing users to connect to any OpenAI-compatible API by entering a base URL, API key, and model name. This is useful for self-hosted models, corporate proxies, or lesser-known providers that implement the OpenAI API format.

## Changes

- `LLMProvider.swift` — add `case custom` with empty defaultBaseURL and no preset model options
- `OpenAICompatibleLLMConfig.swift` — add `CustomLLMTag`, make model field optional for custom provider, custom base URL placeholder
- `LLMProviderRegistry.swift` — register custom provider in the config map

## Test plan

- [ ] Open Settings → LLM → select "Custom (OpenAI Compatible)"
- [ ] Enter a base URL, API key, and model name → save
- [ ] Verify test connection works against a real OpenAI-compatible endpoint
- [ ] Verify model field is optional (can save without specifying a model)
- [ ] Verify other providers are unaffected