### PR TITLE
功能（热键）：支持将耳机/媒体按键用作热键触发项

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,11 +25,13 @@ var targets: [Target] = [
         exclude: excludes,
         cSettings: hasSherpaFramework ? [.headerSearchPath("Bridge")] : [],
         swiftSettings: swiftDefines,
-        linkerSettings: hasSherpaFramework ? [
+        linkerSettings: (hasSherpaFramework ? [
             .linkedLibrary("c++"),
             .linkedFramework("Accelerate"),
             .linkedFramework("Foundation"),
-        ] : []
+        ] : []) + [
+            .linkedFramework("MediaPlayer"),
+        ]
     ),
     .testTarget(
         name: "Type4MeTests",

--- a/Type4Me/Input/HotkeyManager.swift
+++ b/Type4Me/Input/HotkeyManager.swift
@@ -13,6 +13,9 @@ struct ModeBinding {
     /// Whether this binding is for a mouse button (encoded with high-bit keyCode).
     var isMouseButton: Bool { ModeBinding.isMouseKeyCode(Int(keyCode)) }
 
+    /// Whether this binding is for a media key (encoded with high-bit keyCode).
+    var isMediaKey: Bool { ModeBinding.isMediaKeyCode(Int(keyCode)) }
+
     /// The mouse button number (2=middle, 3+=side buttons). Only valid when isMouseButton is true.
     var mouseButtonNumber: Int { ModeBinding.mouseButtonNumber(from: Int(keyCode)) }
 
@@ -24,6 +27,7 @@ struct ModeBinding {
     // The encoded value fits in both Int and UInt16 (CGKeyCode).
 
     private static let mouseKeyCodeBase = 0x8000
+    private static let mediaKeyCodeBase = 0x9000
 
     /// Encode a mouse button number as a keyCode (for storage in ProcessingMode.hotkeyCode).
     static func mouseKeyCode(for buttonNumber: Int) -> Int { mouseKeyCodeBase + buttonNumber }
@@ -32,7 +36,24 @@ struct ModeBinding {
     static func mouseButtonNumber(from keyCode: Int) -> Int { keyCode - mouseKeyCodeBase }
 
     /// Check if a keyCode represents a mouse button.
-    static func isMouseKeyCode(_ keyCode: Int) -> Bool { keyCode >= mouseKeyCodeBase }
+    static func isMouseKeyCode(_ keyCode: Int) -> Bool { keyCode >= mouseKeyCodeBase && keyCode < mediaKeyCodeBase }
+
+    // MARK: - Media Key Encoding
+    //
+    // Convention: keyCode = 0x9000 + NX_KEYTYPE value.
+    // NX_KEYTYPE_SOUND_UP=0, NX_KEYTYPE_SOUND_DOWN=1, NX_KEYTYPE_MUTE=7,
+    // NX_KEYTYPE_PLAY=16, NX_KEYTYPE_NEXT=17, NX_KEYTYPE_PREVIOUS=18,
+    // NX_KEYTYPE_FAST=19, NX_KEYTYPE_REWIND=20.
+    // No collision with keyboard (0–127) or mouse (0x8000+) keyCodes.
+
+    /// Encode an NX_KEYTYPE value as a keyCode (for storage in ProcessingMode.hotkeyCode).
+    static func mediaKeyCode(for keyType: Int) -> Int { mediaKeyCodeBase + keyType }
+
+    /// Decode a media keyCode back to the NX_KEYTYPE value.
+    static func mediaKeyType(from keyCode: Int) -> Int { keyCode - mediaKeyCodeBase }
+
+    /// Check if a keyCode represents a media key.
+    static func isMediaKeyCode(_ keyCode: Int) -> Bool { keyCode >= mediaKeyCodeBase }
 }
 
 final class HotkeyManager: NSObject {
@@ -106,6 +127,7 @@ final class HotkeyManager: NSObject {
             | (1 << CGEventType.flagsChanged.rawValue)
             | (1 << CGEventType.otherMouseDown.rawValue)
             | (1 << CGEventType.otherMouseUp.rawValue)
+            | (1 << 14)  // kCGEventSystemDefined (NX_SYSDEFINED) for media/headphone keys
 
         let userInfo = Unmanaged.passUnretained(self).toOpaque()
 
@@ -245,12 +267,67 @@ final class HotkeyManager: NSObject {
             return Unmanaged.passUnretained(event)
         }
 
+        // MARK: Media key events (headphone buttons, keyboard media keys)
+        if type.rawValue == 14 {  // kCGEventSystemDefined (NX_SYSDEFINED)
+            guard let nsEvent = NSEvent(cgEvent: event),
+                  nsEvent.type == .systemDefined,
+                  nsEvent.subtype.rawValue == 8 else {
+                return Unmanaged.passUnretained(event)
+            }
+
+            let keyType = Int((nsEvent.data1 >> 16) & 0xFFFF)
+            let keyState = Int((nsEvent.data1 >> 8) & 0xFF)
+            let isKeyDown = keyState == 0x0A
+            let isKeyUp = keyState == 0x0B
+
+            guard Self.isKnownMediaKeyType(keyType) else {
+                return Unmanaged.passUnretained(event)
+            }
+
+            let encodedKeyCode = ModeBinding.mediaKeyCode(for: keyType)
+
+            for binding in bindings {
+                guard binding.isMediaKey, Int(binding.keyCode) == encodedKeyCode else { continue }
+
+                switch binding.style {
+                case .hold:
+                    if isKeyDown {
+                        handleBindingEvent(binding: binding, pressed: true)
+                    } else if isKeyUp {
+                        handleBindingEvent(binding: binding, pressed: false)
+                    }
+                case .toggle:
+                    if isKeyDown {
+                        let id = binding.modeId
+                        if let activeId = activeToggleModeId, activeId != id {
+                            toggleState[activeId] = false
+                            activeToggleModeId = nil
+                            onCrossModeStop?(id)
+                        } else {
+                            let isOn = toggleState[id] ?? false
+                            toggleState[id] = !isOn
+                            if !isOn {
+                                activeToggleModeId = id
+                                binding.onStart()
+                            } else {
+                                activeToggleModeId = nil
+                                binding.onStop()
+                            }
+                        }
+                    }
+                }
+                return nil  // Swallow matched media key events
+            }
+
+            return Unmanaged.passUnretained(event)
+        }
+
         // MARK: Keyboard events
         let keyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
 
         for binding in bindings {
-            // Skip mouse button bindings in the keyboard path
-            guard !binding.isMouseButton else { continue }
+            // Skip mouse button and media key bindings in the keyboard path
+            guard !binding.isMouseButton && !binding.isMediaKey else { continue }
             guard binding.keyCode == keyCode else { continue }
 
             if isModifierKeyCode(keyCode) {
@@ -418,9 +495,9 @@ final class HotkeyManager: NSObject {
             let id = binding.modeId
             guard holdState[id] == true else { continue }
 
-            // Mouse buttons: no API to query current state, rely on mouseUp events instead.
-            // Safety timer will catch truly stuck mouse holds.
-            if binding.isMouseButton { continue }
+            // Mouse buttons and media keys: no API to query current state, rely on release events instead.
+            // Safety timer will catch truly stuck holds.
+            if binding.isMouseButton || binding.isMediaKey { continue }
 
             let stillDown: Bool
             if isModifierKeyCode(binding.keyCode) {
@@ -439,6 +516,12 @@ final class HotkeyManager: NSObject {
     }
 
     // MARK: - Helpers
+
+    private static func isKnownMediaKeyType(_ keyType: Int) -> Bool {
+        // NX_KEYTYPE values from IOKit/hidsystem/IOHIDParameter.h
+        // SOUND_UP=0, SOUND_DOWN=1, MUTE=7, PLAY=16, NEXT=17, PREVIOUS=18, FAST=19, REWIND=20
+        [0, 1, 7, 16, 17, 18, 19, 20].contains(keyType)
+    }
 
     private func isModifierKeyCode(_ keyCode: CGKeyCode) -> Bool {
         [54, 55, 56, 58, 59, 60, 61, 62, 63].contains(keyCode)

--- a/Type4Me/Input/HotkeyManager.swift
+++ b/Type4Me/Input/HotkeyManager.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import MediaPlayer
 
 typealias HotkeyStyle = ProcessingMode.HotkeyStyle
 
@@ -106,6 +107,10 @@ final class HotkeyManager: NSObject {
     /// Timestamp of the last event received by the tap callback.
     fileprivate var lastEventTime: Date?
 
+    /// Tokens for MPRemoteCommandCenter handlers (prevents Apple Music from auto-launching).
+    private var mediaCommandTokens: [(command: MPRemoteCommand, token: Any)] = []
+    private var isMediaSessionActive = false
+
     // MARK: - Registration
 
     func registerBindings(_ newBindings: [ModeBinding]) {
@@ -115,6 +120,7 @@ final class HotkeyManager: NSObject {
         wasModifierDown = [:]
         holdSafetyTimers.values.forEach { $0.invalidate() }
         holdSafetyTimers = [:]
+        updateMediaKeySession()
     }
 
     // MARK: - Start / Stop
@@ -131,14 +137,25 @@ final class HotkeyManager: NSObject {
 
         let userInfo = Unmanaged.passUnretained(self).toOpaque()
 
-        guard let tap = CGEvent.tapCreate(
+        // Try cghidEventTap first for more reliable interception of media/headphone keys.
+        // If unavailable (e.g. insufficient permissions), fall back to cgSessionEventTap.
+        let tap: CFMachPort? = CGEvent.tapCreate(
+            tap: .cghidEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: eventMask,
+            callback: hotkeyCallback,
+            userInfo: userInfo
+        ) ?? CGEvent.tapCreate(
             tap: .cgSessionEventTap,
             place: .headInsertEventTap,
             options: .defaultTap,
             eventsOfInterest: eventMask,
             callback: hotkeyCallback,
             userInfo: userInfo
-        ) else {
+        )
+
+        guard let tap = tap else {
             return false
         }
 
@@ -151,10 +168,12 @@ final class HotkeyManager: NSObject {
         CGEvent.tapEnable(tap: tap, enable: true)
 
         startHealthCheck()
+        updateMediaKeySession()
         return true
     }
 
     func stop() {
+        deactivateMediaKeySession()
         healthCheckTimer?.invalidate()
         healthCheckTimer = nil
         if let tap = eventTap {
@@ -567,6 +586,102 @@ final class HotkeyManager: NSObject {
         case 59, 62: return flags.contains(.maskControl)
         case 63: return flags.contains(.maskSecondaryFn)
         default: return false
+        }
+    }
+
+    // MARK: - Media Session (prevent Apple Music auto-launch)
+
+    /// Register as an active media session when transport media keys (play/next/prev)
+    /// are bound as hotkeys, so the system doesn't launch Apple Music on key press.
+    private func updateMediaKeySession() {
+        for (command, token) in mediaCommandTokens {
+            command.removeTarget(token)
+        }
+        mediaCommandTokens = []
+
+        // Find which transport key types are bound (volume keys don't launch Apple Music)
+        let boundKeyTypes = Set(bindings.filter(\.isMediaKey).map { ModeBinding.mediaKeyType(from: Int($0.keyCode)) })
+        let transportKeyTypes: Set<Int> = [16, 17, 18, 19, 20]
+        let boundTransportKeys = boundKeyTypes.intersection(transportKeyTypes)
+
+        if boundTransportKeys.isEmpty {
+            if isMediaSessionActive {
+                MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+                MPNowPlayingInfoCenter.default().playbackState = .stopped
+                isMediaSessionActive = false
+                NSLog("[HotkeyManager] Deactivated media session (no transport keys bound)")
+            }
+            return
+        }
+
+        let commandCenter = MPRemoteCommandCenter.shared()
+
+        if !isMediaSessionActive {
+            // Must set non-empty NowPlaying info with playbackState=.playing —
+            // mediaremoted on macOS 15 ignores apps with empty nowPlayingInfo.
+            let nowPlayingInfo: [String: Any] = [
+                MPMediaItemPropertyTitle: "Type4Me Voice Input",
+                MPNowPlayingInfoPropertyPlaybackRate: 1.0,
+                MPNowPlayingInfoPropertyElapsedPlaybackTime: 0.0,
+            ]
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+            MPNowPlayingInfoCenter.default().playbackState = .playing
+            isMediaSessionActive = true
+            NSLog("[HotkeyManager] Activated media session (transport keys bound)")
+        }
+
+        let handler: (MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus = { event in
+            NSLog("[HotkeyManager] Media remote command received: %@", String(describing: type(of: event)))
+            return .success
+        }
+
+        if boundTransportKeys.contains(16) {
+            commandCenter.playCommand.isEnabled = true
+            commandCenter.pauseCommand.isEnabled = true
+            commandCenter.togglePlayPauseCommand.isEnabled = true
+
+            let playToken = commandCenter.playCommand.addTarget(handler: handler)
+            let pauseToken = commandCenter.pauseCommand.addTarget(handler: handler)
+            let toggleToken = commandCenter.togglePlayPauseCommand.addTarget(handler: handler)
+            mediaCommandTokens.append(contentsOf: [
+                (command: commandCenter.playCommand, token: playToken),
+                (command: commandCenter.pauseCommand, token: pauseToken),
+                (command: commandCenter.togglePlayPauseCommand, token: toggleToken),
+            ])
+        }
+        if boundTransportKeys.contains(17) {
+            commandCenter.nextTrackCommand.isEnabled = true
+            let token = commandCenter.nextTrackCommand.addTarget(handler: handler)
+            mediaCommandTokens.append((command: commandCenter.nextTrackCommand, token: token))
+        }
+        if boundTransportKeys.contains(18) {
+            commandCenter.previousTrackCommand.isEnabled = true
+            let token = commandCenter.previousTrackCommand.addTarget(handler: handler)
+            mediaCommandTokens.append((command: commandCenter.previousTrackCommand, token: token))
+        }
+        if boundTransportKeys.contains(19) {
+            commandCenter.seekForwardCommand.isEnabled = true
+            let token = commandCenter.seekForwardCommand.addTarget(handler: handler)
+            mediaCommandTokens.append((command: commandCenter.seekForwardCommand, token: token))
+        }
+        if boundTransportKeys.contains(20) {
+            commandCenter.seekBackwardCommand.isEnabled = true
+            let token = commandCenter.seekBackwardCommand.addTarget(handler: handler)
+            mediaCommandTokens.append((command: commandCenter.seekBackwardCommand, token: token))
+        }
+    }
+
+    private func deactivateMediaKeySession() {
+        for (command, token) in mediaCommandTokens {
+            command.isEnabled = false
+            command.removeTarget(token)
+        }
+        mediaCommandTokens = []
+        if isMediaSessionActive {
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+            MPNowPlayingInfoCenter.default().playbackState = .stopped
+            isMediaSessionActive = false
+            NSLog("[HotkeyManager] Deactivated media session (stop)")
         }
     }
 }

--- a/Type4Me/UI/Settings/HotkeyRecorderView.swift
+++ b/Type4Me/UI/Settings/HotkeyRecorderView.swift
@@ -63,7 +63,7 @@ struct HotkeyRecorderView: View {
     // MARK: - Display
 
     private var displayText: String {
-        if isRecording { return L("按下快捷键或鼠标按键...", "Press a key or mouse button...") }
+        if isRecording { return L("按下快捷键、鼠标或耳机按键...", "Press a key, mouse or headphone button...") }
         guard let kc = keyCode else { return L("未设置", "Not set") }
         return Self.keyDisplayName(keyCode: kc, modifiers: modifiers)
     }
@@ -84,7 +84,25 @@ struct HotkeyRecorderView: View {
             await MainActor.run { stopRecording() }
         }
 
-        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.flagsChanged, .keyDown, .otherMouseDown]) { event in
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.flagsChanged, .keyDown, .otherMouseDown, .systemDefined]) { event in
+            // Media key pressed (headphone buttons, keyboard media keys)
+            if event.type == .systemDefined {
+                guard event.subtype.rawValue == 8 else { return event }
+                let keyType = Int((event.data1 >> 16) & 0xFFFF)
+                let keyState = Int((event.data1 >> 8) & 0xFF)
+                guard keyState == 0x0A else { return event }  // key down only
+                guard Self.isKnownMediaKeyType(keyType) else { return event }
+
+                modifierCaptureTask?.cancel()
+                modifierCaptureTask = nil
+                pendingModifierCode = nil
+
+                keyCode = ModeBinding.mediaKeyCode(for: keyType)
+                modifiers = 0
+                stopRecording()
+                return nil
+            }
+
             // Mouse button pressed (middle click, side buttons)
             if event.type == .otherMouseDown {
                 let buttonNumber = event.buttonNumber
@@ -181,6 +199,10 @@ struct HotkeyRecorderView: View {
 
     static let modifierKeyCodes: Set<Int> = [54, 55, 56, 58, 59, 60, 61, 62, 63]
 
+    static func isKnownMediaKeyType(_ keyType: Int) -> Bool {
+        [0, 1, 7, 16, 17, 18, 19, 20].contains(keyType)
+    }
+
     private func isModifierPressed(keyCode: Int, flags: NSEvent.ModifierFlags) -> Bool {
         switch keyCode {
         case 54, 55: return flags.contains(.command)
@@ -215,8 +237,8 @@ struct HotkeyRecorderView: View {
     // MARK: - Key Display Name
 
     static func keyDisplayName(keyCode: Int, modifiers: UInt64?) -> String {
-        // Mouse buttons: no modifier combos, just the button name
-        if ModeBinding.isMouseKeyCode(keyCode) {
+        // Mouse buttons and media keys: no modifier combos, just the name
+        if ModeBinding.isMouseKeyCode(keyCode) || ModeBinding.isMediaKeyCode(keyCode) {
             return singleKeyName(keyCode)
         }
 
@@ -240,6 +262,22 @@ struct HotkeyRecorderView: View {
             switch btn {
             case 2: return L("鼠标中键", "Mouse Middle")
             default: return L("鼠标 \(btn + 1)", "Mouse \(btn + 1)")  // button 3 → "Mouse 4", etc.
+            }
+        }
+
+        // Media keys (high-bit keyCode convention: 0x9000 + NX_KEYTYPE)
+        if ModeBinding.isMediaKeyCode(keyCode) {
+            let keyType = ModeBinding.mediaKeyType(from: keyCode)
+            switch keyType {
+            case 0:  return L("音量↑", "Vol ↑")
+            case 1:  return L("音量↓", "Vol ↓")
+            case 7:  return L("静音", "Mute")
+            case 16: return L("播放/暂停", "Play/Pause")
+            case 17: return L("下一曲", "Next")
+            case 18: return L("上一曲", "Prev")
+            case 19: return L("快进", "Fast")
+            case 20: return L("快退", "Rewind")
+            default: return L("媒体键\(keyType)", "Media\(keyType)")
             }
         }
 

--- a/Type4Me/UI/Settings/ModesSettingsTab.swift
+++ b/Type4Me/UI/Settings/ModesSettingsTab.swift
@@ -462,7 +462,7 @@ private struct HotkeyRecordingSheet: View {
                             .fill(TF.settingsAccentRed)
                             .frame(width: 8, height: 8)
                             .opacity(0.8)
-                        Text(L("按下快捷键或鼠标按键...", "Press a key or mouse button..."))
+                        Text(L("按下快捷键、鼠标或耳机按键...", "Press a key, mouse or headphone button..."))
                             .font(.system(size: 14))
                             .foregroundStyle(TF.settingsTextSecondary)
                     }
@@ -538,6 +538,19 @@ private struct HotkeyRecordingSheet: View {
                 .fixedSize(horizontal: false, vertical: true)
             }
 
+            if let kc = capturedKeyCode, ModeBinding.isMediaKeyCode(kc) {
+                let keyType = ModeBinding.mediaKeyType(from: kc)
+                if keyType == 0 || keyType == 1 || keyType == 7 {
+                    Text(L(
+                        "⚠️ 绑定音量/静音键后，按下该键时系统音量将不会改变",
+                        "⚠️ When volume/mute key is bound, pressing it will not change system volume"
+                    ))
+                    .font(.system(size: 11))
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
             HStack(spacing: 12) {
                 if !isListening && capturedKeyCode != nil {
                     Button(L("重录", "Re-record")) {
@@ -594,7 +607,26 @@ private struct HotkeyRecordingSheet: View {
         cleanup()
         isListening = true
 
-        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.flagsChanged, .keyDown, .otherMouseDown]) { event in
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.flagsChanged, .keyDown, .otherMouseDown, .systemDefined]) { event in
+            // Media key (headphone buttons, keyboard media keys)
+            if event.type == .systemDefined {
+                guard event.subtype.rawValue == 8 else { return event }
+                let keyType = Int((event.data1 >> 16) & 0xFFFF)
+                let keyState = Int((event.data1 >> 8) & 0xFF)
+                guard keyState == 0x0A else { return event }  // key down only
+                guard HotkeyRecorderView.isKnownMediaKeyType(keyType) else { return event }
+
+                modifierCaptureTask?.cancel()
+                modifierCaptureTask = nil
+                pendingModifierCode = nil
+
+                capturedKeyCode = ModeBinding.mediaKeyCode(for: keyType)
+                capturedModifiers = 0
+                isListening = false
+                removeMonitor()
+                return nil
+            }
+
             // Mouse button (middle click, side buttons)
             if event.type == .otherMouseDown {
                 let buttonNumber = event.buttonNumber


### PR DESCRIPTION
允许录制有线/无线耳机按钮（播放/暂停、音量加/减、静音、上一曲/下一曲）并将其用作模式热键，此功能与现有对键盘和鼠标按钮的支持并行。

- 在模式绑定（ModeBinding）中新增媒体键编码（0x9000 + NX_KEYTYPE）
- 在热键管理器（HotkeyManager）的事件分接器中捕获kCGEventSystemDefined类型事件
- 在热键录制器视图中添加.systemDefined类型事件的监听
- 为所有媒体键添加本地化显示名称
- 绑定音量/静音键时显示警告（系统音量功能将被禁用）