### PR TITLE
feat: Add recording effect text setting and cancel action｜增加录音动效文字开关&点击录音动效红点取消录音

### DIFF
--- a/Type4Me/Type4MeApp.swift
+++ b/Type4Me/Type4MeApp.swift
@@ -80,7 +80,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         DebugFileLogger.startSession()
         DebugFileLogger.log("applicationDidFinishLaunching")
-        floatingBarController = FloatingBarController(state: appState)
+        floatingBarController = FloatingBarController(
+            state: appState,
+            onCancelRecording: { [weak self] in
+                self?.cancelRecordingFromFloatingBar()
+            }
+        )
 
         // Bridge ASR events → AppState for floating bar display
         let session = self.session
@@ -630,6 +635,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         hotkeyManager.resetActiveState()
+    }
+
+    private func cancelRecordingFromFloatingBar() {
+        let phase = appState.barPhase
+        guard phase == .recording || phase == .preparing else { return }
+
+        DebugFileLogger.log("floating bar cancel tap phase=\(phase)")
+        hotkeyManager.isProcessing = false
+        hotkeyManager.resetActiveState()
+        appState.showCancelled()
+
+        Task {
+            await session.cancelRecording()
+        }
     }
 
     private func userFacingMessage(for error: Error) -> String {

--- a/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
@@ -53,16 +53,19 @@ final class FloatingBarController {
     private let panelSize: NSSize
     private var panelGeneration = 0
 
-    init(state: AppState) {
+    init(state: AppState, onCancelRecording: @escaping () -> Void) {
         self.state = state
 
         let inset: CGFloat = 16  // extra room for shadow/glow
-        let contentHeight = TF.barHeight + TF.transcriptPopupGap + TF.transcriptPopupMaxHeight
+        let contentHeight = TF.barHeight
         let frame = NSRect(x: 0, y: 0, width: TF.barWidth + inset * 2, height: contentHeight + inset * 2)
         panelSize = frame.size
         panel = FloatingBarPanel(contentRect: frame)
 
-        let barView = FloatingBarView<AppState>(state: state)
+        let barView = FloatingBarView<AppState>(
+            state: state,
+            onCancelRecording: onCancelRecording
+        )
         let hosting = NSHostingView(rootView: barView)
         hosting.layer?.backgroundColor = .clear
         hosting.frame = NSRect(origin: .zero, size: frame.size)

--- a/Type4Me/UI/FloatingBar/FloatingBarView.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarView.swift
@@ -29,34 +29,28 @@ protocol FloatingBarState: AnyObject, Observable {
 struct FloatingBarView<S: FloatingBarState>: View {
 
     let state: S
-
+    var onCancelRecording: (() -> Void)?
 
     @State private var breathe = false
     @State private var doneGlow = true
-    /// High-water mark: only grows during recording, never shrinks (prevents ASR correction jitter)
-    @State private var recordingPeakWidth: CGFloat = TF.barHeight
+    /// High-water mark: only grows during recording, never shrinks on small ASR corrections.
+    @State private var recordingPeakWidth: CGFloat = RecordingEffectLayout.defaultCompactWidth(from: TF.barWidthCompact)
     @State private var processingStartDate: Date?
     @State private var doneStartDate: Date?
-    @State private var isHovered = false
-    @AppStorage("tf_hoverTranscriptPreview") private var hoverTranscriptPreview = true
+    @AppStorage(RecordingEffectLayout.storageKey) private var showRecordingEffectText = RecordingEffectLayout.defaultShowsText
 
-    // MARK: - Transcript Popup
-
-    private var showTranscriptPopup: Bool {
-        guard hoverTranscriptPreview, isHovered, state.barPhase == .recording, !state.segments.isEmpty else { return false }
-        let textWidth = measureText(state.transcriptionText)
-        return textWidth + 66 > TF.barWidth
-    }
+    private let recordingEffectLayout = RecordingEffectLayout(
+        compactWidth: RecordingEffectLayout.defaultCompactWidth(from: TF.barWidthCompact),
+        maxWidth: TF.barWidth,
+        textPaddingWidth: RecordingEffectLayout.defaultTextPaddingWidth
+    )
 
     private var capsuleWidth: CGFloat {
         switch state.barPhase {
         case .preparing:
             return TF.barHeight
         case .recording:
-            if state.segments.isEmpty {
-                return state.isQwen3OnlyMode ? 110 : TF.barHeight
-            }
-            return recordingPeakWidth
+            return recordingWidth
         case .processing:
             return measureText(state.effectiveProcessingLabel) + 66.0
         case .done:
@@ -69,15 +63,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 
     var body: some View {
-        VStack(spacing: TF.transcriptPopupGap) {
-            if showTranscriptPopup {
-                transcriptPopup
-                    .transition(.asymmetric(
-                        insertion: .scale(scale: 0.95, anchor: .bottom).combined(with: .opacity),
-                        removal: .opacity
-                    ))
-            }
-
+        VStack(spacing: 0) {
             if state.barPhase != .hidden {
                 capsuleBar
                 .transition(.asymmetric(
@@ -86,38 +72,17 @@ struct FloatingBarView<S: FloatingBarState>: View {
                 ))
             }
         }
-        .background {
-            FloatingBarHoverTracker { hovered in
-                withAnimation(TF.springSnappy) {
-                    isHovered = hovered
-                }
-            }
-        }
         .padding(.bottom, 16)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
         .animation(TF.springSnappy, value: state.barPhase != .hidden)
-        .animation(TF.springSnappy, value: showTranscriptPopup)
         .onChange(of: state.barPhase) { _, newPhase in
             handlePhaseChange(newPhase)
         }
         .onChange(of: state.segments) { _, newSegments in
-            guard state.barPhase == .recording else { return }
-            let text = newSegments.map(\.text).joined()
-            let textWidth = measureText(text)
-            let needed = min(TF.barWidth, max(TF.barHeight, textWidth + 66.0))
-            if needed > recordingPeakWidth {
-                // Growing: fixed velocity 250pt/s
-                let distance = needed - recordingPeakWidth
-                let duration = max(0.12, Double(distance / 250.0))
-                withAnimation(.linear(duration: duration)) {
-                    recordingPeakWidth = needed
-                }
-            } else if recordingPeakWidth - needed > 30 {
-                // Large correction (hotword etc.): allow shrink
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    recordingPeakWidth = needed
-                }
-            }
+            updateRecordingPeakWidth(for: newSegments, animated: true)
+        }
+        .onChange(of: showRecordingEffectText) { _, _ in
+            updateRecordingPeakWidth(for: state.segments, animated: true)
         }
     }
 
@@ -185,45 +150,74 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
     private var recordingContent: some View {
         HStack(spacing: 10) {
-            // Module 1: dot (fixed position, 14pt from left edge)
-            RecordingDot(meter: state.audioLevel)
+            Button {
+                onCancelRecording?()
+            } label: {
+                RecordingDot(meter: state.audioLevel)
+            }
+            .buttonStyle(.plain)
+            .contentShape(Circle())
+            .accessibilityLabel(Text(L("取消录音", "Cancel recording")))
+            .help(L("取消录音", "Cancel recording"))
 
-            // Module 2: text container (fills remaining space, grows with frame)
-            // Uses overlay so text sizing never affects HStack layout
-            if state.segments.isEmpty && state.isQwen3OnlyMode {
-                Text(L("录音中", "Recording"))
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(.white)
-            } else if !state.segments.isEmpty {
-                Color.clear
-                    .overlay(alignment: .trailing) {
-                        Text(state.transcriptionText)
-                            .font(.system(size: 14, weight: .medium))
-                            .foregroundStyle(.white)
-                            .lineLimit(1)
-                            .fixedSize(horizontal: true, vertical: false)
-                    }
-                    .mask {
-                        if recordingPeakWidth >= TF.barWidth {
-                            HStack(spacing: 0) {
-                                LinearGradient(
-                                    colors: [.clear, .white],
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                )
-                                .frame(width: 12)
-                                Rectangle()
-                            }
-                        } else {
-                            Rectangle()
-                        }
-                    }
-                    .padding(.trailing, 4)
-                    .allowsHitTesting(false)
-                    .transition(.opacity)
+            if recordingTextContent != .hidden {
+                recordingTranscriptContent
+            } else {
+                Spacer(minLength: 0)
             }
         }
         .padding(.horizontal, 14)
+        .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder
+    private var recordingTranscriptContent: some View {
+        if recordingTextContent == .qwenPlaceholder {
+            Text(recordingText)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(.white)
+        } else if recordingTextContent == .transcript {
+            Color.clear
+                .overlay(alignment: .trailing) {
+                    Text(state.transcriptionText)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
+                }
+                .mask {
+                    if recordingPeakWidth >= TF.barWidth {
+                        HStack(spacing: 0) {
+                            LinearGradient(
+                                colors: [.clear, .white],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                            .frame(width: 12)
+                            Rectangle()
+                        }
+                    } else {
+                        Rectangle()
+                    }
+                }
+                .padding(.trailing, 4)
+                .allowsHitTesting(false)
+                .transition(.opacity)
+        } else {
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var recordingTextContent: RecordingEffectLayout.Content {
+        RecordingEffectLayout.content(
+            showText: showRecordingEffectText,
+            hasSegments: !state.segments.isEmpty,
+            isQwen3OnlyMode: state.isQwen3OnlyMode
+        )
+    }
+
+    private var recordingText: String {
+        recordingText(for: recordingTextContent, segments: state.segments)
     }
 
     private var processingContent: some View {
@@ -312,16 +306,9 @@ struct FloatingBarView<S: FloatingBarState>: View {
     // MARK: - Phase Transitions
 
     private func handlePhaseChange(_ phase: FloatingBarPhase) {
-        // Reset hover state on panel show/hide boundaries.
-        // NSTrackingArea suspends events when the view is hidden (panel orderOut)
-        // instead of firing mouseExited, so isHovered would otherwise leak across
-        // recording sessions and auto-show the popup without any actual hover.
-        if phase == .preparing || phase == .hidden {
-            isHovered = false
-        }
         switch phase {
         case .preparing:
-            recordingPeakWidth = TF.barHeight
+            recordingPeakWidth = recordingEffectLayout.compactWidth
             processingStartDate = nil
             doneStartDate = nil
             breathe = false
@@ -329,7 +316,11 @@ struct FloatingBarView<S: FloatingBarState>: View {
                 breathe = true
             }
         case .recording:
-            recordingPeakWidth = TF.barHeight
+            recordingPeakWidth = recordingEffectLayout.nextPeakWidth(
+                content: recordingTextContent,
+                currentPeak: recordingEffectLayout.compactWidth,
+                textWidth: measureText(recordingText)
+            )
             breathe = false
             withAnimation(.easeInOut(duration: 2.0).repeatForever(autoreverses: true)) {
                 breathe = true
@@ -351,6 +342,53 @@ struct FloatingBarView<S: FloatingBarState>: View {
         }
     }
 
+    private var recordingWidth: CGFloat {
+        recordingEffectLayout.recordingWidth(
+            content: recordingTextContent,
+            peakWidth: recordingPeakWidth
+        )
+    }
+
+    private func updateRecordingPeakWidth(for segments: [TranscriptionSegment], animated: Bool) {
+        guard state.barPhase == .recording else { return }
+
+        let content = RecordingEffectLayout.content(
+            showText: showRecordingEffectText,
+            hasSegments: !segments.isEmpty,
+            isQwen3OnlyMode: state.isQwen3OnlyMode
+        )
+        let text = recordingText(for: content, segments: segments)
+        let needed = recordingEffectLayout.nextPeakWidth(
+            content: content,
+            currentPeak: recordingPeakWidth,
+            textWidth: measureText(text)
+        )
+        guard needed != recordingPeakWidth else { return }
+
+        let update = {
+            recordingPeakWidth = needed
+        }
+
+        if needed > recordingPeakWidth {
+            let distance = needed - recordingPeakWidth
+            let duration = max(0.12, Double(distance / 250.0))
+            withAnimation(animated ? .linear(duration: duration) : nil, update)
+        } else if recordingPeakWidth - needed > 30 {
+            withAnimation(animated ? .easeInOut(duration: 0.2) : nil, update)
+        }
+    }
+
+    private func recordingText(for content: RecordingEffectLayout.Content, segments: [TranscriptionSegment]) -> String {
+        switch content {
+        case .hidden:
+            return ""
+        case .qwenPlaceholder:
+            return L("录音中", "Recording")
+        case .transcript:
+            return segments.map(\.text).joined()
+        }
+    }
+
     private func feedbackWidth(for message: String) -> CGFloat {
         measureText(message) + 66.0
     }
@@ -358,24 +396,6 @@ struct FloatingBarView<S: FloatingBarState>: View {
     /// Measure actual rendered width using the same font as the floating bar text.
     private func measureText(_ string: String) -> CGFloat {
         ceil((string as NSString).size(withAttributes: [.font: floatingBarFont]).width)
-    }
-
-    // MARK: - Transcript Popup View
-
-    private var transcriptPopup: some View {
-        Text(state.transcriptionText)
-            .font(.system(size: 14, weight: .medium))
-            .foregroundStyle(.white)
-            .fixedSize(horizontal: false, vertical: true)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(12)
-            .frame(width: TF.barWidth)
-            .background(
-                RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous)
-                    .fill(Color(white: 0.08, opacity: 0.78))
-            )
-            .clipShape(RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous))
-            .shadow(color: Color.black.opacity(0.3), radius: 8, y: -2)
     }
 }
 
@@ -894,58 +914,5 @@ private final class LevelTimeline {
         }
         levels[levels.count - 1] = currentLevel
         return levels
-    }
-}
-
-// MARK: - Hover Tracking (works even when app is not active)
-
-/// Uses NSTrackingArea with `.activeAlways` so hover fires on a non-key,
-/// non-activating NSPanel regardless of which app is in the foreground.
-struct FloatingBarHoverTracker: NSViewRepresentable {
-    let onHoverChanged: (Bool) -> Void
-
-    func makeNSView(context: Context) -> HoverTrackingNSView {
-        let view = HoverTrackingNSView()
-        view.onHoverChanged = onHoverChanged
-        return view
-    }
-
-    func updateNSView(_ nsView: HoverTrackingNSView, context: Context) {
-        nsView.onHoverChanged = onHoverChanged
-    }
-}
-
-final class HoverTrackingNSView: NSView {
-    var onHoverChanged: ((Bool) -> Void)?
-    private var enterWorkItem: DispatchWorkItem?
-
-    override func updateTrackingAreas() {
-        for area in trackingAreas { removeTrackingArea(area) }
-        addTrackingArea(NSTrackingArea(
-            rect: bounds,
-            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
-            owner: self
-        ))
-        super.updateTrackingAreas()
-    }
-
-    override func mouseEntered(with event: NSEvent) {
-        enterWorkItem?.cancel()
-        let work = DispatchWorkItem { [weak self] in
-            guard let self, let window = self.window else { return }
-            // Re-check mouse position at trigger time: updateTrackingAreas()
-            // sends synthetic mouseEntered when the tracking area is recreated
-            // with the cursor inside (e.g. bar grows during recording).
-            let mouseInView = self.convert(window.mouseLocationOutsideOfEventStream, from: nil)
-            guard self.bounds.contains(mouseInView) else { return }
-            self.onHoverChanged?(true)
-        }
-        enterWorkItem = work
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: work)
-    }
-
-    override func mouseExited(with event: NSEvent) {
-        enterWorkItem?.cancel()
-        onHoverChanged?(false)
     }
 }

--- a/Type4Me/UI/FloatingBar/RecordingEffectLayout.swift
+++ b/Type4Me/UI/FloatingBar/RecordingEffectLayout.swift
@@ -1,0 +1,48 @@
+import CoreGraphics
+
+struct RecordingEffectLayout {
+
+    enum Content: Equatable {
+        case hidden
+        case qwenPlaceholder
+        case transcript
+    }
+
+    static let storageKey = "tf_showRecordingEffectText"
+    static let defaultShowsText = false
+    static let defaultTextPaddingWidth: CGFloat = 66.0
+    static let defaultCompactWidthRatio: CGFloat = 0.5
+
+    let compactWidth: CGFloat
+    let maxWidth: CGFloat
+    let textPaddingWidth: CGFloat
+
+    static func defaultCompactWidth(from baseCompactWidth: CGFloat) -> CGFloat {
+        baseCompactWidth * defaultCompactWidthRatio
+    }
+
+    func recordingWidth(content: Content, peakWidth: CGFloat) -> CGFloat {
+        guard content != .hidden else { return compactWidth }
+        return peakWidth
+    }
+
+    func neededWidth(textWidth: CGFloat) -> CGFloat {
+        min(maxWidth, max(compactWidth, textWidth + textPaddingWidth))
+    }
+
+    func nextPeakWidth(content: Content, currentPeak: CGFloat, textWidth: CGFloat) -> CGFloat {
+        guard content != .hidden else { return compactWidth }
+
+        let needed = neededWidth(textWidth: textWidth)
+        if needed > currentPeak || currentPeak - needed > 30 {
+            return needed
+        }
+        return currentPeak
+    }
+
+    static func content(showText: Bool, hasSegments: Bool, isQwen3OnlyMode: Bool) -> Content {
+        guard showText else { return .hidden }
+        if hasSegments { return .transcript }
+        return isQwen3OnlyMode ? .qwenPlaceholder : .hidden
+    }
+}

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -20,7 +20,7 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
     @AppStorage("tf_showDockIcon") private var showDockIcon = true
     @AppStorage("tf_bypassProxy") private var bypassProxy = "off"
     @AppStorage("tf_stripTrailingPunctuation") private var stripTrailingPunctuation = "off"
-    @AppStorage("tf_hoverTranscriptPreview") private var hoverTranscriptPreview = true
+    @AppStorage(RecordingEffectLayout.storageKey) private var showRecordingEffectText = RecordingEffectLayout.defaultShowsText
     @AppStorage("tf_micKeepAlive") private var micKeepAlive = false
     @AppStorage("tf_selectedMicrophoneUID") private var selectedMicrophoneUID = ""
     @AppStorage("tf_selectedSpeakerUID") private var selectedSpeakerUID = ""
@@ -57,11 +57,21 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
 
                 SettingsDivider()
 
-                // Row 2: 录音动效 / 麦克风保活
+                // Row 2: 录音动效 / 动效文字
                 HStack(alignment: .top, spacing: 16) {
                     visualStyleRow
                         .frame(maxWidth: .infinity)
+                    recordingEffectTextRow
+                        .frame(maxWidth: .infinity)
+                }
+
+                SettingsDivider()
+
+                // Row 3: 麦克风保活
+                HStack(alignment: .top, spacing: 16) {
                     micKeepAliveRow
+                        .frame(maxWidth: .infinity)
+                    Spacer()
                         .frame(maxWidth: .infinity)
                 }
             }
@@ -83,11 +93,11 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
 
                 SettingsDivider()
 
-                // Row 2: 去句末标点 / 悬停文字预览
+                // Row 2: 去句末标点
                 HStack(alignment: .top, spacing: 16) {
                     stripPunctuationRow
                         .frame(maxWidth: .infinity)
-                    hoverPreviewRow
+                    Spacer()
                         .frame(maxWidth: .infinity)
                 }
             }
@@ -370,24 +380,16 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
         .padding(.vertical, 6)
     }
 
-    private var hoverPreviewRow: some View {
+    private var recordingEffectTextRow: some View {
         VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 4) {
-                Text(L("悬停文字预览", "Hover Text Preview").uppercased())
-                    .font(.system(size: 10, weight: .semibold))
-                    .tracking(0.8)
-                    .foregroundStyle(TF.settingsTextTertiary)
-                Text("|")
-                    .font(.system(size: 10))
-                    .foregroundStyle(TF.settingsTextTertiary.opacity(0.5))
-                Text(L("鼠标悬停悬浮条时显示完整文本", "Show full text when hovering the bar"))
-                    .font(.system(size: 10))
-                    .foregroundStyle(TF.settingsTextTertiary)
-            }
+            Text(L("录音动效文字", "Recording Effect Text").uppercased())
+                .font(.system(size: 10, weight: .semibold))
+                .tracking(0.8)
+                .foregroundStyle(TF.settingsTextTertiary)
             settingsDropdown(
                 selection: Binding(
-                    get: { hoverTranscriptPreview ? "on" : "off" },
-                    set: { hoverTranscriptPreview = $0 == "on" }
+                    get: { showRecordingEffectText ? "on" : "off" },
+                    set: { showRecordingEffectText = $0 == "on" }
                 ),
                 options: [
                     ("on", L("开启", "On")),

--- a/Type4MeTests/RecordingEffectLayoutTests.swift
+++ b/Type4MeTests/RecordingEffectLayoutTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import Type4Me
+
+final class RecordingEffectLayoutTests: XCTestCase {
+
+    private let layout = RecordingEffectLayout(
+        compactWidth: 100,
+        maxWidth: 400,
+        textPaddingWidth: 66
+    )
+
+    func testDefaultHidesRecordingEffectText() {
+        XCTAssertEqual(RecordingEffectLayout.storageKey, "tf_showRecordingEffectText")
+        XCTAssertFalse(RecordingEffectLayout.defaultShowsText)
+    }
+
+    func testDefaultCompactWidthIsHalfOfBaseCompactWidth() {
+        XCTAssertEqual(RecordingEffectLayout.defaultCompactWidth(from: 200), 100)
+    }
+
+    func testContentIsHiddenWhenToggleIsOff() {
+        XCTAssertEqual(
+            RecordingEffectLayout.content(showText: false, hasSegments: true, isQwen3OnlyMode: true),
+            .hidden
+        )
+        XCTAssertEqual(
+            RecordingEffectLayout.content(showText: false, hasSegments: false, isQwen3OnlyMode: true),
+            .hidden
+        )
+    }
+
+    func testContentUsesPlaceholderForQwen3OnlyRecordingWhenToggleIsOn() {
+        XCTAssertEqual(
+            RecordingEffectLayout.content(showText: true, hasSegments: false, isQwen3OnlyMode: true),
+            .qwenPlaceholder
+        )
+    }
+
+    func testContentShowsTranscriptOnlyWhenToggleIsOnAndSegmentsExist() {
+        XCTAssertEqual(
+            RecordingEffectLayout.content(showText: true, hasSegments: true, isQwen3OnlyMode: false),
+            .transcript
+        )
+        XCTAssertEqual(
+            RecordingEffectLayout.content(showText: true, hasSegments: false, isQwen3OnlyMode: false),
+            .hidden
+        )
+    }
+
+    func testRecordingWidthStaysCompactWhenToggleIsOff() {
+        XCTAssertEqual(
+            layout.recordingWidth(content: .hidden, peakWidth: 390),
+            100
+        )
+    }
+
+    func testRecordingWidthUsesPeakWhenTextIsVisible() {
+        XCTAssertEqual(
+            layout.recordingWidth(content: .qwenPlaceholder, peakWidth: 130),
+            130
+        )
+        XCTAssertEqual(
+            layout.recordingWidth(content: .transcript, peakWidth: 390),
+            390
+        )
+    }
+
+    func testNeededWidthClampsToCompactAndMaxWidth() {
+        XCTAssertEqual(layout.neededWidth(textWidth: 20), 100)
+        XCTAssertEqual(layout.neededWidth(textWidth: 200), 266)
+        XCTAssertEqual(layout.neededWidth(textWidth: 500), 400)
+    }
+
+    func testNextPeakWidthResetsToCompactWhenToggleIsOff() {
+        XCTAssertEqual(
+            layout.nextPeakWidth(content: .hidden, currentPeak: 390, textWidth: 500),
+            100
+        )
+    }
+
+    func testNextPeakWidthGrowsForLongerText() {
+        XCTAssertEqual(
+            layout.nextPeakWidth(content: .transcript, currentPeak: 220, textWidth: 260),
+            326
+        )
+    }
+
+    func testNextPeakWidthGrowsForQwenPlaceholderText() {
+        XCTAssertEqual(
+            layout.nextPeakWidth(content: .qwenPlaceholder, currentPeak: 100, textWidth: 70),
+            136
+        )
+    }
+
+    func testNextPeakWidthKeepsPeakForSmallCorrections() {
+        XCTAssertEqual(
+            layout.nextPeakWidth(content: .transcript, currentPeak: 350, textWidth: 260),
+            350
+        )
+    }
+
+    func testNextPeakWidthShrinksForLargeCorrections() {
+        XCTAssertEqual(
+            layout.nextPeakWidth(content: .transcript, currentPeak: 390, textWidth: 260),
+            326
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Add a setting to control whether text is shown inside the recording effect.
- Allow clicking the red button in the recording effect to cancel recording.

## Implementation Notes

- Added `RecordingEffectLayout` as a focused, testable layout policy for recording bar behavior.
- Centralized the AppStorage key/default for the recording effect text setting so `FloatingBarView` and `GeneralSettingsTab` stay consistent.
- Removed the previous hover transcript preview path from the recording bar.

## Tests

- `swift build`
- `swift test --filter RecordingEffectLayoutTests`
- `swift test --filter AppStateTests`

## Local Verification

- Rebuilt the cloud/pure app bundle.
- Replaced `/Applications/Type4Me.app`.
- Launched the updated app locally.

---

## 概要

- 新增设置项，用于控制是否在录音动效中展示文字。
- 支持点击录音动效中的红色按钮取消录音。

## 实现说明

- 新增 `RecordingEffectLayout`，把录音条的布局行为收敛成可测试的小型策略对象。
- 统一 `FloatingBarView` 和 `GeneralSettingsTab` 使用的 AppStorage key 和默认值，避免配置漂移。
- 移除了录音条之前的悬停文字预览路径。

## 测试

- `swift build`
- `swift test --filter RecordingEffectLayoutTests`
- `swift test --filter AppStateTests`

## 本地验证

- 已重新构建 cloud/pure 版本 app。
- 已覆盖安装到 `/Applications/Type4Me.app`。
- 已在本机启动更新后的 app。