### PR TITLE
fix: expand trigger style button hit area to full button width

### DIFF
--- a/Type4Me/UI/Settings/ModesSettingsTab.swift
+++ b/Type4Me/UI/Settings/ModesSettingsTab.swift
@@ -517,6 +517,7 @@ private struct HotkeyRecordingSheet: View {
                                     RoundedRectangle(cornerRadius: 5)
                                         .fill(selected ? TF.settingsNavActive : .clear)
                                 )
+                                .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
                     }


### PR DESCRIPTION
- Fix trigger style buttons ("Hold to record" / "Toggle") in hotkey settings
   only responding to clicks on the text label
- Added `.contentShape(Rectangle())` to each button's label so the entire button
   area is clickable