### PR TITLE
feat(asr): add low-volume whisper fallback

### DIFF
--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -10,6 +10,14 @@ private final class UploadFailureFlag: Sendable {
     }
 }
 
+private enum WhisperFallbackSettings {
+    static let enabledKey = "tf_whisperFallbackEnabled"
+    static let rmsThresholdKey = "tf_whisperFallbackRMSThreshold"
+    static let minDuration: TimeInterval = 0.8
+    static let defaultRMSThreshold = 0.006
+    static let pcmBytesPerSecond = 16000 * 2
+}
+
 actor RecognitionSession {
 
     // MARK: - State
@@ -670,17 +678,33 @@ actor RecognitionSession {
             }
             eventConsumptionTask?.cancel()
             eventConsumptionTask = nil
-            onASREvent?(.processingResult(text: ""))
-            onASREvent?(.completed)
-            if sessionGeneration == myGeneration, state != .idle {
-                state = .idle
-                hasEmittedReadyForCurrentSession = false
-                currentTranscript = .empty
-                warmUpASRConnection()
+            let fullAudio = audioEngine.getRecordedAudio()
+            if let fallbackText = await attemptWhisperFallbackIfNeeded(
+                audio: fullAudio,
+                localText: "",
+                reason: "no-speech"
+            ) {
+                currentTranscript = RecognitionTranscript(
+                    confirmedSegments: [fallbackText],
+                    partialText: "",
+                    authoritativeText: fallbackText,
+                    isFinal: true
+                )
+                onASREvent?(.processingResult(text: fallbackText))
+                DebugFileLogger.log("stop: whisper fallback recovered no-speech session (\(fallbackText.count) chars)")
+            } else {
+                onASREvent?(.processingResult(text: ""))
+                onASREvent?(.completed)
+                if sessionGeneration == myGeneration, state != .idle {
+                    state = .idle
+                    hasEmittedReadyForCurrentSession = false
+                    currentTranscript = .empty
+                    warmUpASRConnection()
+                }
+                resetSpeculativeLLM()
+                SystemVolumeManager.restore()
+                return
             }
-            resetSpeculativeLLM()
-            SystemVolumeManager.restore()
-            return
         }
 
         // Two-phase wait: for streaming providers with short recordings and no
@@ -689,7 +713,7 @@ actor RecognitionSession {
         // Phase 2: if text arrives, endAudio + wait up to 1s for final result.
         let provider = activeProvider
         let providerIsStreaming = ASRProviderRegistry.capabilities(for: provider).isStreaming
-        if providerIsStreaming {
+        if speechDetected && providerIsStreaming {
             let duration = recordingStartTime.map { Date().timeIntervalSince($0) } ?? 0
             let hasStreamingText = !currentTranscript.composedText
                 .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -707,17 +731,33 @@ actor RecognitionSession {
                     }
                     eventConsumptionTask?.cancel()
                     eventConsumptionTask = nil
-                    onASREvent?(.processingResult(text: ""))
-                    onASREvent?(.completed)
-                    if sessionGeneration == myGeneration, state != .idle {
-                        state = .idle
-                        hasEmittedReadyForCurrentSession = false
-                        currentTranscript = .empty
-                        warmUpASRConnection()
+                    let fullAudio = audioEngine.getRecordedAudio()
+                    if let fallbackText = await attemptWhisperFallbackIfNeeded(
+                        audio: fullAudio,
+                        localText: "",
+                        reason: "short-no-streaming-text"
+                    ) {
+                        currentTranscript = RecognitionTranscript(
+                            confirmedSegments: [fallbackText],
+                            partialText: "",
+                            authoritativeText: fallbackText,
+                            isFinal: true
+                        )
+                        onASREvent?(.processingResult(text: fallbackText))
+                        DebugFileLogger.log("stop: whisper fallback recovered short silent session (\(fallbackText.count) chars)")
+                    } else {
+                        onASREvent?(.processingResult(text: ""))
+                        onASREvent?(.completed)
+                        if sessionGeneration == myGeneration, state != .idle {
+                            state = .idle
+                            hasEmittedReadyForCurrentSession = false
+                            currentTranscript = .empty
+                            warmUpASRConnection()
+                        }
+                        resetSpeculativeLLM()
+                        SystemVolumeManager.restore()
+                        return
                     }
-                    resetSpeculativeLLM()
-                    SystemVolumeManager.restore()
-                    return
                 }
 
                 // Phase 2: streaming text arrived — endAudio + short wait for final
@@ -818,6 +858,37 @@ actor RecognitionSession {
             }
         }
 
+        // Batch fallback is reserved for transport/server failures. Whisper fallback
+        // handles quiet local audio before LLM work starts, so downstream processing
+        // uses the recovered transcript rather than the sparse local result.
+        let uploadFailed = uploadFailureFlag?.failed == true
+        let hasUsableStreamingResult = !currentTranscript.confirmedSegments.isEmpty
+        let streamingFailed = Self.shouldAttemptBatchFallback(
+            uploadFailed: uploadFailed,
+            asrTeardownClean: asrTeardownClean,
+            streamingError: lastStreamingError
+        )
+        let needsBatchFallback = streamingFailed
+            && (uploadFailed || lastStreamingError != nil || !hasUsableStreamingResult)
+        if !needsBatchFallback {
+            let localText = currentTranscript.displayText
+            let fullAudio = audioEngine.getRecordedAudio()
+            if let fallbackText = await attemptWhisperFallbackIfNeeded(
+                audio: fullAudio,
+                localText: localText,
+                reason: "low-volume-or-poor-local-result"
+            ) {
+                currentTranscript = RecognitionTranscript(
+                    confirmedSegments: [fallbackText],
+                    partialText: "",
+                    authoritativeText: fallbackText,
+                    isFinal: true
+                )
+                onASREvent?(.processingResult(text: fallbackText))
+                DebugFileLogger.log("stop: whisper fallback replaced local result (\(localText.count) -> \(fallbackText.count) chars)")
+            }
+        }
+
         // Now that we have the final transcript, decide whether to reuse
         // the speculative LLM result or fire a fresh request.
         let canEarlyLLM = providerIsStreaming
@@ -882,15 +953,6 @@ actor RecognitionSession {
         // Batch fallback: only when the server is truly missing audio (upload failed).
         // If upload was fine but drain timed out, the server already has all audio;
         // use whatever streaming produced rather than re-sending everything.
-        let uploadFailed = uploadFailureFlag?.failed == true
-        let hasUsableStreamingResult = !currentTranscript.confirmedSegments.isEmpty
-        let streamingFailed = Self.shouldAttemptBatchFallback(
-            uploadFailed: uploadFailed,
-            asrTeardownClean: asrTeardownClean,
-            streamingError: lastStreamingError
-        )
-        let needsBatchFallback = streamingFailed
-            && (uploadFailed || lastStreamingError != nil || !hasUsableStreamingResult)
         if streamingFailed && !needsBatchFallback {
             DebugFileLogger.log("stop: drain timeout but streaming has confirmed text, skipping batch fallback")
         }
@@ -1518,6 +1580,152 @@ actor RecognitionSession {
     }
 
     // MARK: - Batch Fallback
+
+    private func attemptWhisperFallbackIfNeeded(audio: Data, localText: String, reason: String) async -> String? {
+        let enabled = UserDefaults.standard.object(forKey: WhisperFallbackSettings.enabledKey) as? Bool ?? false
+        guard enabled else { return nil }
+        guard activeProvider != .volcano else { return nil }
+        guard let volcanoConfig = KeychainService.loadASRConfig(for: .volcano) as? VolcanoASRConfig else {
+            DebugFileLogger.log("whisper fallback skipped: volcano config missing")
+            return nil
+        }
+
+        let duration = pcmDuration(audio)
+        guard duration >= WhisperFallbackSettings.minDuration else { return nil }
+
+        let rms = pcmRMS(audio)
+        let threshold = UserDefaults.standard.object(forKey: WhisperFallbackSettings.rmsThresholdKey) as? Double
+            ?? WhisperFallbackSettings.defaultRMSThreshold
+        let trimmed = localText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowVolume = rms > 0 && rms <= threshold
+        let poorLocalResult = trimmed.isEmpty
+            || trimmed.count <= 2
+            || (duration >= 2.0 && trimmed.count < 4)
+        let sparseLocalResult = trimmed.count < max(8, Int(duration * 2.0))
+        guard poorLocalResult || (lowVolume && sparseLocalResult) else { return nil }
+
+        DebugFileLogger.log(
+            "whisper fallback triggered reason=\(reason) duration=\(String(format: "%.1f", duration))s rms=\(String(format: "%.4f", rms)) threshold=\(String(format: "%.4f", threshold)) local=\(trimmed.count)chars"
+        )
+        onASREvent?(.processingLabelOverride(L("低声增强中", "Enhancing whisper")))
+        let result = await transcribeWithVolcano(audio: audio, config: volcanoConfig)
+        guard let text = result?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty else {
+            DebugFileLogger.log("whisper fallback failed or empty")
+            return nil
+        }
+
+        if trimmed.isEmpty || text.count >= max(3, trimmed.count) {
+            DebugFileLogger.log("whisper fallback accepted \(text.count) chars")
+            return text
+        }
+
+        DebugFileLogger.log("whisper fallback rejected: fallback shorter than local (\(text.count) < \(trimmed.count))")
+        return nil
+    }
+
+    private func pcmDuration(_ audio: Data) -> TimeInterval {
+        TimeInterval(audio.count) / TimeInterval(WhisperFallbackSettings.pcmBytesPerSecond)
+    }
+
+    private func pcmRMS(_ audio: Data) -> Double {
+        guard audio.count >= 2 else { return 0 }
+        var sumSquares = 0.0
+        var sampleCount = 0
+        audio.withUnsafeBytes { raw in
+            let bytes = raw.bindMemory(to: UInt8.self)
+            var i = 0
+            while i + 1 < bytes.count {
+                let lo = UInt16(bytes[i])
+                let hi = UInt16(bytes[i + 1]) << 8
+                let sample = Int16(bitPattern: hi | lo)
+                let normalized = Double(sample) / 32768.0
+                sumSquares += normalized * normalized
+                sampleCount += 1
+                i += 2
+            }
+        }
+        guard sampleCount > 0 else { return 0 }
+        return sqrt(sumSquares / Double(sampleCount))
+    }
+
+    private func transcribeWithVolcano(audio: Data, config: VolcanoASRConfig) async -> String? {
+        let resultTask = Task.detached { () -> String? in
+            let client = VolcASRClient()
+            do {
+                let options = ASRRequestOptions(
+                    enablePunc: true,
+                    hotwords: HotwordStorage.loadEffective(),
+                    bypassProxy: ProxyBypassMode.current.bypassASR
+                )
+                try await client.connect(config: config, options: options)
+
+                let chunkSize = 6400
+                var offset = 0
+                while offset < audio.count {
+                    guard !Task.isCancelled else {
+                        await client.disconnect()
+                        return nil
+                    }
+                    let end = min(offset + chunkSize, audio.count)
+                    try await client.sendAudio(audio.subdata(in: offset..<end))
+                    offset = end
+                }
+                try await client.endAudio()
+
+                var bestText = ""
+                let events = await client.events
+                for await event in events {
+                    switch event {
+                    case .transcript(let transcript):
+                        let text = transcript.authoritativeText.isEmpty
+                            ? transcript.composedText
+                            : transcript.authoritativeText
+                        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            bestText = trimmed
+                        }
+                        if transcript.isFinal || (!transcript.confirmedSegments.isEmpty && transcript.partialText.isEmpty) {
+                            await client.disconnect()
+                            return bestText.isEmpty ? nil : bestText
+                        }
+                    case .error(let error):
+                        DebugFileLogger.log("whisper fallback volcano error: \(error)")
+                        await client.disconnect()
+                        return nil
+                    case .completed:
+                        await client.disconnect()
+                        return bestText.isEmpty ? nil : bestText
+                    default:
+                        continue
+                    }
+                }
+                await client.disconnect()
+                return nil
+            } catch {
+                DebugFileLogger.log("whisper fallback volcano exception: \(error)")
+                await client.disconnect()
+                return nil
+            }
+        }
+
+        return await withCheckedContinuation { continuation in
+            let finished = OSAllocatedUnfairLock(initialState: false)
+            Task.detached {
+                let result = await resultTask.value
+                if finished.withLock({ let old = $0; $0 = true; return !old }) {
+                    continuation.resume(returning: result)
+                }
+            }
+            Task.detached {
+                try? await Task.sleep(for: .seconds(30))
+                if finished.withLock({ let old = $0; $0 = true; return !old }) {
+                    resultTask.cancel()
+                    DebugFileLogger.log("whisper fallback timeout after 30s")
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
+    }
 
     /// Try to transcribe full audio via the same provider.
     /// Soniox uses its async REST API (faster for complete audio); others use a fresh streaming connection.

--- a/Type4Me/UI/Settings/ASRSettingsCard.swift
+++ b/Type4Me/UI/Settings/ASRSettingsCard.swift
@@ -25,6 +25,7 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
     @State private var qwen3Toggling = false
     @AppStorage("tf_qwen3FinalEnabled") private var qwen3FinalEnabled = true
     @AppStorage("tf_sensevoiceEnabled") private var sensevoiceEnabled = true
+    @AppStorage("tf_whisperFallbackEnabled") private var whisperFallbackEnabled = false
     @State private var qwen3StartError: String?
 
     private var currentASRFields: [CredentialField] {
@@ -58,6 +59,10 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
 
     private var isASRProviderAvailable: Bool {
         ASRProviderRegistry.entry(for: selectedASRProvider)?.isAvailable ?? false
+    }
+
+    private var hasVolcanoFallbackConfig: Bool {
+        KeychainService.loadASRConfig(for: .volcano) != nil
     }
 
     private var currentASRGuideLinks: [(prefix: String?, label: String, url: URL)] {
@@ -438,6 +443,8 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
                     #endif
                 }
 
+                whisperFallbackOption
+
                 HStack {
                     Spacer()
                     testButton(L("测试连接", "Test"), status: asrTestStatus) { testLocalModel() }
@@ -459,6 +466,52 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
             }
         }
         .padding(.vertical, 8)
+    }
+
+    private var whisperFallbackOption: some View {
+        let canEnable = hasVolcanoFallbackConfig
+        let enabledBinding = Binding<Bool>(
+            get: { whisperFallbackEnabled && canEnable },
+            set: { newValue in
+                whisperFallbackEnabled = canEnable ? newValue : false
+            }
+        )
+
+        return HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "moon.zzz.fill")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 26, height: 26)
+                .background(RoundedRectangle(cornerRadius: 7).fill(canEnable ? TF.settingsAccentBlue : TF.settingsTextTertiary))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(L("低声增强", "Whisper Enhancement"))
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(TF.settingsText)
+
+                Text(L("使用本地识别时，如果检测到低音量或本地结果过短，会调用火山引擎进行辅助识别。开启前必须先配置并保存火山引擎 (Doubao) API 凭证。",
+                       "When using local recognition, low-volume or very short local results can be rechecked with Volcano. Configure and save Volcano (Doubao) API credentials before enabling."))
+                    .font(.system(size: 10))
+                    .foregroundStyle(TF.settingsTextSecondary)
+                    .lineSpacing(2)
+
+                if !canEnable {
+                    Text(L("未检测到火山引擎配置，请先切换到火山引擎并保存凭证。",
+                           "Volcano credentials not found. Switch to Volcano and save credentials first."))
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(TF.settingsAccentAmber)
+                }
+            }
+
+            Spacer()
+
+            Toggle("", isOn: enabledBinding)
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .disabled(!canEnable)
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 8).fill(TF.settingsCardAlt))
     }
 
     private func staticEngineBlock(


### PR DESCRIPTION
## Summary
- add an opt-in Whisper Enhancement toggle for local ASR users with saved Volcano credentials
- detect low-volume or sparse local transcripts using PCM duration/RMS heuristics
- recheck affected recordings through Volcano before LLM processing so downstream polishing/actions use the recovered transcript

## Validation
- swift build
- swift test

## Notes
- Based on upstream v1.9.5 / origin/main at 256d47a.
- PR #23 for automatic system-volume lowering is already merged, so this PR only covers the later low-volume recognition fallback.