### PR TITLE
[codex] Add input device priority settings

### DIFF
--- a/Type4Me/Audio/AudioCaptureEngine.swift
+++ b/Type4Me/Audio/AudioCaptureEngine.swift
@@ -56,14 +56,14 @@ final class AudioCaptureEngine: NSObject, @unchecked Sendable, AVCaptureAudioDat
     /// Set before calling `start()`. Empty string or nil means system default.
     var selectedDeviceUID: String?
 
+    /// Returns rich metadata for available audio input devices.
+    static func availableAudioInputDevices() -> [AudioInputDevice] {
+        AudioInputDeviceDiscovery.availableInputDevices()
+    }
+
     /// Returns a list of available audio input devices (UID + display name).
     static func availableAudioDevices() -> [(uid: String, name: String)] {
-        let discoverySession = AVCaptureDevice.DiscoverySession(
-            deviceTypes: [.builtInMicrophone, .externalUnknown],
-            mediaType: .audio,
-            position: .unspecified
-        )
-        return discoverySession.devices.map { (uid: $0.uniqueID, name: $0.localizedName) }
+        availableAudioInputDevices().map { (uid: $0.uid, name: $0.name) }
     }
 
     /// Resolve the capture device: use selectedDeviceUID if set and valid, otherwise system default.

--- a/Type4Me/Audio/AudioInputDevicePreference.swift
+++ b/Type4Me/Audio/AudioInputDevicePreference.swift
@@ -1,0 +1,331 @@
+import AudioToolbox
+@preconcurrency import AVFoundation
+import CoreAudio
+import Foundation
+
+enum AudioInputDeviceCategory: String, CaseIterable, Codable, Equatable {
+    case bluetooth
+    case builtIn
+    case external
+    case virtual
+    case other
+
+    static let defaultPriorityOrder: [AudioInputDeviceCategory] = [
+        .bluetooth,
+        .builtIn,
+        .external,
+        .virtual,
+        .other,
+    ]
+
+    var displayName: String {
+        switch self {
+        case .bluetooth:
+            return L("蓝牙设备", "Bluetooth")
+        case .builtIn:
+            return L("内置麦克风", "Built-in")
+        case .external:
+            return L("外接/USB", "External/USB")
+        case .virtual:
+            return L("虚拟设备", "Virtual")
+        case .other:
+            return L("其他设备", "Other")
+        }
+    }
+}
+
+enum AudioInputDeviceSelectionMode: String, CaseIterable {
+    case systemDefault
+    case automatic
+    case manual
+
+    var displayName: String {
+        switch self {
+        case .systemDefault:
+            return L("系统默认", "System")
+        case .automatic:
+            return L("自动优先级", "Auto")
+        case .manual:
+            return L("固定设备", "Manual")
+        }
+    }
+}
+
+struct AudioInputDevice: Identifiable, Equatable {
+    var id: String { uid }
+    let uid: String
+    let name: String
+    let category: AudioInputDeviceCategory
+}
+
+enum AudioInputDevicePreferenceStore {
+    static let selectionModeKey = "tf_microphoneSelectionMode"
+    static let selectedUIDKey = "tf_selectedMicrophoneUID"
+    static let priorityOrderKey = "tf_microphonePriorityOrder"
+    static let defaultPriorityOrderStorageValue = storageValue(for: AudioInputDeviceCategory.defaultPriorityOrder)
+
+    static func migrateIfNeeded() {
+        guard UserDefaults.standard.object(forKey: selectionModeKey) == nil else { return }
+        let selectedUID = UserDefaults.standard.string(forKey: selectedUIDKey) ?? ""
+        let mode: AudioInputDeviceSelectionMode = selectedUID.isEmpty ? .systemDefault : .manual
+        UserDefaults.standard.set(mode.rawValue, forKey: selectionModeKey)
+    }
+
+    static func selectionMode() -> AudioInputDeviceSelectionMode {
+        migrateIfNeeded()
+        let rawValue = UserDefaults.standard.string(forKey: selectionModeKey)
+        return rawValue.flatMap(AudioInputDeviceSelectionMode.init(rawValue:)) ?? .systemDefault
+    }
+
+    static func priorityOrder() -> [AudioInputDeviceCategory] {
+        priorityOrder(from: UserDefaults.standard.string(forKey: priorityOrderKey))
+    }
+
+    static func priorityOrder(from rawValue: String?) -> [AudioInputDeviceCategory] {
+        let parsed = (rawValue ?? "")
+            .split(separator: ",")
+            .compactMap { AudioInputDeviceCategory(rawValue: String($0)) }
+        return normalizedPriorityOrder(parsed)
+    }
+
+    static func storageValue(for order: [AudioInputDeviceCategory]) -> String {
+        normalizedPriorityOrder(order)
+            .map(\.rawValue)
+            .joined(separator: ",")
+    }
+
+    static func resolvedDeviceUID(devices: [AudioInputDevice] = AudioInputDeviceDiscovery.availableInputDevices()) -> String? {
+        resolvedDevice(devices: devices)?.uid
+    }
+
+    static func resolvedCachedDeviceUID() -> String? {
+        switch selectionMode() {
+        case .systemDefault:
+            return nil
+        case .manual:
+            let selectedUID = UserDefaults.standard.string(forKey: selectedUIDKey) ?? ""
+            return selectedUID.isEmpty ? nil : selectedUID
+        case .automatic:
+            let order = priorityOrder()
+            if let cached = resolvedAutomaticDevice(
+                devices: AudioInputDeviceMonitor.shared.currentDevices(),
+                priorityOrder: order
+            ) {
+                return cached.uid
+            }
+            return resolvedAutomaticDevice(
+                devices: AudioInputDeviceMonitor.shared.refreshSynchronously(),
+                priorityOrder: order
+            )?.uid
+        }
+    }
+
+    static func resolvedDevice(devices: [AudioInputDevice]) -> AudioInputDevice? {
+        switch selectionMode() {
+        case .systemDefault:
+            return nil
+        case .manual:
+            let selectedUID = UserDefaults.standard.string(forKey: selectedUIDKey) ?? ""
+            return devices.first { $0.uid == selectedUID }
+        case .automatic:
+            return resolvedAutomaticDevice(devices: devices, priorityOrder: priorityOrder())
+        }
+    }
+
+    static func resolvedAutomaticDevice(
+        devices: [AudioInputDevice],
+        priorityOrder: [AudioInputDeviceCategory]
+    ) -> AudioInputDevice? {
+        let order = normalizedPriorityOrder(priorityOrder)
+        for category in order {
+            if let device = devices.first(where: { $0.category == category }) {
+                return device
+            }
+        }
+        return nil
+    }
+
+    private static func normalizedPriorityOrder(_ order: [AudioInputDeviceCategory]) -> [AudioInputDeviceCategory] {
+        var result: [AudioInputDeviceCategory] = []
+        for category in order where !result.contains(category) {
+            result.append(category)
+        }
+        for category in AudioInputDeviceCategory.defaultPriorityOrder where !result.contains(category) {
+            result.append(category)
+        }
+        return result
+    }
+}
+
+enum AudioInputDeviceDiscovery {
+    static func availableInputDevices() -> [AudioInputDevice] {
+        let discoverySession = AVCaptureDevice.DiscoverySession(
+            deviceTypes: [.microphone, .external],
+            mediaType: .audio,
+            position: .unspecified
+        )
+        return discoverySession.devices.map {
+            AudioInputDevice(
+                uid: $0.uniqueID,
+                name: $0.localizedName,
+                category: category(for: $0)
+            )
+        }
+    }
+
+    private static func category(for device: AVCaptureDevice) -> AudioInputDeviceCategory {
+        let transport = coreAudioDeviceID(forUID: device.uniqueID).map { transportType(device: $0) }
+        return category(forName: device.localizedName, uid: device.uniqueID, transportType: transport)
+    }
+
+    static func category(forName deviceName: String, uid: String, transportType: UInt32?) -> AudioInputDeviceCategory {
+        let name = deviceName.lowercased()
+        if name.contains("airpods") || name.contains("bluetooth") || name.contains("蓝牙") {
+            return .bluetooth
+        }
+
+        switch transportType {
+        case kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE:
+            return .bluetooth
+        case kAudioDeviceTransportTypeBuiltIn:
+            return .builtIn
+        case kAudioDeviceTransportTypeVirtual, kAudioDeviceTransportTypeAggregate:
+            return .virtual
+        case kAudioDeviceTransportTypeUSB, kAudioDeviceTransportTypePCI, kAudioDeviceTransportTypeFireWire:
+            return .external
+        case .some:
+            return .other
+        case .none:
+            if uid == "BuiltInMicrophoneDevice" || name.contains("macbook") || name.contains("内置") {
+                return .builtIn
+            }
+            return .external
+        }
+    }
+
+    private static func coreAudioDeviceID(forUID uid: String) -> AudioDeviceID? {
+        var size: UInt32 = 0
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        guard AudioObjectGetPropertyDataSize(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &size
+        ) == noErr else {
+            return nil
+        }
+
+        let count = Int(size) / MemoryLayout<AudioDeviceID>.size
+        var deviceIDs = Array(repeating: AudioDeviceID(0), count: count)
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &size,
+            &deviceIDs
+        ) == noErr else {
+            return nil
+        }
+
+        return deviceIDs.first { deviceUID($0) == uid }
+    }
+
+    private static func deviceUID(_ deviceID: AudioDeviceID) -> String? {
+        var uid = "" as CFString
+        var size = UInt32(MemoryLayout<CFString>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceUID,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = withUnsafeMutablePointer(to: &uid) { pointer in
+            AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, pointer)
+        }
+        guard status == noErr else { return nil }
+        return uid as String
+    }
+
+    private static func transportType(device: AudioDeviceID) -> UInt32 {
+        var transport: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyTransportType,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = AudioObjectGetPropertyData(device, &address, 0, nil, &size, &transport)
+        guard status == noErr else { return 0 }
+        return transport
+    }
+}
+
+extension Notification.Name {
+    static let audioInputDevicesDidChange = Notification.Name("Type4MeAudioInputDevicesDidChange")
+}
+
+final class AudioInputDeviceMonitor {
+    static let shared = AudioInputDeviceMonitor()
+
+    private let queue = DispatchQueue(label: "com.type4me.audio.input-devices", qos: .utility)
+    private let lock = NSLock()
+    private var started = false
+    private var cachedDevices: [AudioInputDevice] = []
+
+    private init() {}
+
+    func start() {
+        guard !started else { return }
+        started = true
+        refreshSynchronously()
+        addListener(selector: kAudioHardwarePropertyDevices)
+        addListener(selector: kAudioHardwarePropertyDefaultInputDevice)
+    }
+
+    func currentDevices() -> [AudioInputDevice] {
+        lock.lock()
+        defer { lock.unlock() }
+        return cachedDevices
+    }
+
+    func replaceCachedDevices(_ devices: [AudioInputDevice]) {
+        lock.lock()
+        cachedDevices = devices
+        lock.unlock()
+    }
+
+    private func addListener(selector: AudioObjectPropertySelector) {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            queue
+        ) { _, _ in
+            self.refreshAsynchronously()
+        }
+    }
+
+    @discardableResult
+    func refreshSynchronously() -> [AudioInputDevice] {
+        let devices = AudioInputDeviceDiscovery.availableInputDevices()
+        replaceCachedDevices(devices)
+        return devices
+    }
+
+    private func refreshAsynchronously() {
+        let devices = AudioInputDeviceDiscovery.availableInputDevices()
+        replaceCachedDevices(devices)
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .audioInputDevicesDidChange, object: nil)
+        }
+    }
+}

--- a/Type4Me/Input/HotkeyManager.swift
+++ b/Type4Me/Input/HotkeyManager.swift
@@ -127,33 +127,47 @@ final class HotkeyManager: NSObject {
 
     @discardableResult
     func start() -> Bool {
+        let hasMediaKeyBindings = bindings.contains { $0.isMediaKey }
+
         let eventMask: CGEventMask =
             (1 << CGEventType.keyDown.rawValue)
             | (1 << CGEventType.keyUp.rawValue)
             | (1 << CGEventType.flagsChanged.rawValue)
             | (1 << CGEventType.otherMouseDown.rawValue)
             | (1 << CGEventType.otherMouseUp.rawValue)
-            | (1 << 14)  // kCGEventSystemDefined (NX_SYSDEFINED) for media/headphone keys
+            | (hasMediaKeyBindings ? (1 << 14) : 0)  // kCGEventSystemDefined (NX_SYSDEFINED) for media/headphone keys
 
         let userInfo = Unmanaged.passUnretained(self).toOpaque()
 
-        // Try cghidEventTap first for more reliable interception of media/headphone keys.
-        // If unavailable (e.g. insufficient permissions), fall back to cgSessionEventTap.
-        let tap: CFMachPort? = CGEvent.tapCreate(
-            tap: .cghidEventTap,
-            place: .headInsertEventTap,
-            options: .defaultTap,
-            eventsOfInterest: eventMask,
-            callback: hotkeyCallback,
-            userInfo: userInfo
-        ) ?? CGEvent.tapCreate(
-            tap: .cgSessionEventTap,
-            place: .headInsertEventTap,
-            options: .defaultTap,
-            eventsOfInterest: eventMask,
-            callback: hotkeyCallback,
-            userInfo: userInfo
-        )
+        let tap: CFMachPort?
+        if hasMediaKeyBindings {
+            // Try cghidEventTap first for more reliable interception of media/headphone keys.
+            // If unavailable (e.g. insufficient permissions), fall back to cgSessionEventTap.
+            tap = CGEvent.tapCreate(
+                tap: .cghidEventTap,
+                place: .headInsertEventTap,
+                options: .defaultTap,
+                eventsOfInterest: eventMask,
+                callback: hotkeyCallback,
+                userInfo: userInfo
+            ) ?? CGEvent.tapCreate(
+                tap: .cgSessionEventTap,
+                place: .headInsertEventTap,
+                options: .defaultTap,
+                eventsOfInterest: eventMask,
+                callback: hotkeyCallback,
+                userInfo: userInfo
+            )
+        } else {
+            tap = CGEvent.tapCreate(
+                tap: .cgSessionEventTap,
+                place: .headInsertEventTap,
+                options: .defaultTap,
+                eventsOfInterest: eventMask,
+                callback: hotkeyCallback,
+                userInfo: userInfo
+            )
+        }
 
         guard let tap = tap else {
             return false

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -406,7 +406,9 @@ actor RecognitionSession {
         }
 
         do {
-            audioEngine.selectedDeviceUID = UserDefaults.standard.string(forKey: "tf_selectedMicrophoneUID")
+            let selectedDeviceUID = AudioInputDevicePreferenceStore.resolvedCachedDeviceUID()
+            audioEngine.selectedDeviceUID = selectedDeviceUID
+            DebugFileLogger.log("audio input selected uid=\(selectedDeviceUID ?? "system-default") mode=\(AudioInputDevicePreferenceStore.selectionMode().rawValue)")
             try audioEngine.start()
             NSLog("[Session] Audio engine started OK")
             DebugFileLogger.log("audio engine started OK")

--- a/Type4Me/Type4MeApp.swift
+++ b/Type4Me/Type4MeApp.swift
@@ -71,6 +71,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         KeychainService.migrateIfNeeded()
         HotwordStorage.migrateIfNeeded()
         SnippetStorage.migrateIfNeeded()
+        AudioInputDevicePreferenceStore.migrateIfNeeded()
 
         // Sync hotwords to Volcengine cloud table (async, non-blocking)
         VolcHotwordSyncManager.syncIfNeeded()
@@ -90,6 +91,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let appState = self.appState
 
         SoundFeedback.warmUp()
+        AudioInputDeviceMonitor.shared.start()
         AudioKeepAliveManager.syncState()
 
         // Pre-warm audio subsystem and ASR connection so the first recording starts instantly
@@ -450,7 +452,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 timer.invalidate()
                 retryTimer = nil
                 hotkeyRetryCount = 0
-                } else if hotkeyRetryCount >= 5 {
+            } else if hotkeyRetryCount >= 5 {
                 // Permission granted but event tap still fails (macOS caches denial at kernel level).
                 // Suggest restart.
                 timer.invalidate()

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -22,12 +22,14 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
     @AppStorage("tf_stripTrailingPunctuation") private var stripTrailingPunctuation = "off"
     @AppStorage("tf_hoverTranscriptPreview") private var hoverTranscriptPreview = true
     @AppStorage("tf_micKeepAlive") private var micKeepAlive = false
+    @AppStorage(AudioInputDevicePreferenceStore.selectionModeKey) private var microphoneSelectionMode = AudioInputDeviceSelectionMode.systemDefault.rawValue
     @AppStorage("tf_selectedMicrophoneUID") private var selectedMicrophoneUID = ""
+    @AppStorage(AudioInputDevicePreferenceStore.priorityOrderKey) private var microphonePriorityOrder = AudioInputDevicePreferenceStore.defaultPriorityOrderStorageValue
     @AppStorage("tf_selectedSpeakerUID") private var selectedSpeakerUID = ""
 
     @State private var hasMic = false
     @State private var hasAccessibility = false
-    @State private var availableMicrophones: [(uid: String, name: String)] = []
+    @State private var availableMicrophones: [AudioInputDevice] = []
     @State private var availableSpeakers: [(uid: String, name: String)] = []
 
     typealias TestStatus = SettingsTestStatus
@@ -205,6 +207,9 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
         }
         .onChange(of: micKeepAlive) { _, _ in
             AudioKeepAliveManager.syncMicState()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .audioInputDevicesDidChange)) { _ in
+            refreshMicrophones()
         }
     }
 
@@ -422,20 +427,110 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
                 .buttonStyle(.plain)
                 .help(L("刷新麦克风列表", "Refresh microphone list"))
             }
-            settingsDropdown(
-                selection: $selectedMicrophoneUID,
-                options: [("", L("系统默认", "System Default"))] + availableMicrophones.map { ($0.uid, $0.name) }
+            settingsSegmentedPicker(
+                selection: $microphoneSelectionMode,
+                options: AudioInputDeviceSelectionMode.allCases.map { ($0.rawValue, $0.displayName) }
             )
+
+            switch AudioInputDeviceSelectionMode(rawValue: microphoneSelectionMode) ?? .systemDefault {
+            case .systemDefault:
+                microphoneHint(
+                    icon: "gearshape",
+                    text: L("跟随 macOS 当前默认输入设备。", "Use the current macOS default input device.")
+                )
+            case .manual:
+                settingsDropdown(
+                    selection: $selectedMicrophoneUID,
+                    options: [("", L("选择设备", "Choose Device"))] + availableMicrophones.map {
+                        ($0.uid, "\($0.name) · \($0.category.displayName)")
+                    }
+                )
+            case .automatic:
+                microphonePriorityEditor
+                microphoneAutoMatchSummary
+            }
         }
         .padding(.vertical, 6)
     }
 
     private func refreshMicrophones() {
-        availableMicrophones = AudioCaptureEngine.availableAudioDevices()
-        if !selectedMicrophoneUID.isEmpty,
+        let devices = AudioCaptureEngine.availableAudioInputDevices()
+        availableMicrophones = devices
+        AudioInputDeviceMonitor.shared.replaceCachedDevices(devices)
+        if microphoneSelectionMode == AudioInputDeviceSelectionMode.manual.rawValue,
+           !selectedMicrophoneUID.isEmpty,
            !availableMicrophones.contains(where: { $0.uid == selectedMicrophoneUID }) {
             selectedMicrophoneUID = ""
         }
+    }
+
+    private var microphonePriorityEditor: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(currentMicrophonePriorityOrder.enumerated()), id: \.element.rawValue) { index, category in
+                HStack(spacing: 8) {
+                    Text("\(index + 1)")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(.white)
+                        .frame(width: 18, height: 18)
+                        .background(Circle().fill(TF.settingsNavActive))
+                    settingsDropdown(
+                        selection: priorityBinding(at: index),
+                        options: AudioInputDeviceCategory.defaultPriorityOrder.map { ($0.rawValue, $0.displayName) }
+                    )
+                }
+            }
+        }
+    }
+
+    private var microphoneAutoMatchSummary: some View {
+        let matched = AudioInputDevicePreferenceStore.resolvedAutomaticDevice(
+            devices: availableMicrophones,
+            priorityOrder: currentMicrophonePriorityOrder
+        )
+        return microphoneHint(
+            icon: matched == nil ? "gearshape" : "checkmark.circle.fill",
+            text: matched.map {
+                L("当前匹配：\($0.name)（\($0.category.displayName)）",
+                  "Current match: \($0.name) (\($0.category.displayName))")
+            } ?? L("当前没有匹配的设备，将回退到系统默认输入。",
+                   "No matching device is available; system default will be used.")
+        )
+    }
+
+    private var currentMicrophonePriorityOrder: [AudioInputDeviceCategory] {
+        AudioInputDevicePreferenceStore.priorityOrder(from: microphonePriorityOrder)
+    }
+
+    private func priorityBinding(at index: Int) -> Binding<String> {
+        Binding(
+            get: {
+                let order = currentMicrophonePriorityOrder
+                guard order.indices.contains(index) else { return AudioInputDeviceCategory.other.rawValue }
+                return order[index].rawValue
+            },
+            set: { newValue in
+                guard let newCategory = AudioInputDeviceCategory(rawValue: newValue) else { return }
+                var order = currentMicrophonePriorityOrder.filter { $0 != newCategory }
+                order.insert(newCategory, at: min(index, order.count))
+                microphonePriorityOrder = AudioInputDevicePreferenceStore.storageValue(for: order)
+            }
+        )
+    }
+
+    private func microphoneHint(icon: String, text: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(TF.settingsTextTertiary)
+            Text(text)
+                .font(.system(size: 10))
+                .foregroundStyle(TF.settingsTextTertiary)
+                .lineLimit(2)
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(RoundedRectangle(cornerRadius: 8).fill(TF.settingsCardAlt.opacity(0.65)))
     }
 
     private var speakerSelectionRow: some View {

--- a/Type4MeTests/AudioInputDevicePreferenceTests.swift
+++ b/Type4MeTests/AudioInputDevicePreferenceTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+import CoreAudio
+@testable import Type4Me
+
+final class AudioInputDevicePreferenceTests: XCTestCase {
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: AudioInputDevicePreferenceStore.selectionModeKey)
+        UserDefaults.standard.removeObject(forKey: AudioInputDevicePreferenceStore.selectedUIDKey)
+        UserDefaults.standard.removeObject(forKey: AudioInputDevicePreferenceStore.priorityOrderKey)
+        AudioInputDeviceMonitor.shared.replaceCachedDevices([])
+        super.tearDown()
+    }
+
+    func testAutomaticResolutionPrefersBluetoothWhenConfiguredFirst() {
+        let devices = [
+            AudioInputDevice(uid: "built-in", name: "MacBook Pro Microphone", category: .builtIn),
+            AudioInputDevice(uid: "airpods", name: "AirPods Pro", category: .bluetooth),
+        ]
+
+        let resolved = AudioInputDevicePreferenceStore.resolvedAutomaticDevice(
+            devices: devices,
+            priorityOrder: [.bluetooth, .builtIn]
+        )
+
+        XCTAssertEqual(resolved?.uid, "airpods")
+    }
+
+    func testAutomaticResolutionPrefersBuiltInWhenConfiguredFirst() {
+        let devices = [
+            AudioInputDevice(uid: "airpods", name: "AirPods Pro", category: .bluetooth),
+            AudioInputDevice(uid: "built-in", name: "MacBook Pro Microphone", category: .builtIn),
+        ]
+
+        let resolved = AudioInputDevicePreferenceStore.resolvedAutomaticDevice(
+            devices: devices,
+            priorityOrder: [.builtIn, .bluetooth]
+        )
+
+        XCTAssertEqual(resolved?.uid, "built-in")
+    }
+
+    func testAutomaticResolutionFallsThroughPriorityOrder() {
+        let devices = [
+            AudioInputDevice(uid: "usb", name: "USB Microphone", category: .external),
+        ]
+
+        let resolved = AudioInputDevicePreferenceStore.resolvedAutomaticDevice(
+            devices: devices,
+            priorityOrder: [.bluetooth, .builtIn, .external]
+        )
+
+        XCTAssertEqual(resolved?.uid, "usb")
+    }
+
+    func testPriorityOrderNormalizesDuplicatesAndMissingCategories() {
+        let order = AudioInputDevicePreferenceStore.priorityOrder(from: "builtIn,bluetooth,builtIn")
+
+        XCTAssertEqual(order.prefix(2), [.builtIn, .bluetooth])
+        XCTAssertEqual(Set(order), Set(AudioInputDeviceCategory.defaultPriorityOrder))
+    }
+
+    func testCategoryUsesBluetoothTransportForMicrophoneDevices() {
+        let category = AudioInputDeviceDiscovery.category(
+            forName: "Li Glasses 0966",
+            uid: "0C-27-56-7F-AF-B3:input",
+            transportType: kAudioDeviceTransportTypeBluetooth
+        )
+
+        XCTAssertEqual(category, .bluetooth)
+    }
+
+    func testCategoryUsesBuiltInTransportForMacMicrophone() {
+        let category = AudioInputDeviceDiscovery.category(
+            forName: "MacBook Pro麦克风",
+            uid: "BuiltInMicrophoneDevice",
+            transportType: kAudioDeviceTransportTypeBuiltIn
+        )
+
+        XCTAssertEqual(category, .builtIn)
+    }
+
+    func testCategoryUsesUSBTransportForExternalMicrophone() {
+        let category = AudioInputDeviceDiscovery.category(
+            forName: "Newmine",
+            uid: "AppleUSBAudioEngine:Generic:Newmine:20210726905921:1",
+            transportType: kAudioDeviceTransportTypeUSB
+        )
+
+        XCTAssertEqual(category, .external)
+    }
+
+    func testManualResolutionUsesSavedDeviceWhenAvailable() {
+        UserDefaults.standard.set(AudioInputDeviceSelectionMode.manual.rawValue, forKey: AudioInputDevicePreferenceStore.selectionModeKey)
+        UserDefaults.standard.set("usb", forKey: AudioInputDevicePreferenceStore.selectedUIDKey)
+        let devices = [
+            AudioInputDevice(uid: "built-in", name: "MacBook Pro Microphone", category: .builtIn),
+            AudioInputDevice(uid: "usb", name: "USB Microphone", category: .external),
+        ]
+
+        let resolved = AudioInputDevicePreferenceStore.resolvedDevice(devices: devices)
+
+        XCTAssertEqual(resolved?.uid, "usb")
+    }
+
+    func testCachedManualResolutionUsesSavedUIDWithoutDeviceList() {
+        UserDefaults.standard.set(AudioInputDeviceSelectionMode.manual.rawValue, forKey: AudioInputDevicePreferenceStore.selectionModeKey)
+        UserDefaults.standard.set("temporarily-unavailable", forKey: AudioInputDevicePreferenceStore.selectedUIDKey)
+
+        let resolved = AudioInputDevicePreferenceStore.resolvedCachedDeviceUID()
+
+        XCTAssertEqual(resolved, "temporarily-unavailable")
+    }
+
+    func testCachedAutomaticResolutionUsesMonitorCache() {
+        UserDefaults.standard.set(AudioInputDeviceSelectionMode.automatic.rawValue, forKey: AudioInputDevicePreferenceStore.selectionModeKey)
+        AudioInputDeviceMonitor.shared.replaceCachedDevices([
+            AudioInputDevice(uid: "built-in", name: "MacBook Pro Microphone", category: .builtIn),
+            AudioInputDevice(uid: "bluetooth", name: "Li Glasses 0966", category: .bluetooth),
+        ])
+
+        let resolved = AudioInputDevicePreferenceStore.resolvedCachedDeviceUID()
+
+        XCTAssertEqual(resolved, "bluetooth")
+    }
+
+    func testMigrationPreservesLegacySelectedMicrophoneAsManualMode() {
+        UserDefaults.standard.set("legacy-mic", forKey: AudioInputDevicePreferenceStore.selectedUIDKey)
+
+        AudioInputDevicePreferenceStore.migrateIfNeeded()
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: AudioInputDevicePreferenceStore.selectionModeKey),
+            AudioInputDeviceSelectionMode.manual.rawValue
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Add microphone input selection modes: system default, manual fixed device, and automatic priority matching.
- Add configurable input-device category priority for Bluetooth, built-in, external/USB, virtual, and other devices.
- Resolve the selected input device at recording start from cached device state so recording start does not enumerate devices on the hot path.
- Maintain the input-device cache through CoreAudio input-device/default-device change notifications and refresh the settings UI when devices change.
- Keep normal keyboard/mouse hotkeys on the previous session event-tap path, only using the HID/media-key path when media-key bindings are configured.

## Why

Some users prefer Bluetooth microphones to be selected automatically when available, while others prefer the built-in Mac microphone. The previous setting only supported system default or a fixed device, so device changes required manual intervention.

Device discovery can have a cold-start cost and should not run between hotkey activation and audio capture startup. This version refreshes device state at app startup and when macOS reports device changes, then uses the cached state when a recording begins.

While testing this on the latest release base, the newer media-key hotkey path caused ordinary hotkeys to request the ListenEvent path unnecessarily on macOS. The hotkey adjustment keeps ordinary shortcuts on the stable path and preserves media-key support for users who explicitly configure media-key bindings.

## Validation

- `git diff --check`
- `swift build`
- `swift test` (179 tests, 0 failures)
- Local app deployment smoke test before the cache optimization: build 13 launched, normal hotkey start/stop worked, no repeated hotkey restart prompt after the fix.
