### PR TITLE
fix: preserve Pangu spacing between CJK and Latin/digits (#186)

### DIFF
--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -1667,25 +1667,39 @@ actor RecognitionSession {
 
 // MARK: - String helpers
 
-private extension String {
+// `internal` (not `private`) so the text-normalization rules can be unit-tested
+// via `@testable import Type4Me` (see RecognitionSessionTests).
+extension String {
     /// Collapse runs of 2+ spaces into a single space.
     /// LLMs sometimes insert extra spaces between CJK and Latin text.
     var collapsingExtraSpaces: String {
         replacingOccurrences(of: " {2,}", with: " ", options: .regularExpression)
     }
 
-    /// Remove unwanted spaces around CJK characters.
-    /// Chinese text never uses inter-word spaces, so any space adjacent to a
-    /// CJK character is noise from ASR token boundaries or LLM formatting.
-    /// Two rules cover all 5 CJK-involving combinations (中↔中, 中↔英, 英↔中,
-    /// 中↔符, 符↔中) while leaving pure English "hello world" intact.
+    /// Remove spurious spaces that hug a CJK character, while preserving the
+    /// space between a CJK character and an adjacent Latin letter or digit
+    /// (Pangu spacing, e.g. "最新的 prompt 提交" stays intact — see issue #186).
+    ///
+    /// Chinese text uses no inter-word spaces, so a space between two CJK
+    /// characters — or between a CJK character and punctuation — is noise from
+    /// ASR token boundaries or LLM formatting and is removed (中↔中, 中↔符,
+    /// 符↔中). A space between a CJK character and an ASCII letter/digit is
+    /// intentional and is kept (中↔英, 英↔中, 中↔数). Pure English
+    /// "hello world" is untouched.
     var removingCJKLatinSpaces: String {
         let cjk = "[\\u3400-\\u4DBF\\u4E00-\\u9FFF\\uF900-\\uFAFF]"
+        // A neighbour that should hug the CJK character with no space: anything
+        // that is neither whitespace nor an ASCII letter/digit (i.e. another CJK
+        // char, punctuation, or a symbol). Latin letters/digits are excluded so
+        // Pangu spacing is preserved.
+        let glue = "[^\\sA-Za-z0-9]"
         var s = self
-        // Space after CJK, before any non-whitespace: "你 好" / "你 ," → "你好" / "你,"
-        s = s.replacingOccurrences(of: "(?<=\(cjk)) +(?=\\S)", with: "", options: .regularExpression)
-        // Space before CJK, after any non-whitespace: ", 你" / "Max 你" → ",你" / "Max你"
-        s = s.replacingOccurrences(of: "(?<=\\S) +(?=\(cjk))", with: "", options: .regularExpression)
+        // Space after CJK, before a non-letter/digit: "你 好" / "你 ，" → "你好" / "你，"
+        // ("最新的 prompt" keeps its space because 'p' is a letter.)
+        s = s.replacingOccurrences(of: "(?<=\(cjk)) +(?=\(glue))", with: "", options: .regularExpression)
+        // Space before CJK, after a non-letter/digit: "， 你" → "，你"
+        // ("Max 你" / "3 个" keep their space because 'x' / '3' are letter/digit.)
+        s = s.replacingOccurrences(of: "(?<=\(glue)) +(?=\(cjk))", with: "", options: .regularExpression)
         return s
     }
 

--- a/Type4MeTests/RecognitionSessionTests.swift
+++ b/Type4MeTests/RecognitionSessionTests.swift
@@ -60,4 +60,35 @@ final class RecognitionSessionTests: XCTestCase {
 
         XCTAssertTrue(shouldFallback)
     }
+
+    // MARK: - CJK / Latin spacing (issue #186)
+
+    /// The space between a CJK character and an adjacent Latin word or digit
+    /// (Pangu spacing) must survive normalization. Regression test for #186,
+    /// where "我已经把最新的 prompt 提交并更新" was collapsed to "...的prompt提交...".
+    func testRemovingCJKLatinSpaces_preservesPanguSpacing() {
+        // The reported case: CJK ↔ Latin spaces are kept.
+        XCTAssertEqual(
+            "我已经把最新的 prompt 提交并更新".removingCJKLatinSpaces,
+            "我已经把最新的 prompt 提交并更新"
+        )
+        // CJK ↔ Latin word, both boundaries.
+        XCTAssertEqual("Max 你好".removingCJKLatinSpaces, "Max 你好")
+        XCTAssertEqual("发布 v1.9.5 版本".removingCJKLatinSpaces, "发布 v1.9.5 版本")
+        // CJK ↔ digit.
+        XCTAssertEqual("第 3 个".removingCJKLatinSpaces, "第 3 个")
+        // Pure English is untouched.
+        XCTAssertEqual("hello world".removingCJKLatinSpaces, "hello world")
+    }
+
+    /// Spaces between two CJK characters, or between a CJK character and
+    /// punctuation, are ASR/LLM noise and must still be removed.
+    func testRemovingCJKLatinSpaces_stripsCJKAndPunctuationNoise() {
+        // CJK ↔ CJK noise from ASR token boundaries.
+        XCTAssertEqual("你 好".removingCJKLatinSpaces, "你好")
+        XCTAssertEqual("你  好".removingCJKLatinSpaces, "你好")
+        // CJK ↔ punctuation (full-width and ASCII).
+        XCTAssertEqual("你好 ，世界".removingCJKLatinSpaces, "你好，世界")
+        XCTAssertEqual("你好 , 世界".removingCJKLatinSpaces, "你好,世界")
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #186 — spaces between Chinese characters and adjacent English words / digits were stripped from the final output, e.g. `我已经把最新的 prompt 提交并更新` → `我已经把最新的prompt提交并更新`.

## Root cause

`String.removingCJKLatinSpaces` (in `Type4Me/Session/RecognitionSession.swift`) runs in the **shared inject path**, after the Quick-Mode / Voice-Polish branches rejoin — which is why the issue reproduces in both modes and regardless of ASR engine or whether the LLM runs, exactly as reported.

Its two regexes removed a space whenever it was adjacent to a CJK character **and the other side was any non-whitespace char** (`\S`), so they also deleted the intentional space at CJK↔Latin and CJK↔digit boundaries.

The CHANGELOG describes this feature as removing spaces *between CJK characters*:

> CJK 字符间多余空格自动清除（ASR 分段拼接产生的空格）

so the implementation over-reached its own documented intent.

## Fix

Narrow the neighbour class from "any non-whitespace" to "non-whitespace **and** non-ASCII-letter/digit", so a space is removed only when the CJK char's neighbour is another CJK character or punctuation. CJK↔Latin / CJK↔digit spaces (Pangu spacing) are kept.

| input | before | after |
|---|---|---|
| `最新的 prompt 提交` | `最新的prompt提交` | `最新的 prompt 提交` ✅ |
| `你 好` (ASR token-boundary noise) | `你好` | `你好` (unchanged) |
| `你好 ，世界` | `你好，世界` | `你好，世界` (unchanged) |
| `第 3 个` | `第3个` | `第 3 个` ✅ |

## Tests

Relaxed the `private` `String` helper extension to internal so the rules are unit-testable via `@testable`, and added `testRemovingCJKLatinSpaces_preservesPanguSpacing` + `testRemovingCJKLatinSpaces_stripsCJKAndPunctuationNoise`. `swift test --filter RecognitionSessionTests` → 8/8 passing.

> Note: the method name `removingCJKLatinSpaces` is now slightly inaccurate (it no longer removes CJK↔Latin spaces). Happy to rename it (e.g. `removingCJKAdjacentSpaces`) if you'd prefer — kept the diff minimal for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)