### PR TITLE
[codex] Reuse LLM clients and URL sessions

### DIFF
--- a/Type4Me/CloudSubscription/CloudLLMClient.swift
+++ b/Type4Me/CloudSubscription/CloudLLMClient.swift
@@ -26,9 +26,24 @@ enum CloudLLMError: Error, LocalizedError {
 actor CloudLLMClient: LLMClient {
 
     private let logger = Logger(subsystem: "com.type4me.app", category: "CloudLLM")
+    private let session: URLSession
+    private let metricsDelegate: LLMURLSessionMetricsDelegate
+
+    init(bypassProxy: Bool = ProxyBypassMode.current.bypassLLM) {
+        let resources = LLMURLSessionFactory.make(
+            providerID: "cloud",
+            bypassProxy: bypassProxy
+        )
+        session = resources.session
+        metricsDelegate = resources.metricsDelegate
+    }
 
     func warmUp(baseURL: String) async {
         // No warmup needed — proxy handles connection pooling
+    }
+
+    func invalidate() async {
+        session.invalidateAndCancel()
     }
 
     func process(text: String, prompt: String, config: LLMConfig) async throws -> String {
@@ -54,7 +69,7 @@ actor CloudLLMClient: LLMClient {
             LLMRequest(text: text, prompt: prompt, mode: "cloud")
         )
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await session.data(for: request)
 
         guard let http = response as? HTTPURLResponse else {
             throw CloudLLMError.networkError

--- a/Type4Me/LLM/ClaudeChatClient.swift
+++ b/Type4Me/LLM/ClaudeChatClient.swift
@@ -4,16 +4,16 @@ import os
 actor ClaudeChatClient: LLMClient {
 
     private let logger = Logger(subsystem: "com.type4me.llm", category: "ClaudeChatClient")
+    private let session: URLSession
+    private let metricsDelegate: LLMURLSessionMetricsDelegate
 
-    private var session: URLSession {
-        let config = URLSessionConfiguration.default
-        // Cap total request duration (including streaming) to 60s so a stalled
-        // server can't hang the for-await loop indefinitely.
-        config.timeoutIntervalForResource = 60
-        if ProxyBypassMode.current.bypassLLM {
-            config.connectionProxyDictionary = [:]
-        }
-        return URLSession(configuration: config)
+    init(bypassProxy: Bool = ProxyBypassMode.current.bypassLLM) {
+        let resources = LLMURLSessionFactory.make(
+            providerID: LLMProvider.claude.rawValue,
+            bypassProxy: bypassProxy
+        )
+        session = resources.session
+        metricsDelegate = resources.metricsDelegate
     }
 
     /// Pre-establish TCP+TLS connection so the first real request skips handshake.
@@ -24,6 +24,10 @@ actor ClaudeChatClient: LLMClient {
         request.timeoutInterval = 5
         _ = try? await session.data(for: request)
         logger.info("Claude connection pre-warmed to \(baseURL)")
+    }
+
+    func invalidate() async {
+        session.invalidateAndCancel()
     }
 
     /// Process text through Anthropic Messages API (streaming).

--- a/Type4Me/LLM/DoubaoChatClient.swift
+++ b/Type4Me/LLM/DoubaoChatClient.swift
@@ -5,20 +5,20 @@ actor DoubaoChatClient: LLMClient {
 
     private let logger = Logger(subsystem: "com.type4me.llm", category: "DoubaoChatClient")
     private let provider: LLMProvider
+    private let session: URLSession
+    private let metricsDelegate: LLMURLSessionMetricsDelegate
 
-    init(provider: LLMProvider = .doubao) {
+    init(
+        provider: LLMProvider = .doubao,
+        bypassProxy: Bool = ProxyBypassMode.current.bypassLLM
+    ) {
         self.provider = provider
-    }
-
-    private var session: URLSession {
-        let config = URLSessionConfiguration.default
-        // Cap total request duration (including streaming) to 60s so a stalled
-        // server can't hang the for-await loop indefinitely.
-        config.timeoutIntervalForResource = 60
-        if ProxyBypassMode.current.bypassLLM {
-            config.connectionProxyDictionary = [:]
-        }
-        return URLSession(configuration: config)
+        let resources = LLMURLSessionFactory.make(
+            providerID: provider.rawValue,
+            bypassProxy: bypassProxy
+        )
+        session = resources.session
+        metricsDelegate = resources.metricsDelegate
     }
 
     /// Pre-establish TCP+TLS connection so the first real request skips handshake.
@@ -29,6 +29,10 @@ actor DoubaoChatClient: LLMClient {
         request.timeoutInterval = 5
         _ = try? await session.data(for: request)
         logger.info("LLM connection pre-warmed to \(baseURL)")
+    }
+
+    func invalidate() async {
+        session.invalidateAndCancel()
     }
 
     /// Process text through Doubao ARK API (OpenAI-compatible streaming).
@@ -80,6 +84,8 @@ actor DoubaoChatClient: LLMClient {
     // MARK: - Streaming (SSE)
 
     private func processStreaming(request: URLRequest, model: String) async throws -> String {
+        let requestStart = ContinuousClock.now
+        DebugFileLogger.log("llm: request started model=\(model)")
         let (bytes, response) = try await session.bytes(for: request)
         guard let http = response as? HTTPURLResponse else {
             throw LLMError.requestFailed(0)
@@ -92,15 +98,25 @@ actor DoubaoChatClient: LLMClient {
 
         var result = ""
         var lineCount = 0
+        var loggedFirstEvent = false
+        var loggedFirstToken = false
         for try await line in bytes.lines {
             lineCount += 1
             guard line.hasPrefix("data: ") else { continue }
+            if !loggedFirstEvent {
+                loggedFirstEvent = true
+                DebugFileLogger.log("llm: first SSE event +\(ContinuousClock.now - requestStart) model=\(model)")
+            }
             let payload = String(line.dropFirst(6))
             if payload == "[DONE]" { break }
             guard let data = payload.data(using: .utf8),
                   let chunk = try? JSONDecoder().decode(ChatStreamChunk.self, from: data),
                   let content = chunk.choices.first?.delta.content
             else { continue }
+            if !loggedFirstToken, !content.isEmpty {
+                loggedFirstToken = true
+                DebugFileLogger.log("llm: first content token +\(ContinuousClock.now - requestStart) model=\(model)")
+            }
             result += content
         }
 
@@ -112,6 +128,7 @@ actor DoubaoChatClient: LLMClient {
             DebugFileLogger.log("LLM[\(model)]: 0 lines received (connection closed immediately)")
             throw LLMError.emptyResponse(nil)
         }
+        DebugFileLogger.log("llm: completed +\(ContinuousClock.now - requestStart) chars=\(result.count) model=\(model)")
         return result
     }
 

--- a/Type4Me/LLM/LLMClient.swift
+++ b/Type4Me/LLM/LLMClient.swift
@@ -1,9 +1,14 @@
 import Foundation
 
 /// Common interface for LLM clients (OpenAI-compatible and Claude).
-protocol LLMClient: Sendable {
+protocol LLMClient: AnyObject, Sendable {
     func process(text: String, prompt: String, config: LLMConfig) async throws -> String
     func warmUp(baseURL: String) async
+    func invalidate() async
+}
+
+extension LLMClient {
+    func invalidate() async {}
 }
 
 extension String {

--- a/Type4Me/LLM/LLMClientCache.swift
+++ b/Type4Me/LLM/LLMClientCache.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+struct LLMClientCacheKey: Equatable, Sendable {
+    let providerID: String
+    let apiKey: String
+    let model: String
+    let baseURL: String
+    let bypassProxy: Bool
+
+    func invalidationReasons(comparedTo newKey: Self) -> [String] {
+        var reasons: [String] = []
+        if providerID != newKey.providerID { reasons.append("provider") }
+        if apiKey != newKey.apiKey { reasons.append("apiKey") }
+        if model != newKey.model { reasons.append("model") }
+        if baseURL != newKey.baseURL { reasons.append("baseURL") }
+        if bypassProxy != newKey.bypassProxy { reasons.append("proxyBypass") }
+        return reasons
+    }
+}
+
+struct LLMClientCache {
+    private(set) var key: LLMClientCacheKey?
+    private(set) var client: (any LLMClient)?
+
+    mutating func resolve(
+        key newKey: LLMClientCacheKey,
+        makeClient: () -> any LLMClient
+    ) -> (client: any LLMClient, reused: Bool, invalidated: (any LLMClient)?, reasons: [String]) {
+        if key == newKey, let client {
+            return (client, true, nil, [])
+        }
+
+        let oldClient = client
+        let reasons = key?.invalidationReasons(comparedTo: newKey) ?? []
+        let newClient = makeClient()
+        key = newKey
+        client = newClient
+        return (newClient, false, oldClient, reasons)
+    }
+
+    mutating func remove() -> (any LLMClient)? {
+        defer {
+            key = nil
+            client = nil
+        }
+        return client
+    }
+}
+
+final class LLMURLSessionMetricsDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    private let providerID: String
+
+    init(providerID: String) {
+        self.providerID = providerID
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didFinishCollecting metrics: URLSessionTaskMetrics
+    ) {
+        guard let transaction = metrics.transactionMetrics.last else { return }
+
+        let dns = Self.duration(from: transaction.domainLookupStartDate, to: transaction.domainLookupEndDate)
+        let connect = Self.duration(from: transaction.connectStartDate, to: transaction.connectEndDate)
+        let tls = Self.duration(from: transaction.secureConnectionStartDate, to: transaction.secureConnectionEndDate)
+        let wait = Self.duration(from: transaction.requestEndDate, to: transaction.responseStartDate)
+        DebugFileLogger.log(
+            "llm metrics: provider=\(providerID) dnsMs=\(dns) connectMs=\(connect) tlsMs=\(tls) responseWaitMs=\(wait) connectionReused=\(transaction.isReusedConnection)"
+        )
+        if transaction.isReusedConnection {
+            DebugFileLogger.log("llm connection reused provider=\(providerID)")
+        }
+    }
+
+    private static func duration(from start: Date?, to end: Date?) -> Int {
+        guard let start, let end else { return 0 }
+        return max(0, Int(end.timeIntervalSince(start) * 1_000))
+    }
+}
+
+enum LLMURLSessionFactory {
+    static func make(
+        providerID: String,
+        bypassProxy: Bool
+    ) -> (session: URLSession, metricsDelegate: LLMURLSessionMetricsDelegate) {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 30
+        config.timeoutIntervalForResource = 60
+        config.httpMaximumConnectionsPerHost = 4
+        if bypassProxy {
+            config.connectionProxyDictionary = [:]
+        }
+        let metricsDelegate = LLMURLSessionMetricsDelegate(providerID: providerID)
+        let session = URLSession(
+            configuration: config,
+            delegate: metricsDelegate,
+            delegateQueue: nil
+        )
+        return (session, metricsDelegate)
+    }
+}

--- a/Type4MeTests/LLMClientCacheTests.swift
+++ b/Type4MeTests/LLMClientCacheTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import Type4Me
+
+final class LLMClientCacheTests: XCTestCase {
+    func testReusesClientForMatchingConfiguration() {
+        var cache = LLMClientCache()
+        let key = makeKey()
+        let first = cache.resolve(key: key) { StubLLMClient() }
+        let second = cache.resolve(key: key) { StubLLMClient() }
+
+        XCTAssertFalse(first.reused)
+        XCTAssertTrue(second.reused)
+        XCTAssertEqual(
+            ObjectIdentifier(first.client),
+            ObjectIdentifier(second.client)
+        )
+        XCTAssertNil(second.invalidated)
+    }
+
+    func testInvalidatesClientWhenConfigurationChanges() async {
+        var cache = LLMClientCache()
+        let first = cache.resolve(key: makeKey()) { StubLLMClient() }
+        let updatedKey = LLMClientCacheKey(
+            providerID: "doubao",
+            apiKey: "new-key",
+            model: "new-model",
+            baseURL: "https://new.example.com/v1",
+            bypassProxy: true
+        )
+        let second = cache.resolve(key: updatedKey) { StubLLMClient() }
+
+        XCTAssertFalse(second.reused)
+        XCTAssertNotEqual(
+            ObjectIdentifier(first.client),
+            ObjectIdentifier(second.client)
+        )
+        XCTAssertEqual(
+            second.reasons,
+            ["apiKey", "model", "baseURL", "proxyBypass"]
+        )
+
+        await second.invalidated?.invalidate()
+        let oldClient = first.client as? StubLLMClient
+        let wasInvalidated = await oldClient?.isInvalidated
+        XCTAssertEqual(wasInvalidated, true)
+    }
+
+    func testProviderChangeInvalidatesCachedClient() {
+        var cache = LLMClientCache()
+        _ = cache.resolve(key: makeKey()) { StubLLMClient() }
+        let claudeKey = LLMClientCacheKey(
+            providerID: "claude",
+            apiKey: "key",
+            model: "model",
+            baseURL: "https://example.com/v1",
+            bypassProxy: false
+        )
+
+        let resolution = cache.resolve(key: claudeKey) { StubLLMClient() }
+
+        XCTAssertEqual(resolution.reasons, ["provider"])
+        XCTAssertNotNil(resolution.invalidated)
+    }
+
+    private func makeKey() -> LLMClientCacheKey {
+        LLMClientCacheKey(
+            providerID: "doubao",
+            apiKey: "key",
+            model: "model",
+            baseURL: "https://example.com/v1",
+            bypassProxy: false
+        )
+    }
+}
+
+private actor StubLLMClient: LLMClient {
+    private(set) var isInvalidated = false
+
+    func process(text: String, prompt: String, config: LLMConfig) async throws -> String {
+        text
+    }
+
+    func warmUp(baseURL: String) async {}
+
+    func invalidate() async {
+        isInvalidated = true
+    }
+}


### PR DESCRIPTION
## Summary

- keep LLM clients alive across recognition sessions
- reuse each client's `URLSession` instead of creating one per request
- invalidate cached clients when provider, credentials, model, base URL, or proxy settings change
- record connection metrics to make reuse visible in debug logs

## Why

Creating a new client and `URLSession` for every request repeatedly pays DNS, TCP, and TLS setup costs. This is especially noticeable in the post-recording path, where connection setup directly adds to perceived input latency.

## Impact

Matching LLM configurations reuse the same client and connection pool. Configuration changes still replace and invalidate the previous client, so credentials and routing settings cannot leak across configurations.

## Validation

- `swift test --filter LLMClientCacheTests`
- 3 tests passed

