### PR TITLE
[codex] Enable LLM actions with provider default model

### DIFF
--- a/Type4Me/UI/Settings/LLMCredentialDraft.swift
+++ b/Type4Me/UI/Settings/LLMCredentialDraft.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+enum LLMCredentialDraft {
+    static func effectiveValues(
+        fields: [CredentialField],
+        savedValues: [String: String],
+        draftValues: [String: String],
+        editedFields: Set<String>
+    ) -> [String: String] {
+        var result: [String: String] = Dictionary(
+            uniqueKeysWithValues: fields.compactMap { field in
+                guard !field.defaultValue.isEmpty else { return nil }
+                return (field.key, field.defaultValue)
+            }
+        )
+        result.merge(savedValues) { _, saved in saved }
+        for key in editedFields {
+            result[key] = draftValues[key] ?? ""
+        }
+        return result
+    }
+
+    static func hasRequiredValues(
+        fields: [CredentialField],
+        values: [String: String]
+    ) -> Bool {
+        fields
+            .filter { !$0.isOptional }
+            .allSatisfy { field in
+                !(values[field.key] ?? "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .isEmpty
+            }
+    }
+}

--- a/Type4Me/UI/Settings/LLMSettingsCard.swift
+++ b/Type4Me/UI/Settings/LLMSettingsCard.swift
@@ -40,19 +40,19 @@ struct LLMSettingsCard: View, SettingsCardHelpers {
 
     /// Effective values: saved base + dirty edits overlaid.
     private var effectiveLLMValues: [String: String] {
-        var result = savedLLMValues
-        for key in editedFields {
-            result[key] = llmCredentialValues[key] ?? ""
-        }
-        return result
+        LLMCredentialDraft.effectiveValues(
+            fields: currentLLMFields,
+            savedValues: savedLLMValues,
+            draftValues: llmCredentialValues,
+            editedFields: editedFields
+        )
     }
 
     private var hasLLMCredentials: Bool {
-        let required = currentLLMFields.filter { !$0.isOptional }
-        let effective = effectiveLLMValues
-        return required.allSatisfy { field in
-            !(effective[field.key] ?? "").isEmpty
-        }
+        LLMCredentialDraft.hasRequiredValues(
+            fields: currentLLMFields,
+            values: effectiveLLMValues
+        )
     }
 
     // MARK: Body

--- a/Type4MeTests/LLMCredentialDraftTests.swift
+++ b/Type4MeTests/LLMCredentialDraftTests.swift
@@ -1,0 +1,97 @@
+import Testing
+@testable import Type4Me
+
+struct LLMCredentialDraftTests {
+    private let fields = [
+        CredentialField(
+            key: "apiKey",
+            label: "API Key",
+            placeholder: "sk-...",
+            isSecure: true,
+            isOptional: false,
+            defaultValue: ""
+        ),
+        CredentialField(
+            key: "model",
+            label: "Model",
+            placeholder: "model",
+            isSecure: false,
+            isOptional: false,
+            defaultValue: "default-model"
+        ),
+        CredentialField(
+            key: "baseURL",
+            label: "Base URL",
+            placeholder: "https://example.com/v1",
+            isSecure: false,
+            isOptional: true,
+            defaultValue: "https://example.com/v1"
+        ),
+    ]
+
+    @Test
+    func defaultModelMakesNewAPIKeyDraftComplete() {
+        let values = LLMCredentialDraft.effectiveValues(
+            fields: fields,
+            savedValues: [:],
+            draftValues: ["apiKey": "secret"],
+            editedFields: ["apiKey"]
+        )
+
+        #expect(values["apiKey"] == "secret")
+        #expect(values["model"] == "default-model")
+        #expect(values["baseURL"] == "https://example.com/v1")
+        #expect(LLMCredentialDraft.hasRequiredValues(fields: fields, values: values))
+    }
+
+    @Test
+    func savedValuesOverrideDefaults() {
+        let values = LLMCredentialDraft.effectiveValues(
+            fields: fields,
+            savedValues: [
+                "apiKey": "saved-secret",
+                "model": "saved-model",
+                "baseURL": "https://saved.example/v1",
+            ],
+            draftValues: [:],
+            editedFields: []
+        )
+
+        #expect(values["apiKey"] == "saved-secret")
+        #expect(values["model"] == "saved-model")
+        #expect(values["baseURL"] == "https://saved.example/v1")
+    }
+
+    @Test
+    func explicitEditOverridesSavedValue() {
+        let values = LLMCredentialDraft.effectiveValues(
+            fields: fields,
+            savedValues: ["apiKey": "old-secret", "model": "saved-model"],
+            draftValues: ["apiKey": "new-secret"],
+            editedFields: ["apiKey"]
+        )
+
+        #expect(values["apiKey"] == "new-secret")
+        #expect(values["model"] == "saved-model")
+    }
+
+    @Test
+    func explicitClearDoesNotRestoreSavedValue() {
+        let values = LLMCredentialDraft.effectiveValues(
+            fields: fields,
+            savedValues: ["apiKey": "saved-secret", "model": "saved-model"],
+            draftValues: ["apiKey": ""],
+            editedFields: ["apiKey"]
+        )
+
+        #expect(values["apiKey"] == "")
+        #expect(!LLMCredentialDraft.hasRequiredValues(fields: fields, values: values))
+    }
+
+    @Test
+    func whitespaceOnlyRequiredValueIsIncomplete() {
+        let values = ["apiKey": " \n ", "model": "default-model"]
+
+        #expect(!LLMCredentialDraft.hasRequiredValues(fields: fields, values: values))
+    }
+}


### PR DESCRIPTION
## Summary

- resolve saved, default, and explicitly edited LLM credential values in one draft model
- allow Save and Test Connection when the API key is entered and the model comes from the provider default
- preserve explicit clears instead of silently restoring saved values
- add focused tests for default, saved, edited, cleared, and whitespace-only values

## Root cause

The settings UI validated only the raw text-field values. A provider model shown through the UI default was therefore visible to the user but absent from validation, leaving Save and Test Connection disabled.

## Impact

The buttons now reflect the effective credential configuration users see. Required fields remain strict, and explicit user edits take precedence over saved/default values.

## Validation

- `swift test --filter LLMCredentialDraftTests`
- 5 Swift Testing cases passed

