### PR TITLE
[codex] Add direct output for short polishing phrases

### DIFF
--- a/Type4Me/CloudSubscription/CloudLLMClient.swift
+++ b/Type4Me/CloudSubscription/CloudLLMClient.swift
@@ -26,9 +26,24 @@ enum CloudLLMError: Error, LocalizedError {
 actor CloudLLMClient: LLMClient {
 
     private let logger = Logger(subsystem: "com.type4me.app", category: "CloudLLM")
+    private let session: URLSession
+    private let metricsDelegate: LLMURLSessionMetricsDelegate
+
+    init(bypassProxy: Bool = ProxyBypassMode.current.bypassLLM) {
+        let resources = LLMURLSessionFactory.make(
+            providerID: "cloud",
+            bypassProxy: bypassProxy
+        )
+        session = resources.session
+        metricsDelegate = resources.metricsDelegate
+    }
 
     func warmUp(baseURL: String) async {
         // No warmup needed — proxy handles connection pooling
+    }
+
+    func invalidate() async {
+        session.invalidateAndCancel()
     }
 
     func process(text: String, prompt: String, config: LLMConfig) async throws -> String {
@@ -54,7 +69,7 @@ actor CloudLLMClient: LLMClient {
             LLMRequest(text: text, prompt: prompt, mode: "cloud")
         )
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await session.data(for: request)
 
         guard let http = response as? HTTPURLResponse else {
             throw CloudLLMError.networkError

--- a/Type4Me/LLM/ClaudeChatClient.swift
+++ b/Type4Me/LLM/ClaudeChatClient.swift
@@ -4,16 +4,16 @@ import os
 actor ClaudeChatClient: LLMClient {
 
     private let logger = Logger(subsystem: "com.type4me.llm", category: "ClaudeChatClient")
+    private let session: URLSession
+    private let metricsDelegate: LLMURLSessionMetricsDelegate
 
-    private var session: URLSession {
-        let config = URLSessionConfiguration.default
-        // Cap total request duration (including streaming) to 60s so a stalled
-        // server can't hang the for-await loop indefinitely.
-        config.timeoutIntervalForResource = 60
-        if ProxyBypassMode.current.bypassLLM {
-            config.connectionProxyDictionary = [:]
-        }
-        return URLSession(configuration: config)
+    init(bypassProxy: Bool = ProxyBypassMode.current.bypassLLM) {
+        let resources = LLMURLSessionFactory.make(
+            providerID: LLMProvider.claude.rawValue,
+            bypassProxy: bypassProxy
+        )
+        session = resources.session
+        metricsDelegate = resources.metricsDelegate
     }
 
     /// Pre-establish TCP+TLS connection so the first real request skips handshake.
@@ -24,6 +24,10 @@ actor ClaudeChatClient: LLMClient {
         request.timeoutInterval = 5
         _ = try? await session.data(for: request)
         logger.info("Claude connection pre-warmed to \(baseURL)")
+    }
+
+    func invalidate() async {
+        session.invalidateAndCancel()
     }
 
     /// Process text through Anthropic Messages API (streaming).

--- a/Type4Me/LLM/DoubaoChatClient.swift
+++ b/Type4Me/LLM/DoubaoChatClient.swift
@@ -5,20 +5,20 @@ actor DoubaoChatClient: LLMClient {
 
     private let logger = Logger(subsystem: "com.type4me.llm", category: "DoubaoChatClient")
     private let provider: LLMProvider
+    private let session: URLSession
+    private let metricsDelegate: LLMURLSessionMetricsDelegate
 
-    init(provider: LLMProvider = .doubao) {
+    init(
+        provider: LLMProvider = .doubao,
+        bypassProxy: Bool = ProxyBypassMode.current.bypassLLM
+    ) {
         self.provider = provider
-    }
-
-    private var session: URLSession {
-        let config = URLSessionConfiguration.default
-        // Cap total request duration (including streaming) to 60s so a stalled
-        // server can't hang the for-await loop indefinitely.
-        config.timeoutIntervalForResource = 60
-        if ProxyBypassMode.current.bypassLLM {
-            config.connectionProxyDictionary = [:]
-        }
-        return URLSession(configuration: config)
+        let resources = LLMURLSessionFactory.make(
+            providerID: provider.rawValue,
+            bypassProxy: bypassProxy
+        )
+        session = resources.session
+        metricsDelegate = resources.metricsDelegate
     }
 
     /// Pre-establish TCP+TLS connection so the first real request skips handshake.
@@ -29,6 +29,10 @@ actor DoubaoChatClient: LLMClient {
         request.timeoutInterval = 5
         _ = try? await session.data(for: request)
         logger.info("LLM connection pre-warmed to \(baseURL)")
+    }
+
+    func invalidate() async {
+        session.invalidateAndCancel()
     }
 
     /// Process text through Doubao ARK API (OpenAI-compatible streaming).
@@ -80,6 +84,8 @@ actor DoubaoChatClient: LLMClient {
     // MARK: - Streaming (SSE)
 
     private func processStreaming(request: URLRequest, model: String) async throws -> String {
+        let requestStart = ContinuousClock.now
+        DebugFileLogger.log("llm: request started model=\(model)")
         let (bytes, response) = try await session.bytes(for: request)
         guard let http = response as? HTTPURLResponse else {
             throw LLMError.requestFailed(0)
@@ -92,15 +98,25 @@ actor DoubaoChatClient: LLMClient {
 
         var result = ""
         var lineCount = 0
+        var loggedFirstEvent = false
+        var loggedFirstToken = false
         for try await line in bytes.lines {
             lineCount += 1
             guard line.hasPrefix("data: ") else { continue }
+            if !loggedFirstEvent {
+                loggedFirstEvent = true
+                DebugFileLogger.log("llm: first SSE event +\(ContinuousClock.now - requestStart) model=\(model)")
+            }
             let payload = String(line.dropFirst(6))
             if payload == "[DONE]" { break }
             guard let data = payload.data(using: .utf8),
                   let chunk = try? JSONDecoder().decode(ChatStreamChunk.self, from: data),
                   let content = chunk.choices.first?.delta.content
             else { continue }
+            if !loggedFirstToken, !content.isEmpty {
+                loggedFirstToken = true
+                DebugFileLogger.log("llm: first content token +\(ContinuousClock.now - requestStart) model=\(model)")
+            }
             result += content
         }
 
@@ -112,6 +128,7 @@ actor DoubaoChatClient: LLMClient {
             DebugFileLogger.log("LLM[\(model)]: 0 lines received (connection closed immediately)")
             throw LLMError.emptyResponse(nil)
         }
+        DebugFileLogger.log("llm: completed +\(ContinuousClock.now - requestStart) chars=\(result.count) model=\(model)")
         return result
     }
 

--- a/Type4Me/LLM/LLMClient.swift
+++ b/Type4Me/LLM/LLMClient.swift
@@ -1,9 +1,14 @@
 import Foundation
 
 /// Common interface for LLM clients (OpenAI-compatible and Claude).
-protocol LLMClient: Sendable {
+protocol LLMClient: AnyObject, Sendable {
     func process(text: String, prompt: String, config: LLMConfig) async throws -> String
     func warmUp(baseURL: String) async
+    func invalidate() async
+}
+
+extension LLMClient {
+    func invalidate() async {}
 }
 
 extension String {

--- a/Type4Me/LLM/LLMClientCache.swift
+++ b/Type4Me/LLM/LLMClientCache.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+struct LLMClientCacheKey: Equatable, Sendable {
+    let providerID: String
+    let apiKey: String
+    let model: String
+    let baseURL: String
+    let bypassProxy: Bool
+
+    func invalidationReasons(comparedTo newKey: Self) -> [String] {
+        var reasons: [String] = []
+        if providerID != newKey.providerID { reasons.append("provider") }
+        if apiKey != newKey.apiKey { reasons.append("apiKey") }
+        if model != newKey.model { reasons.append("model") }
+        if baseURL != newKey.baseURL { reasons.append("baseURL") }
+        if bypassProxy != newKey.bypassProxy { reasons.append("proxyBypass") }
+        return reasons
+    }
+}
+
+struct LLMClientCache {
+    private(set) var key: LLMClientCacheKey?
+    private(set) var client: (any LLMClient)?
+
+    mutating func resolve(
+        key newKey: LLMClientCacheKey,
+        makeClient: () -> any LLMClient
+    ) -> (client: any LLMClient, reused: Bool, invalidated: (any LLMClient)?, reasons: [String]) {
+        if key == newKey, let client {
+            return (client, true, nil, [])
+        }
+
+        let oldClient = client
+        let reasons = key?.invalidationReasons(comparedTo: newKey) ?? []
+        let newClient = makeClient()
+        key = newKey
+        client = newClient
+        return (newClient, false, oldClient, reasons)
+    }
+
+    mutating func remove() -> (any LLMClient)? {
+        defer {
+            key = nil
+            client = nil
+        }
+        return client
+    }
+}
+
+final class LLMURLSessionMetricsDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    private let providerID: String
+
+    init(providerID: String) {
+        self.providerID = providerID
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didFinishCollecting metrics: URLSessionTaskMetrics
+    ) {
+        guard let transaction = metrics.transactionMetrics.last else { return }
+
+        let dns = Self.duration(from: transaction.domainLookupStartDate, to: transaction.domainLookupEndDate)
+        let connect = Self.duration(from: transaction.connectStartDate, to: transaction.connectEndDate)
+        let tls = Self.duration(from: transaction.secureConnectionStartDate, to: transaction.secureConnectionEndDate)
+        let wait = Self.duration(from: transaction.requestEndDate, to: transaction.responseStartDate)
+        DebugFileLogger.log(
+            "llm metrics: provider=\(providerID) dnsMs=\(dns) connectMs=\(connect) tlsMs=\(tls) responseWaitMs=\(wait) connectionReused=\(transaction.isReusedConnection)"
+        )
+        if transaction.isReusedConnection {
+            DebugFileLogger.log("llm connection reused provider=\(providerID)")
+        }
+    }
+
+    private static func duration(from start: Date?, to end: Date?) -> Int {
+        guard let start, let end else { return 0 }
+        return max(0, Int(end.timeIntervalSince(start) * 1_000))
+    }
+}
+
+enum LLMURLSessionFactory {
+    static func make(
+        providerID: String,
+        bypassProxy: Bool
+    ) -> (session: URLSession, metricsDelegate: LLMURLSessionMetricsDelegate) {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 30
+        config.timeoutIntervalForResource = 60
+        config.httpMaximumConnectionsPerHost = 4
+        if bypassProxy {
+            config.connectionProxyDictionary = [:]
+        }
+        let metricsDelegate = LLMURLSessionMetricsDelegate(providerID: providerID)
+        let session = URLSession(
+            configuration: config,
+            delegate: metricsDelegate,
+            delegateQueue: nil
+        )
+        return (session, metricsDelegate)
+    }
+}

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -804,10 +804,11 @@ actor RecognitionSession {
         var earlyLLMTask: Task<String?, Never>?
         var earlyLLMInput: String?
         if needsLLM && !partialAtStop.isEmpty {
-            let exemptionThreshold = currentMode.id == ProcessingMode.formalWritingId
-                ? (Int(UserDefaults.standard.string(forKey: "tf_shortTextExemption") ?? "0") ?? 0)
-                : 0
-            if exemptionThreshold == 0 || partialAtStop.count >= exemptionThreshold {
+            let partialDirectDecision = ShortTextDirectPolicy.decide(
+                text: partialAtStop,
+                mode: currentMode
+            )
+            if partialDirectDecision != .directOutput {
                 let existingDiff = TranscriptDiff.classify(
                     source: speculativeLLMText,
                     final: partialAtStop
@@ -846,21 +847,24 @@ actor RecognitionSession {
                     earlyLLMTask = task
                     earlyLLMInput = provisionalInput
                 }
+            } else {
+                cancelStaleSpeculativeRequest(reason: "shortTextDirectOutput")
+                DebugFileLogger.log(
+                    "stop: provisional canceled reason=shortTextDirectOutput"
+                )
             }
         }
 
-        // Early label override for short text exemption (语音润色 only).
+        // Early label override for short direct output (语音润色 only).
         // Use streaming transcript to update UI immediately, before ASR teardown,
         // so the floating bar doesn't flash "润色中" → "校准中".
-        if needsLLM && currentMode.id == ProcessingMode.formalWritingId {
-            let exemptionThreshold = Int(UserDefaults.standard.string(forKey: "tf_shortTextExemption") ?? "0") ?? 0
-            if exemptionThreshold > 0 {
-                let streamingText = currentTranscript.composedText
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                if streamingText.count < exemptionThreshold {
-                    onASREvent?(.processingLabelOverride(L("校准中", "Calibrating")))
-                }
-            }
+        if needsLLM,
+           ShortTextDirectPolicy.decide(
+               text: partialAtStop,
+               mode: currentMode
+           ) == .directOutput
+        {
+            onASREvent?(.processingLabelOverride(L("校准中", "Calibrating")))
         }
 
         // ASR teardown: send endAudio, then wait for the final transcript.
@@ -978,15 +982,33 @@ actor RecognitionSession {
             DebugFileLogger.log("stop: finalTranscript len=\(finalLLMInput.count) diffType=noProvisional semanticMatch=false")
         }
 
-        let exemptionThreshold = currentMode.id == ProcessingMode.formalWritingId
-            ? (Int(UserDefaults.standard.string(forKey: "tf_shortTextExemption") ?? "0") ?? 0)
-            : 0
-        if needsLLM && exemptionThreshold > 0 && finalLLMInput.count < exemptionThreshold {
+        let shortDirectEnabled = ShortTextDirectPolicy.isEnabled
+        let shortDirectThreshold = ShortTextDirectPolicy.threshold
+        let finalSemanticLength = ShortTextDirectPolicy.semanticLength(of: finalLLMInput)
+        let shortDirectDecision = ShortTextDirectPolicy.decide(
+            text: finalLLMInput,
+            mode: currentMode,
+            enabled: shortDirectEnabled,
+            threshold: shortDirectThreshold
+        )
+        DebugFileLogger.log(
+            "stop: short-text direct check mode=\(currentMode.name) rawLen=\(finalLLMInput.count) semanticLen=\(finalSemanticLength) threshold=\(shortDirectThreshold) enabled=\(shortDirectEnabled)"
+        )
+        switch shortDirectDecision {
+        case .directOutput:
             needsLLM = false
             earlyLLMTask?.cancel()
             earlyLLMTask = nil
-            DebugFileLogger.log("stop: short text exemption (\(finalLLMInput.count) < \(exemptionThreshold) chars), skipping LLM")
+            cancelStaleSpeculativeRequest(reason: "shortTextDirectOutput")
+            DebugFileLogger.log("stop: short-text direct output selected")
+            DebugFileLogger.log("stop: provisional canceled reason=shortTextDirectOutput")
             onASREvent?(.processingLabelOverride(L("校准中", "Calibrating")))
+        case .modeRequiresLLM:
+            DebugFileLogger.log("stop: short-text direct output skipped reason=modeRequiresLLM")
+        case .textTooLong:
+            DebugFileLogger.log("stop: short-text direct output skipped reason=textTooLong")
+        case .disabled:
+            DebugFileLogger.log("stop: short-text direct output skipped reason=disabled")
         }
 
         let freshConfig = needsLLM ? loadEffectiveLLMConfig() : nil
@@ -1041,16 +1063,6 @@ actor RecognitionSession {
 
             // Apply snippet replacements before LLM (e.g. "我的邮箱" → actual email)
             finalText = SnippetStorage.applyEffective(to: finalText, bundleId: targetBundleId)
-
-            // Short text exemption (for non-streaming providers, 语音润色 only)
-            if needsLLM && earlyLLMTask == nil && currentMode.id == ProcessingMode.formalWritingId {
-                let exemptionThreshold = Int(UserDefaults.standard.string(forKey: "tf_shortTextExemption") ?? "0") ?? 0
-                if exemptionThreshold > 0 && finalText.count < exemptionThreshold {
-                    DebugFileLogger.log("stop: short text exemption (\(finalText.count) < \(exemptionThreshold) chars), skipping LLM (sync path)")
-                    needsLLM = false
-                    onASREvent?(.processingLabelOverride(L("校准中", "Calibrating")))
-                }
-            }
 
             // LLM post-processing: prefer early result (fired at stop time),
             // fall back to synchronous call for very short recordings where
@@ -1208,6 +1220,11 @@ actor RecognitionSession {
             guard finalInjectionGuard.claim(generation: myGeneration) else {
                 DebugFileLogger.log("stop: duplicate injection blocked generation=\(myGeneration)")
                 return
+            }
+            if shortDirectDecision == .directOutput {
+                DebugFileLogger.log(
+                    "stop: short-text direct injecting finalTranscript len=\(finalText.count)"
+                )
             }
             _ = await withCheckedContinuation { continuation in
                 Task.detached {
@@ -1498,7 +1515,16 @@ actor RecognitionSession {
         var text = currentTranscript.composedText
             .trimmingCharacters(in: .whitespacesAndNewlines)
         text = SnippetStorage.applyEffective(to: text, bundleId: targetBundleId)
-        let submission = speculativeThrottle.submit(text)
+        let semanticLength = ShortTextDirectPolicy.semanticLength(of: text)
+        let minimumSemanticLength = ShortTextDirectPolicy.isSafePolishingMode(currentMode)
+            && ShortTextDirectPolicy.isEnabled
+            ? ShortTextDirectPolicy.threshold + 1
+            : 8
+        let throttleText = String(repeating: "x", count: semanticLength)
+        let submission = speculativeThrottle.submit(
+            throttleText,
+            minimumTextLength: minimumSemanticLength
+        )
 
         speculativeDebounceTask?.cancel()
         speculativeDebounceTask = nil
@@ -1506,10 +1532,10 @@ actor RecognitionSession {
         switch submission {
         case .tooShort:
             DebugFileLogger.log(
-                "speculative request skipped reason=textTooShort len=\(text.count) min=\(SpeculativeLLMThrottle.minimumTextLength)"
+                "speculative request skipped reason=textTooShort rawLen=\(text.count) semanticLen=\(semanticLength) min=\(minimumSemanticLength)"
             )
         case .deltaTooSmall:
-            let delta = text.count - speculativeThrottle.lastStartedText.count
+            let delta = semanticLength - speculativeThrottle.lastStartedText.count
             DebugFileLogger.log(
                 "speculative request skipped reason=deltaTooSmall len=\(text.count) delta=\(delta) minDelta=\(SpeculativeLLMThrottle.minimumCharacterIncrement)"
             )
@@ -1520,22 +1546,22 @@ actor RecognitionSession {
         case .duplicate:
             break
         case .debounce:
-            scheduleSpeculativeDebounce(for: text)
+            scheduleSpeculativeDebounce(for: text, throttleText: throttleText)
         }
     }
 
-    private func scheduleSpeculativeDebounce(for text: String) {
+    private func scheduleSpeculativeDebounce(for text: String, throttleText: String) {
         speculativeDebounceTask?.cancel()
         speculativeDebounceTask = Task {
             try? await Task.sleep(for: SpeculativeLLMThrottle.debounceDuration)
             guard !Task.isCancelled, state == .recording else { return }
-            await fireSpeculativeLLM(text: text)
+            await fireSpeculativeLLM(text: text, throttleText: throttleText)
         }
     }
 
-    private func fireSpeculativeLLM(text: String) async {
+    private func fireSpeculativeLLM(text: String, throttleText: String) async {
         guard let llmConfig = loadEffectiveLLMConfig() else { return }
-        guard speculativeThrottle.beginDebouncedRequest(for: text) else { return }
+        guard speculativeThrottle.beginDebouncedRequest(for: throttleText) else { return }
 
         speculativeLLMText = text
         speculativeLLMGeneration = sessionGeneration
@@ -1610,13 +1636,23 @@ actor RecognitionSession {
             DebugFileLogger.log("speculative request completed len=\(input.count)")
         }
 
-        guard let pending = speculativeThrottle.requestCompleted(input: input),
+        let completedThrottleText = String(
+            repeating: "x",
+            count: ShortTextDirectPolicy.semanticLength(of: input)
+        )
+        guard let pending = speculativeThrottle.requestCompleted(input: completedThrottleText),
               state == .recording
         else { return }
 
         let submission = speculativeThrottle.submit(pending)
         if submission == .debounce {
-            scheduleSpeculativeDebounce(for: pending)
+            var pendingText = currentTranscript.composedText
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            pendingText = SnippetStorage.applyEffective(
+                to: pendingText,
+                bundleId: targetBundleId
+            )
+            scheduleSpeculativeDebounce(for: pendingText, throttleText: pending)
         }
     }
 

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -66,16 +66,50 @@ actor RecognitionSession {
     private var isCloudMode: Bool { activeProvider == .cloud }
     #endif
 
+    private var llmClientCache = LLMClientCache()
+
     /// Return the appropriate LLM client for the currently selected provider.
-    private func currentLLMClient() -> any LLMClient {
+    private func currentLLMClient(config: LLMConfig) async -> any LLMClient {
+        let bypassProxy = ProxyBypassMode.current.bypassLLM
+        let providerID: String
         #if HAS_CLOUD_SUBSCRIPTION
-        if isCloudMode { return CloudLLMClient() }
+        providerID = isCloudMode ? "cloud" : KeychainService.selectedLLMProvider.rawValue
+        #else
+        providerID = KeychainService.selectedLLMProvider.rawValue
         #endif
         let provider = KeychainService.selectedLLMProvider
-        if provider == .claude {
-            return ClaudeChatClient()
+        let key = LLMClientCacheKey(
+            providerID: providerID,
+            apiKey: config.apiKey,
+            model: config.model,
+            baseURL: config.baseURL,
+            bypassProxy: bypassProxy
+        )
+        let resolution = llmClientCache.resolve(key: key) {
+            #if HAS_CLOUD_SUBSCRIPTION
+            if isCloudMode {
+                return CloudLLMClient(bypassProxy: bypassProxy)
+            }
+            #endif
+            if provider == .claude {
+                return ClaudeChatClient(bypassProxy: bypassProxy)
+            }
+            return DoubaoChatClient(provider: provider, bypassProxy: bypassProxy)
         }
-        return DoubaoChatClient(provider: provider)
+
+        if resolution.reused {
+            DebugFileLogger.log("llm client reused provider=\(providerID)")
+        } else {
+            if let invalidated = resolution.invalidated {
+                let reason = resolution.reasons.isEmpty
+                    ? "cacheReset"
+                    : resolution.reasons.joined(separator: ",")
+                DebugFileLogger.log("llm client invalidated provider=\(providerID) reason=\(reason)")
+                await invalidated.invalidate()
+            }
+            DebugFileLogger.log("llm client created provider=\(providerID)")
+        }
+        return resolution.client
     }
 
     /// Load LLM credentials from KeychainService.
@@ -219,7 +253,10 @@ actor RecognitionSession {
 
     private var speculativeLLMTask: Task<String?, Never>?
     private var speculativeLLMText: String = ""
+    private var speculativeLLMGeneration: Int?
     private var speculativeDebounceTask: Task<Void, Never>?
+    private var speculativeThrottle = SpeculativeLLMThrottle()
+    private var finalInjectionGuard = FinalInjectionGuard()
     /// Stores the last LLM error from the early/fresh LLM task, consumed once by stopRecording().
     private var pendingLLMError: Error?
     /// When true, skip text injection (paste) but still save to clipboard & history.
@@ -285,6 +322,7 @@ actor RecognitionSession {
         self.recordingStartTime = nil
         hasEmittedReadyForCurrentSession = false
         injectionAborted = false
+        finalInjectionGuard.reset()
         pendingLLMError = nil
         lastStreamingError = nil
         state = .starting
@@ -359,7 +397,6 @@ actor RecognitionSession {
         // Load hotwords
         let hotwords = HotwordStorage.loadEffective()
         let biasSettings = ASRBiasSettingsStorage.load()
-        let needsLLM = !effectiveMode.prompt.isEmpty
         let requestOptions = ASRRequestOptions(
             enablePunc: true,
             hotwords: hotwords,
@@ -369,7 +406,10 @@ actor RecognitionSession {
 
         // Capture prompt context while the user's selection is still active.
         promptContext = await PromptContext.capture()
-        guard sessionGeneration == myGeneration else {
+        guard SessionGenerationGuard.isCurrent(
+            expected: myGeneration,
+            active: sessionGeneration
+        ) else {
             DebugFileLogger.log("startRecording: zombie detected after capture, bailing")
             return
         }
@@ -377,7 +417,10 @@ actor RecognitionSession {
         // Reset text state and clean up previous pipeline
         currentTranscript = .empty
         await finishAudioChunkPipeline(timeout: .milliseconds(100))
-        guard sessionGeneration == myGeneration else {
+        guard SessionGenerationGuard.isCurrent(
+            expected: myGeneration,
+            active: sessionGeneration
+        ) else {
             DebugFileLogger.log("startRecording: zombie detected after pipeline cleanup, bailing")
             return
         }
@@ -503,7 +546,7 @@ actor RecognitionSession {
 
         // Pre-warm LLM connection for modes with post-processing
         if !currentMode.prompt.isEmpty, let llmConfig = loadEffectiveLLMConfig() {
-            let client = currentLLMClient()
+            let client = await currentLLMClient(config: llmConfig)
             Task { await client.warmUp(baseURL: llmConfig.baseURL) }
         }
 
@@ -748,10 +791,63 @@ actor RecognitionSession {
             }
         }
 
-        // Keep speculative LLM task alive — we'll compare its input text
-        // against the final ASR transcript after full teardown.
+        // Keep a matching speculative request alive, or start a stop-time
+        // provisional request before waiting for ASR final.
         cancelSpeculativeLLM()
+        speculativeThrottle.prepareForStop()
         var needsLLM = !currentMode.prompt.isEmpty
+        var partialAtStop = currentTranscript.composedText
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        partialAtStop = SnippetStorage.applyEffective(to: partialAtStop, bundleId: targetBundleId)
+        DebugFileLogger.log("stop: partialAtStop len=\(partialAtStop.count)")
+
+        var earlyLLMTask: Task<String?, Never>?
+        var earlyLLMInput: String?
+        if needsLLM && !partialAtStop.isEmpty {
+            let exemptionThreshold = currentMode.id == ProcessingMode.formalWritingId
+                ? (Int(UserDefaults.standard.string(forKey: "tf_shortTextExemption") ?? "0") ?? 0)
+                : 0
+            if exemptionThreshold == 0 || partialAtStop.count >= exemptionThreshold {
+                let existingDiff = TranscriptDiff.classify(
+                    source: speculativeLLMText,
+                    final: partialAtStop
+                )
+                if speculativeLLMGeneration == myGeneration,
+                   existingDiff.canReuseLLMResult,
+                   let speculativeLLMTask {
+                    earlyLLMTask = speculativeLLMTask
+                    earlyLLMInput = speculativeLLMText
+                    DebugFileLogger.log("stop-time provisional reused inputLen=\(speculativeLLMText.count) diffType=\(existingDiff.type.rawValue) +\(ContinuousClock.now - stopT0)")
+                } else if let llmConfig = loadEffectiveLLMConfig() {
+                    cancelStaleSpeculativeRequest(reason: "stopInputChanged")
+                    speculativeLLMText = partialAtStop
+                    speculativeLLMGeneration = myGeneration
+                    speculativeThrottle.markStopTimeRequestStarted(input: partialAtStop)
+                    pendingLLMError = nil
+                    let prompt = promptContext.expandContextVariables(currentMode.prompt)
+                    let client = await currentLLMClient(config: llmConfig)
+                    let provisionalInput = partialAtStop
+                    DebugFileLogger.log("stop-time provisional request started model=\(llmConfig.model) len=\(provisionalInput.count) +\(ContinuousClock.now - stopT0)")
+                    let task = Task<String?, Never> {
+                        do {
+                            let result = try await client.process(
+                                text: provisionalInput, prompt: prompt, config: llmConfig
+                            )
+                            guard !Task.isCancelled else { return nil }
+                            DebugFileLogger.log("stop-time provisional request completed len=\(result.count) +\(ContinuousClock.now - stopT0)")
+                            return result
+                        } catch {
+                            guard !Task.isCancelled else { return nil }
+                            DebugFileLogger.log("stop-time provisional request failed +\(ContinuousClock.now - stopT0) error=\(error)")
+                            return nil
+                        }
+                    }
+                    speculativeLLMTask = task
+                    earlyLLMTask = task
+                    earlyLLMInput = provisionalInput
+                }
+            }
+        }
 
         // Early label override for short text exemption (语音润色 only).
         // Use streaming transcript to update UI immediately, before ASR teardown,
@@ -818,59 +914,6 @@ actor RecognitionSession {
             }
         }
 
-        // Now that we have the final transcript, decide whether to reuse
-        // the speculative LLM result or fire a fresh request.
-        let canEarlyLLM = providerIsStreaming
-        var earlyLLMTask: Task<String?, Never>?
-        if needsLLM && canEarlyLLM {
-            var finalASRText = currentTranscript.displayText
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            finalASRText = SnippetStorage.applyEffective(to: finalASRText, bundleId: targetBundleId)
-
-            // Short text exemption: skip LLM for short texts (语音润色 only)
-            let exemptionThreshold = currentMode.id == ProcessingMode.formalWritingId
-                ? (Int(UserDefaults.standard.string(forKey: "tf_shortTextExemption") ?? "0") ?? 0)
-                : 0
-            if exemptionThreshold > 0 && finalASRText.count < exemptionThreshold {
-                DebugFileLogger.log("stop: short text exemption (\(finalASRText.count) < \(exemptionThreshold) chars), skipping LLM")
-                needsLLM = false
-                onASREvent?(.processingLabelOverride(L("校准中", "Calibrating")))
-            }
-
-            DebugFileLogger.log("stop: needsLLM=\(needsLLM) mode=\(currentMode.name) text=\(finalASRText.count)chars specMatch=\(finalASRText == speculativeLLMText)")
-            if needsLLM && !finalASRText.isEmpty {
-                if finalASRText == speculativeLLMText, let specTask = speculativeLLMTask {
-                    // Final transcript matches speculative input — reuse (may already be done!)
-                    earlyLLMTask = specTask
-                    state = .postProcessing
-                    DebugFileLogger.log("stop: reusing speculative LLM +\(ContinuousClock.now - stopT0)")
-                } else if let llmConfig = loadEffectiveLLMConfig() {
-                    // Final transcript differs from speculative input (tail words arrived),
-                    // discard stale result and fire fresh LLM with complete text.
-                    speculativeLLMTask?.cancel()
-                    let prompt = promptContext.expandContextVariables(currentMode.prompt)
-                    let client = currentLLMClient()
-                    state = .postProcessing
-                    if finalASRText != speculativeLLMText {
-                        DebugFileLogger.log("stop: final transcript changed (spec=\(speculativeLLMText.count)chars final=\(finalASRText.count)chars), firing fresh LLM")
-                    }
-                    DebugFileLogger.log("stop: fresh LLM firing mode=\(currentMode.name) model=\(llmConfig.model) with \(finalASRText.count) chars +\(ContinuousClock.now - stopT0)")
-                    earlyLLMTask = Task {
-                        do {
-                            let result = try await client.process(
-                                text: finalASRText, prompt: prompt, config: llmConfig
-                            )
-                            DebugFileLogger.log("stop: fresh LLM done \(result.count) chars +\(ContinuousClock.now - stopT0)")
-                            return result
-                        } catch {
-                            DebugFileLogger.log("stop: fresh LLM FAILED +\(ContinuousClock.now - stopT0) error=\(error)")
-                            self.setPendingLLMError(error)
-                            return nil
-                        }
-                    }
-                }
-            }
-        }
         eventConsumptionTask = nil
         asrClient = nil
         hasEmittedReadyForCurrentSession = false
@@ -922,6 +965,74 @@ actor RecognitionSession {
         let effectiveText = currentTranscript.displayText
         currentConfig = nil
 
+        var finalLLMInput = effectiveText.trimmingCharacters(in: .whitespacesAndNewlines)
+        finalLLMInput = SnippetStorage.applyEffective(to: finalLLMInput, bundleId: targetBundleId)
+        let finalDiff = earlyLLMInput.map {
+            TranscriptDiff.classify(source: $0, final: finalLLMInput)
+        }
+        if let finalDiff {
+            DebugFileLogger.log(
+                "stop: specLen=\(finalDiff.sourceLength) finalTranscript len=\(finalDiff.finalLength) diffType=\(finalDiff.type.rawValue) commonPrefixLength=\(finalDiff.commonPrefixLength) commonSuffixLength=\(finalDiff.commonSuffixLength) addedSuffixUnicode=\(finalDiff.addedSuffixUnicode) changedInMiddle=\(finalDiff.changedInMiddle) semanticMatch=\(finalDiff.canReuseLLMResult)"
+            )
+        } else {
+            DebugFileLogger.log("stop: finalTranscript len=\(finalLLMInput.count) diffType=noProvisional semanticMatch=false")
+        }
+
+        let exemptionThreshold = currentMode.id == ProcessingMode.formalWritingId
+            ? (Int(UserDefaults.standard.string(forKey: "tf_shortTextExemption") ?? "0") ?? 0)
+            : 0
+        if needsLLM && exemptionThreshold > 0 && finalLLMInput.count < exemptionThreshold {
+            needsLLM = false
+            earlyLLMTask?.cancel()
+            earlyLLMTask = nil
+            DebugFileLogger.log("stop: short text exemption (\(finalLLMInput.count) < \(exemptionThreshold) chars), skipping LLM")
+            onASREvent?(.processingLabelOverride(L("校准中", "Calibrating")))
+        }
+
+        let freshConfig = needsLLM ? loadEffectiveLLMConfig() : nil
+        let freshPrompt = promptContext.expandContextVariables(currentMode.prompt)
+        let freshClient: (any LLMClient)?
+        if let freshConfig {
+            freshClient = await currentLLMClient(config: freshConfig)
+        } else {
+            freshClient = nil
+        }
+        let freshModeName = currentMode.name
+        let earlySelection = EarlyLLMTaskSelector.select(
+            earlyInput: earlyLLMInput,
+            finalInput: finalLLMInput,
+            needsLLM: needsLLM,
+            earlyTask: earlyLLMTask
+        ) {
+            guard let llmConfig = freshConfig,
+                  let client = freshClient,
+                  !finalLLMInput.isEmpty
+            else {
+                return nil
+            }
+            let freshInput = finalLLMInput
+            return Task {
+                DebugFileLogger.log("fresh fallback request started mode=\(freshModeName) model=\(llmConfig.model) len=\(freshInput.count) +\(ContinuousClock.now - stopT0)")
+                do {
+                    let result = try await client.process(
+                        text: freshInput, prompt: freshPrompt, config: llmConfig
+                    )
+                    guard !Task.isCancelled else { return nil }
+                    DebugFileLogger.log("stop: fresh LLM done len=\(result.count) +\(ContinuousClock.now - stopT0)")
+                    return result
+                } catch {
+                    guard !Task.isCancelled else { return nil }
+                    DebugFileLogger.log("stop: fresh LLM FAILED +\(ContinuousClock.now - stopT0) error=\(error)")
+                    return nil
+                }
+            }
+        }
+        earlyLLMTask = earlySelection.task
+        if earlyLLMTask != nil {
+            state = .postProcessing
+        }
+        DebugFileLogger.log("stop: provisional reused=\(earlySelection.reused) +\(ContinuousClock.now - stopT0)")
+
         if !effectiveText.isEmpty {
             let rawText = effectiveText
             var finalText = effectiveText
@@ -967,6 +1078,13 @@ actor RecognitionSession {
                     }
                 }
 
+                guard SessionGenerationGuard.isCurrent(
+                    expected: myGeneration,
+                    active: sessionGeneration
+                ) else {
+                    DebugFileLogger.log("stop: ignored stale early LLM completion gen=\(myGeneration) active=\(sessionGeneration)")
+                    return
+                }
                 if let result = earlyResult, !result.isEmpty {
                     DebugFileLogger.log("stop: early LLM result received \(result.count) chars +\(ContinuousClock.now - stopT0)")
                     let cleaned = result.collapsingExtraSpaces
@@ -996,7 +1114,7 @@ actor RecognitionSession {
                 state = .postProcessing
                 if let llmConfig = loadEffectiveLLMConfig() {
                     DebugFileLogger.log("stop: sync LLM firing mode=\(currentMode.name) model=\(llmConfig.model) with \(finalText.count) chars")
-                    let client = currentLLMClient()
+                    let client = await currentLLMClient(config: llmConfig)
                     let prompt = promptContext.expandContextVariables(currentMode.prompt)
                     let textForLLM = finalText
 
@@ -1029,6 +1147,13 @@ actor RecognitionSession {
                         }
                     }
 
+                    guard SessionGenerationGuard.isCurrent(
+                        expected: myGeneration,
+                        active: sessionGeneration
+                    ) else {
+                        DebugFileLogger.log("stop: ignored stale sync LLM completion gen=\(myGeneration) active=\(sessionGeneration)")
+                        return
+                    }
                     if let result = llmResult {
                         let cleaned = result.collapsingExtraSpaces
                         if currentMode.id == ProcessingMode.macActionId {
@@ -1073,7 +1198,18 @@ actor RecognitionSession {
             let aborted = injectionAborted
             let onEvent = self.onASREvent
             let injectLog = "stop: injecting method=clipboard len=\(finalText.count) +\(ContinuousClock.now - stopT0)"
-            let injectionOutcome: InjectionOutcome = await withCheckedContinuation { continuation in
+            guard SessionGenerationGuard.isCurrent(
+                expected: myGeneration,
+                active: sessionGeneration
+            ) else {
+                DebugFileLogger.log("stop: injection skipped for stale generation gen=\(myGeneration) active=\(sessionGeneration)")
+                return
+            }
+            guard finalInjectionGuard.claim(generation: myGeneration) else {
+                DebugFileLogger.log("stop: duplicate injection blocked generation=\(myGeneration)")
+                return
+            }
+            _ = await withCheckedContinuation { continuation in
                 Task.detached {
                     let outcome: InjectionOutcome
                     if aborted {
@@ -1086,7 +1222,7 @@ actor RecognitionSession {
                     }
                     // Notify UI immediately from this thread, before actor resumes
                     onEvent?(.finalized(text: finalText, injection: outcome))
-                    DebugFileLogger.log("stop: finalized emitted from injection task")
+                    DebugFileLogger.log("stop: finalized +\(ContinuousClock.now - stopT0)")
                     // Only restore clipboard when text was successfully inserted.
                     // When outcome is .copiedToClipboard (injection failed or ESC abort),
                     // keep the text in clipboard so user can manually paste.
@@ -1149,6 +1285,7 @@ actor RecognitionSession {
         resetSpeculativeLLM()
         SystemVolumeManager.restore()
         logger.info("Session complete, injected \(effectiveText.count) chars")
+        DebugFileLogger.log("stop: total +\(ContinuousClock.now - stopT0)")
     }
 
     // MARK: - ASR Events
@@ -1351,48 +1488,135 @@ actor RecognitionSession {
         return !KeychainService.selectedLLMProvider.isLocal
     }
 
-    /// Debounce: after each transcript update, wait 800ms of silence before
-    /// speculatively sending current text to LLM. If the user is still
-    /// speaking, the timer resets.
+    /// Debounce transcript updates before starting a speculative request.
     private func scheduleSpeculativeLLM() {
         guard isSpeculativeLLMEnabled else { return }
         #if HAS_CLOUD_SUBSCRIPTION
         if isCloudMode { return }
         #endif
-        speculativeDebounceTask?.cancel()
-        speculativeDebounceTask = Task {
-            try? await Task.sleep(for: .milliseconds(800))
-            guard !Task.isCancelled, state == .recording else { return }
-            await fireSpeculativeLLM()
-        }
-    }
 
-    private func fireSpeculativeLLM() async {
         var text = currentTranscript.composedText
             .trimmingCharacters(in: .whitespacesAndNewlines)
         text = SnippetStorage.applyEffective(to: text, bundleId: targetBundleId)
-        guard !text.isEmpty, text != speculativeLLMText else { return }
-        guard let llmConfig = loadEffectiveLLMConfig() else { return }
+        let submission = speculativeThrottle.submit(text)
 
-        // Cancel previous speculative call if text changed
-        speculativeLLMTask?.cancel()
+        speculativeDebounceTask?.cancel()
+        speculativeDebounceTask = nil
+
+        switch submission {
+        case .tooShort:
+            DebugFileLogger.log(
+                "speculative request skipped reason=textTooShort len=\(text.count) min=\(SpeculativeLLMThrottle.minimumTextLength)"
+            )
+        case .deltaTooSmall:
+            let delta = text.count - speculativeThrottle.lastStartedText.count
+            DebugFileLogger.log(
+                "speculative request skipped reason=deltaTooSmall len=\(text.count) delta=\(delta) minDelta=\(SpeculativeLLMThrottle.minimumCharacterIncrement)"
+            )
+        case .queued:
+            DebugFileLogger.log(
+                "speculative request queued reason=inFlight len=\(text.count)"
+            )
+        case .duplicate:
+            break
+        case .debounce:
+            scheduleSpeculativeDebounce(for: text)
+        }
+    }
+
+    private func scheduleSpeculativeDebounce(for text: String) {
+        speculativeDebounceTask?.cancel()
+        speculativeDebounceTask = Task {
+            try? await Task.sleep(for: SpeculativeLLMThrottle.debounceDuration)
+            guard !Task.isCancelled, state == .recording else { return }
+            await fireSpeculativeLLM(text: text)
+        }
+    }
+
+    private func fireSpeculativeLLM(text: String) async {
+        guard let llmConfig = loadEffectiveLLMConfig() else { return }
+        guard speculativeThrottle.beginDebouncedRequest(for: text) else { return }
+
         speculativeLLMText = text
+        speculativeLLMGeneration = sessionGeneration
+        pendingLLMError = nil
+        let requestGeneration = sessionGeneration
+        let requestText = text
         let prompt = promptContext.expandContextVariables(currentMode.prompt)
 
-        let client = currentLLMClient()
-        DebugFileLogger.log("speculative LLM: firing mode=\(currentMode.name) model=\(llmConfig.model) with \(text.count) chars")
+        let client = await currentLLMClient(config: llmConfig)
+        DebugFileLogger.log(
+            "speculative request started mode=\(currentMode.name) model=\(llmConfig.model) len=\(text.count)"
+        )
         speculativeLLMTask = Task {
+            let result: String?
             do {
-                let result = try await client.process(
+                let processed = try await client.process(
                     text: text, prompt: prompt, config: llmConfig
                 )
-                DebugFileLogger.log("speculative LLM: done \(result.count) chars")
-                return result
+                guard !Task.isCancelled else {
+                    self.speculativeRequestFinished(
+                        input: requestText,
+                        generation: requestGeneration,
+                        resultWasIgnored: true
+                    )
+                    return nil
+                }
+                result = processed
             } catch {
-                DebugFileLogger.log("speculative LLM: failed \(error)")
-                self.setPendingLLMError(error)
-                return nil
+                if Task.isCancelled {
+                    self.speculativeRequestFinished(
+                        input: requestText,
+                        generation: requestGeneration,
+                        resultWasIgnored: true
+                    )
+                    return nil
+                }
+                DebugFileLogger.log("speculative request failed error=\(error)")
+                self.setPendingLLMError(
+                    error,
+                    generation: requestGeneration,
+                    requestText: requestText
+                )
+                result = nil
             }
+            self.speculativeRequestFinished(
+                input: requestText,
+                generation: requestGeneration,
+                resultWasIgnored: false
+            )
+            return result
+        }
+    }
+
+    private func speculativeRequestFinished(
+        input: String,
+        generation: Int,
+        resultWasIgnored: Bool
+    ) {
+        guard generation == sessionGeneration,
+              generation == speculativeLLMGeneration,
+              input == speculativeLLMText
+        else {
+            DebugFileLogger.log(
+                "speculative request result ignored reason=stale generation=\(generation) active=\(sessionGeneration) len=\(input.count)"
+            )
+            return
+        }
+
+        if resultWasIgnored {
+            DebugFileLogger.log("speculative request result ignored reason=cancelled len=\(input.count)")
+        } else {
+            DebugFileLogger.log("speculative request completed len=\(input.count)")
+        }
+
+        guard let pending = speculativeThrottle.requestCompleted(input: input),
+              state == .recording
+        else { return }
+
+        let submission = speculativeThrottle.submit(pending)
+        if submission == .debounce {
+            scheduleSpeculativeDebounce(for: pending)
         }
     }
 
@@ -1402,7 +1626,20 @@ actor RecognitionSession {
         // Don't cancel speculativeLLMTask here — stopRecording may reuse it
     }
 
-    private func setPendingLLMError(_ error: Error) {
+    private func cancelStaleSpeculativeRequest(reason: String) {
+        guard let speculativeLLMTask else { return }
+        speculativeLLMTask.cancel()
+        self.speculativeLLMTask = nil
+        DebugFileLogger.log(
+            "speculative request canceled reason=\(reason) len=\(speculativeLLMText.count)"
+        )
+    }
+
+    private func setPendingLLMError(_ error: Error, generation: Int, requestText: String) {
+        guard generation == sessionGeneration,
+              generation == speculativeLLMGeneration,
+              requestText == speculativeLLMText
+        else { return }
         pendingLLMError = error
     }
 
@@ -1412,6 +1649,8 @@ actor RecognitionSession {
         speculativeLLMTask?.cancel()
         speculativeLLMTask = nil
         speculativeLLMText = ""
+        speculativeLLMGeneration = nil
+        speculativeThrottle.reset()
     }
 
     // MARK: - Timeout Helper

--- a/Type4Me/Session/ShortTextDirectPolicy.swift
+++ b/Type4Me/Session/ShortTextDirectPolicy.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+enum ShortTextDirectPolicy {
+    static let enabledKey = "tf_shortTextDirectEnabled"
+    static let thresholdKey = "tf_shortTextDirectThreshold"
+    static let defaultThreshold = 8
+
+    enum Decision: Equatable, Sendable {
+        case directOutput
+        case disabled
+        case modeRequiresLLM
+        case textTooLong
+    }
+
+    static var isEnabled: Bool {
+        guard let stored = UserDefaults.standard.object(forKey: enabledKey) else {
+            return true
+        }
+        return stored as? Bool ?? true
+    }
+
+    static var threshold: Int {
+        guard let stored = UserDefaults.standard.object(forKey: thresholdKey) else {
+            return defaultThreshold
+        }
+        if let value = stored as? Int {
+            return max(0, value)
+        }
+        if let value = stored as? String, let parsed = Int(value) {
+            return max(0, parsed)
+        }
+        return defaultThreshold
+    }
+
+    static func semanticLength(of text: String) -> Int {
+        text.unicodeScalars.reduce(into: 0) { count, scalar in
+            guard !CharacterSet.whitespacesAndNewlines.contains(scalar),
+                  !CharacterSet.punctuationCharacters.contains(scalar)
+            else { return }
+            count += 1
+        }
+    }
+
+    static func isSafePolishingMode(_ mode: ProcessingMode) -> Bool {
+        mode.id == ProcessingMode.formalWritingId
+            && mode.prompt == ProcessingMode.formalWritingPromptTemplate
+    }
+
+    static func decide(
+        text: String,
+        mode: ProcessingMode,
+        enabled: Bool = isEnabled,
+        threshold: Int = threshold
+    ) -> Decision {
+        guard enabled else { return .disabled }
+        guard isSafePolishingMode(mode) else { return .modeRequiresLLM }
+        return semanticLength(of: text) <= threshold ? .directOutput : .textTooLong
+    }
+
+    static func shouldStartStopTimeProvisional(
+        partialText: String,
+        mode: ProcessingMode,
+        enabled: Bool = isEnabled,
+        threshold: Int = threshold
+    ) -> Bool {
+        decide(
+            text: partialText,
+            mode: mode,
+            enabled: enabled,
+            threshold: threshold
+        ) != .directOutput
+    }
+}

--- a/Type4Me/Session/SpeculativeLLMThrottle.swift
+++ b/Type4Me/Session/SpeculativeLLMThrottle.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 struct SpeculativeLLMThrottle: Sendable {
-    static let minimumTextLength = 8
     static let minimumCharacterIncrement = 8
     static let debounceDuration: Duration = .milliseconds(600)
 
@@ -18,8 +17,8 @@ struct SpeculativeLLMThrottle: Sendable {
     private(set) var pendingText: String?
     private(set) var inFlight = false
 
-    mutating func submit(_ text: String) -> Submission {
-        guard text.count >= Self.minimumTextLength else {
+    mutating func submit(_ text: String, minimumTextLength: Int = 8) -> Submission {
+        guard text.count >= minimumTextLength else {
             debounceText = nil
             pendingText = nil
             return .tooShort

--- a/Type4Me/Session/SpeculativeLLMThrottle.swift
+++ b/Type4Me/Session/SpeculativeLLMThrottle.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+struct SpeculativeLLMThrottle: Sendable {
+    static let minimumTextLength = 8
+    static let minimumCharacterIncrement = 8
+    static let debounceDuration: Duration = .milliseconds(600)
+
+    enum Submission: Equatable, Sendable {
+        case tooShort
+        case deltaTooSmall
+        case debounce
+        case queued
+        case duplicate
+    }
+
+    private(set) var lastStartedText = ""
+    private(set) var debounceText: String?
+    private(set) var pendingText: String?
+    private(set) var inFlight = false
+
+    mutating func submit(_ text: String) -> Submission {
+        guard text.count >= Self.minimumTextLength else {
+            debounceText = nil
+            pendingText = nil
+            return .tooShort
+        }
+        guard text != lastStartedText else {
+            debounceText = nil
+            pendingText = nil
+            return .duplicate
+        }
+        guard lastStartedText.isEmpty
+                || text.count - lastStartedText.count >= Self.minimumCharacterIncrement
+        else {
+            debounceText = nil
+            pendingText = nil
+            return .deltaTooSmall
+        }
+
+        if inFlight {
+            pendingText = text
+            debounceText = nil
+            return .queued
+        }
+
+        debounceText = text
+        return .debounce
+    }
+
+    mutating func beginDebouncedRequest(for text: String) -> Bool {
+        guard !inFlight, debounceText == text else { return false }
+        debounceText = nil
+        pendingText = nil
+        lastStartedText = text
+        inFlight = true
+        return true
+    }
+
+    mutating func requestCompleted(input: String) -> String? {
+        guard inFlight, input == lastStartedText else { return nil }
+        inFlight = false
+        let next = pendingText
+        pendingText = nil
+        return next
+    }
+
+    mutating func prepareForStop() {
+        debounceText = nil
+        pendingText = nil
+    }
+
+    mutating func markStopTimeRequestStarted(input: String) {
+        prepareForStop()
+        lastStartedText = input
+        inFlight = true
+    }
+
+    mutating func reset() {
+        lastStartedText = ""
+        debounceText = nil
+        pendingText = nil
+        inFlight = false
+    }
+}
+
+struct FinalInjectionGuard: Sendable {
+    private var claimedGeneration: Int?
+
+    mutating func claim(generation: Int) -> Bool {
+        guard claimedGeneration != generation else { return false }
+        claimedGeneration = generation
+        return true
+    }
+
+    mutating func reset() {
+        claimedGeneration = nil
+    }
+}

--- a/Type4Me/Session/TranscriptDiff.swift
+++ b/Type4Me/Session/TranscriptDiff.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+enum TranscriptDiffType: String, Equatable, Sendable {
+    case exactMatch
+    case punctuationOnly
+    case whitespaceOnly
+    case trailingPunctuationOnly
+    case suffixAdded
+    case prefixAdded
+    case semanticChange
+}
+
+struct TranscriptDiff: Sendable, Equatable {
+    let type: TranscriptDiffType
+    let sourceLength: Int
+    let finalLength: Int
+    let commonPrefixLength: Int
+    let commonSuffixLength: Int
+    let addedSuffixUnicode: [String]
+    let changedInMiddle: Bool
+
+    var canReuseLLMResult: Bool {
+        switch type {
+        case .exactMatch, .punctuationOnly, .whitespaceOnly, .trailingPunctuationOnly:
+            return true
+        case .suffixAdded, .prefixAdded, .semanticChange:
+            return false
+        }
+    }
+
+    static func classify(source: String, final: String) -> TranscriptDiff {
+        let prefixLength = commonPrefix(source, final)
+        let suffixLength = commonSuffix(source, final, excludingPrefix: prefixLength)
+        let sourceCharacters = Array(source)
+        let finalCharacters = Array(final)
+        let addedSuffix = final.hasPrefix(source)
+            ? finalCharacters.dropFirst(sourceCharacters.count).map(unicodeLabel)
+            : []
+        let changedInMiddle = prefixLength + suffixLength < min(sourceCharacters.count, finalCharacters.count)
+
+        let type: TranscriptDiffType
+        if source == final {
+            type = .exactMatch
+        } else if removingWhitespace(source) == removingWhitespace(final) {
+            type = .whitespaceOnly
+        } else if normalizingPunctuationAndWhitespace(source) == normalizingPunctuationAndWhitespace(final) {
+            type = .punctuationOnly
+        } else if removingTrailingPunctuation(source) == removingTrailingPunctuation(final) {
+            type = .trailingPunctuationOnly
+        } else if final.hasPrefix(source) {
+            type = .suffixAdded
+        } else if final.hasSuffix(source) {
+            type = .prefixAdded
+        } else {
+            type = .semanticChange
+        }
+
+        return TranscriptDiff(
+            type: type,
+            sourceLength: sourceCharacters.count,
+            finalLength: finalCharacters.count,
+            commonPrefixLength: prefixLength,
+            commonSuffixLength: suffixLength,
+            addedSuffixUnicode: addedSuffix,
+            changedInMiddle: changedInMiddle
+        )
+    }
+
+    private static let punctuationMap: [Character: Character] = [
+        "，": ",", "。": ".", "！": "!", "？": "?", "；": ";", "：": ":",
+        "（": "(", "）": ")", "【": "[", "】": "]", "“": "\"", "”": "\"",
+        "‘": "'", "’": "'",
+    ]
+
+    private static let trailingPunctuation = CharacterSet(
+        charactersIn: "，。！？；：、,.!?;:…— \t\r\n"
+    )
+
+    private static func removingWhitespace(_ text: String) -> String {
+        String(text.unicodeScalars.filter { !CharacterSet.whitespacesAndNewlines.contains($0) })
+    }
+
+    private static func normalizingPunctuationAndWhitespace(_ text: String) -> String {
+        String(text.compactMap { character -> Character? in
+            if character.unicodeScalars.allSatisfy({
+                CharacterSet.whitespacesAndNewlines.contains($0)
+            }) {
+                return nil
+            }
+            return punctuationMap[character] ?? character
+        })
+    }
+
+    private static func removingTrailingPunctuation(_ text: String) -> String {
+        let normalized = normalizingPunctuationAndWhitespace(text)
+        return normalized.trimmingCharacters(in: trailingPunctuation)
+    }
+
+    private static func commonPrefix(_ lhs: String, _ rhs: String) -> Int {
+        zip(lhs, rhs).prefix { pair in pair.0 == pair.1 }.count
+    }
+
+    private static func commonSuffix(_ lhs: String, _ rhs: String, excludingPrefix prefix: Int) -> Int {
+        let maximum = min(lhs.count, rhs.count) - prefix
+        guard maximum > 0 else { return 0 }
+        return zip(lhs.reversed(), rhs.reversed())
+            .prefix(maximum)
+            .prefix { pair in pair.0 == pair.1 }
+            .count
+    }
+
+    private static func unicodeLabel(_ character: Character) -> String {
+        character.unicodeScalars
+            .map { String(format: "U+%04X", $0.value) }
+            .joined(separator: "+")
+    }
+}
+
+enum EarlyLLMDecision: Equatable, Sendable {
+    case noRequest
+    case reuse
+    case runFresh
+
+    static func decide(earlyInput: String?, finalInput: String, needsLLM: Bool) -> EarlyLLMDecision {
+        guard needsLLM, !finalInput.isEmpty else { return .noRequest }
+        guard let earlyInput, !earlyInput.isEmpty else { return .runFresh }
+        return TranscriptDiff.classify(source: earlyInput, final: finalInput).canReuseLLMResult
+            ? .reuse
+            : .runFresh
+    }
+}
+
+struct EarlyLLMTaskSelection {
+    let task: Task<String?, Never>?
+    let reused: Bool
+}
+
+enum EarlyLLMTaskSelector {
+    static func select(
+        earlyInput: String?,
+        finalInput: String,
+        needsLLM: Bool,
+        earlyTask: Task<String?, Never>?,
+        makeFreshTask: () -> Task<String?, Never>?
+    ) -> EarlyLLMTaskSelection {
+        switch EarlyLLMDecision.decide(
+            earlyInput: earlyInput,
+            finalInput: finalInput,
+            needsLLM: needsLLM
+        ) {
+        case .reuse:
+            if let earlyTask {
+                return EarlyLLMTaskSelection(task: earlyTask, reused: true)
+            }
+            return EarlyLLMTaskSelection(task: makeFreshTask(), reused: false)
+        case .runFresh:
+            earlyTask?.cancel()
+            return EarlyLLMTaskSelection(task: makeFreshTask(), reused: false)
+        case .noRequest:
+            earlyTask?.cancel()
+            return EarlyLLMTaskSelection(task: nil, reused: false)
+        }
+    }
+}
+
+enum SessionGenerationGuard {
+    static func isCurrent(expected: Int, active: Int) -> Bool {
+        expected == active
+    }
+}

--- a/Type4Me/UI/Settings/ModesSettingsTab.swift
+++ b/Type4Me/UI/Settings/ModesSettingsTab.swift
@@ -961,7 +961,7 @@ private struct ModeDetailInner: View {
 
 // MARK: - Formal Writing Detail Inner
 
-private struct FormalWritingDetailInner: View {
+private struct FormalWritingDetailInner: View, SettingsCardHelpers {
 
     let mode: ProcessingMode
     let onSave: (ProcessingMode) -> Void
@@ -989,28 +989,62 @@ private struct FormalWritingDetailInner: View {
     private let directThresholdOptions = [4, 6, 8, 10, 12]
 
     private var shortTextDirectSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Toggle(
-                L("短句直接输出", "Direct Output for Short Phrases"),
-                isOn: $shortTextDirectEnabled
-            )
-            .toggleStyle(.switch)
-            Text(L("语义字符不超过阈值时跳过润色，直接使用最终识别结果",
-                   "Skip polishing when semantic content does not exceed the threshold"))
+        settingsGroupCard(L("短句处理", "Short Phrase Handling"), icon: "text.badge.checkmark") {
+            HStack(alignment: .top, spacing: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    settingLabel(
+                        L("短句直接输出", "Direct Output"),
+                        description: L("跳过 LLM 润色", "Skip LLM polishing")
+                    )
+                    settingsDropdown(
+                        selection: Binding(
+                            get: { shortTextDirectEnabled ? "on" : "off" },
+                            set: { shortTextDirectEnabled = $0 == "on" }
+                        ),
+                        options: [
+                            ("on", L("开启", "On")),
+                            ("off", L("关闭", "Off")),
+                        ]
+                    )
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 6)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    settingLabel(
+                        L("直接输出阈值", "Direct Output Threshold"),
+                        description: L("忽略空格与标点", "Ignores spaces and punctuation")
+                    )
+                    settingsDropdown(
+                        selection: Binding(
+                            get: { String(shortTextDirectThreshold) },
+                            set: { shortTextDirectThreshold = Int($0) ?? ShortTextDirectPolicy.defaultThreshold }
+                        ),
+                        options: directThresholdOptions.map { value in
+                            (String(value), L("\(value) 个语义字符", "\(value) semantic characters"))
+                        }
+                    )
+                    .disabled(!shortTextDirectEnabled)
+                    .opacity(shortTextDirectEnabled ? 1 : 0.45)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 6)
+            }
+        }
+    }
+
+    private func settingLabel(_ title: String, description: String) -> some View {
+        HStack(spacing: 4) {
+            Text(title.uppercased())
+                .font(.system(size: 10, weight: .semibold))
+                .tracking(0.8)
+                .foregroundStyle(TF.settingsTextTertiary)
+            Text("|")
+                .font(.system(size: 10))
+                .foregroundStyle(TF.settingsTextTertiary.opacity(0.5))
+            Text(description)
                 .font(.system(size: 10))
                 .foregroundStyle(TF.settingsTextTertiary)
-            if shortTextDirectEnabled {
-                Picker(
-                    L("阈值", "Threshold"),
-                    selection: $shortTextDirectThreshold
-                ) {
-                    ForEach(directThresholdOptions, id: \.self) { value in
-                        Text(L("\(value) 个语义字符", "\(value) semantic characters"))
-                            .tag(value)
-                    }
-                }
-                .pickerStyle(.menu)
-            }
         }
     }
 

--- a/Type4Me/UI/Settings/ModesSettingsTab.swift
+++ b/Type4Me/UI/Settings/ModesSettingsTab.swift
@@ -422,13 +422,8 @@ struct ModesSettingsTab: View {
         ]
     }
 
-    @AppStorage("tf_shortTextExemption") private var shortTextExemption = "0"
-
     private func formalWritingModeDetail(_ mode: ProcessingMode) -> some View {
-        FormalWritingDetailInner(
-            mode: mode,
-            shortTextExemption: $shortTextExemption
-        ) { updated in
+        FormalWritingDetailInner(mode: mode) { updated in
             if let idx = modes.firstIndex(where: { $0.id == updated.id }) {
                 modes[idx] = updated
                 persistModes()
@@ -851,7 +846,6 @@ private struct ModeDetailInner: View {
     let mode: ProcessingMode
     let onSave: (ProcessingMode) -> Void
 
-    @AppStorage("tf_shortTextExemption") private var shortTextExemption = "0"
     @State private var name = ""
     @State private var processingLabel = ""
     @State private var prompt = ""
@@ -863,59 +857,6 @@ private struct ModeDetailInner: View {
 
     private var isDirty: Bool {
         name != mode.name || processingLabel != mode.processingLabel || prompt != mode.prompt
-    }
-
-    private let exemptionOptions: [(value: String, label: String)] = [
-        ("0", L("关闭", "Off")),
-        ("10", L("10 字以下", "Under 10 chars")),
-        ("20", L("20 字以下", "Under 20 chars")),
-        ("30", L("30 字以下", "Under 30 chars")),
-        ("40", L("40 字以下", "Under 40 chars")),
-        ("50", L("50 字以下", "Under 50 chars")),
-    ]
-
-    private var shortTextExemptionSection: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(L("短文本跳过", "Short Text Skip").uppercased())
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(TF.settingsTextTertiary)
-            exemptionDropdown
-            Text(L("文本少于该字数时跳过润色，直接使用识别结果",
-                     "Skip polishing for texts shorter than this threshold"))
-                .font(.system(size: 10))
-                .foregroundStyle(TF.settingsTextTertiary)
-        }
-    }
-
-    private var exemptionDropdown: some View {
-        let currentLabel = exemptionOptions.first(where: { $0.value == shortTextExemption })?.label ?? shortTextExemption
-        return Menu {
-            ForEach(exemptionOptions, id: \.value) { option in
-                Button {
-                    shortTextExemption = option.value
-                } label: {
-                    if option.value == shortTextExemption {
-                        Label(option.label, systemImage: "checkmark")
-                    } else {
-                        Text(option.label)
-                    }
-                }
-            }
-        } label: {
-            HStack(spacing: 8) {
-                Text(currentLabel)
-                    .font(.system(size: 13))
-                    .foregroundStyle(TF.settingsText)
-                Spacer()
-                Image(systemName: "chevron.down")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(TF.settingsTextTertiary)
-            }
-            .padding(.horizontal, 12)
-            .frame(height: 36)
-            .background(RoundedRectangle(cornerRadius: 8).fill(TF.settingsCardAlt))
-        }
-        .buttonStyle(.plain)
     }
 
     var body: some View {
@@ -1023,9 +964,10 @@ private struct ModeDetailInner: View {
 private struct FormalWritingDetailInner: View {
 
     let mode: ProcessingMode
-    @Binding var shortTextExemption: String
     let onSave: (ProcessingMode) -> Void
 
+    @AppStorage(ShortTextDirectPolicy.enabledKey) private var shortTextDirectEnabled = true
+    @AppStorage(ShortTextDirectPolicy.thresholdKey) private var shortTextDirectThreshold = ShortTextDirectPolicy.defaultThreshold
     @State private var name = ""
     @State private var processingLabel = ""
     @State private var prompt = ""
@@ -1044,25 +986,31 @@ private struct FormalWritingDetailInner: View {
         prompt == ProcessingMode.formalWritingPromptTemplate
     }
 
-    private let exemptionOptions: [(value: String, label: String)] = [
-        ("0", L("关闭", "Off")),
-        ("10", L("10 字以下", "Under 10 chars")),
-        ("20", L("20 字以下", "Under 20 chars")),
-        ("30", L("30 字以下", "Under 30 chars")),
-        ("40", L("40 字以下", "Under 40 chars")),
-        ("50", L("50 字以下", "Under 50 chars")),
-    ]
+    private let directThresholdOptions = [4, 6, 8, 10, 12]
 
-    private var shortTextExemptionSection: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(L("短文本跳过", "Short Text Skip").uppercased())
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(TF.settingsTextTertiary)
-            exemptionDropdown
-            Text(L("文本少于该字数时跳过润色，直接使用识别结果",
-                     "Skip polishing for texts shorter than this threshold"))
+    private var shortTextDirectSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle(
+                L("短句直接输出", "Direct Output for Short Phrases"),
+                isOn: $shortTextDirectEnabled
+            )
+            .toggleStyle(.switch)
+            Text(L("语义字符不超过阈值时跳过润色，直接使用最终识别结果",
+                   "Skip polishing when semantic content does not exceed the threshold"))
                 .font(.system(size: 10))
                 .foregroundStyle(TF.settingsTextTertiary)
+            if shortTextDirectEnabled {
+                Picker(
+                    L("阈值", "Threshold"),
+                    selection: $shortTextDirectThreshold
+                ) {
+                    ForEach(directThresholdOptions, id: \.self) { value in
+                        Text(L("\(value) 个语义字符", "\(value) semantic characters"))
+                            .tag(value)
+                    }
+                }
+                .pickerStyle(.menu)
+            }
         }
     }
 
@@ -1175,8 +1123,7 @@ private struct FormalWritingDetailInner: View {
                     .foregroundStyle(TF.settingsTextTertiary)
             }
 
-            // Short text exemption
-            shortTextExemptionSection
+            shortTextDirectSection
 
             // Prompt 模板
             VStack(alignment: .leading, spacing: 4) {
@@ -1203,37 +1150,6 @@ private struct FormalWritingDetailInner: View {
         .onChange(of: name) { _, _ in if saveStatus == .saved { saveStatus = .dirty } }
         .onChange(of: processingLabel) { _, _ in if saveStatus == .saved { saveStatus = .dirty } }
         .onChange(of: prompt) { _, _ in if saveStatus == .saved { saveStatus = .dirty } }
-    }
-
-    private var exemptionDropdown: some View {
-        let currentLabel = exemptionOptions.first(where: { $0.value == shortTextExemption })?.label ?? shortTextExemption
-        return Menu {
-            ForEach(exemptionOptions, id: \.value) { option in
-                Button {
-                    shortTextExemption = option.value
-                } label: {
-                    if option.value == shortTextExemption {
-                        Label(option.label, systemImage: "checkmark")
-                    } else {
-                        Text(option.label)
-                    }
-                }
-            }
-        } label: {
-            HStack(spacing: 8) {
-                Text(currentLabel)
-                    .font(.system(size: 13))
-                    .foregroundStyle(TF.settingsText)
-                Spacer()
-                Image(systemName: "chevron.down")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(TF.settingsTextTertiary)
-            }
-            .padding(.horizontal, 12)
-            .frame(height: 36)
-            .background(RoundedRectangle(cornerRadius: 8).fill(TF.settingsCardAlt))
-        }
-        .buttonStyle(.plain)
     }
 
     private func syncFields() {

--- a/Type4MeTests/LLMClientCacheTests.swift
+++ b/Type4MeTests/LLMClientCacheTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import Type4Me
+
+final class LLMClientCacheTests: XCTestCase {
+    func testReusesClientForMatchingConfiguration() {
+        var cache = LLMClientCache()
+        let key = makeKey()
+        let first = cache.resolve(key: key) { StubLLMClient() }
+        let second = cache.resolve(key: key) { StubLLMClient() }
+
+        XCTAssertFalse(first.reused)
+        XCTAssertTrue(second.reused)
+        XCTAssertEqual(
+            ObjectIdentifier(first.client),
+            ObjectIdentifier(second.client)
+        )
+        XCTAssertNil(second.invalidated)
+    }
+
+    func testInvalidatesClientWhenConfigurationChanges() async {
+        var cache = LLMClientCache()
+        let first = cache.resolve(key: makeKey()) { StubLLMClient() }
+        let updatedKey = LLMClientCacheKey(
+            providerID: "doubao",
+            apiKey: "new-key",
+            model: "new-model",
+            baseURL: "https://new.example.com/v1",
+            bypassProxy: true
+        )
+        let second = cache.resolve(key: updatedKey) { StubLLMClient() }
+
+        XCTAssertFalse(second.reused)
+        XCTAssertNotEqual(
+            ObjectIdentifier(first.client),
+            ObjectIdentifier(second.client)
+        )
+        XCTAssertEqual(
+            second.reasons,
+            ["apiKey", "model", "baseURL", "proxyBypass"]
+        )
+
+        await second.invalidated?.invalidate()
+        let oldClient = first.client as? StubLLMClient
+        let wasInvalidated = await oldClient?.isInvalidated
+        XCTAssertEqual(wasInvalidated, true)
+    }
+
+    func testProviderChangeInvalidatesCachedClient() {
+        var cache = LLMClientCache()
+        _ = cache.resolve(key: makeKey()) { StubLLMClient() }
+        let claudeKey = LLMClientCacheKey(
+            providerID: "claude",
+            apiKey: "key",
+            model: "model",
+            baseURL: "https://example.com/v1",
+            bypassProxy: false
+        )
+
+        let resolution = cache.resolve(key: claudeKey) { StubLLMClient() }
+
+        XCTAssertEqual(resolution.reasons, ["provider"])
+        XCTAssertNotNil(resolution.invalidated)
+    }
+
+    private func makeKey() -> LLMClientCacheKey {
+        LLMClientCacheKey(
+            providerID: "doubao",
+            apiKey: "key",
+            model: "model",
+            baseURL: "https://example.com/v1",
+            bypassProxy: false
+        )
+    }
+}
+
+private actor StubLLMClient: LLMClient {
+    private(set) var isInvalidated = false
+
+    func process(text: String, prompt: String, config: LLMConfig) async throws -> String {
+        text
+    }
+
+    func warmUp(baseURL: String) async {}
+
+    func invalidate() async {
+        isInvalidated = true
+    }
+}

--- a/Type4MeTests/RecognitionSessionTests.swift
+++ b/Type4MeTests/RecognitionSessionTests.swift
@@ -60,4 +60,317 @@ final class RecognitionSessionTests: XCTestCase {
 
         XCTAssertTrue(shouldFallback)
     }
+
+    func testTranscriptDiffExactMatch() {
+        let diff = TranscriptDiff.classify(source: "你好", final: "你好")
+
+        XCTAssertEqual(diff.type, .exactMatch)
+        XCTAssertTrue(diff.canReuseLLMResult)
+    }
+
+    func testTranscriptDiffWhitespaceOnly() {
+        let diff = TranscriptDiff.classify(source: "你 好", final: "你好\n")
+
+        XCTAssertEqual(diff.type, .whitespaceOnly)
+        XCTAssertTrue(diff.canReuseLLMResult)
+    }
+
+    func testTranscriptDiffPunctuationWidthOnly() {
+        let diff = TranscriptDiff.classify(source: "你好。继续", final: "你好.继续")
+
+        XCTAssertEqual(diff.type, .punctuationOnly)
+        XCTAssertTrue(diff.canReuseLLMResult)
+    }
+
+    func testTranscriptDiffTrailingPunctuationOnly() {
+        let diff = TranscriptDiff.classify(source: "你好", final: "你好。")
+
+        XCTAssertEqual(diff.type, .trailingPunctuationOnly)
+        XCTAssertEqual(diff.addedSuffixUnicode, ["U+3002"])
+        XCTAssertTrue(diff.canReuseLLMResult)
+    }
+
+    func testTranscriptDiffSuffixAdded() {
+        let diff = TranscriptDiff.classify(source: "你好", final: "你好啊")
+
+        XCTAssertEqual(diff.type, .suffixAdded)
+        XCTAssertFalse(diff.canReuseLLMResult)
+    }
+
+    func testTranscriptDiffPrefixAdded() {
+        let diff = TranscriptDiff.classify(source: "开会", final: "今天开会")
+
+        XCTAssertEqual(diff.type, .prefixAdded)
+        XCTAssertFalse(diff.canReuseLLMResult)
+    }
+
+    func testTranscriptDiffSemanticChange() {
+        let diff = TranscriptDiff.classify(source: "今天开会", final: "明天开会")
+
+        XCTAssertEqual(diff.type, .semanticChange)
+        XCTAssertTrue(diff.changedInMiddle)
+        XCTAssertFalse(diff.canReuseLLMResult)
+    }
+
+    func testNormalizationDoesNotModifyReturnedTranscript() {
+        let final = "你好。\n"
+
+        _ = TranscriptDiff.classify(source: "你好.", final: final)
+
+        XCTAssertEqual(final, "你好。\n")
+    }
+
+    func testEarlyLLMDecisionReusesExactProvisional() {
+        XCTAssertEqual(
+            EarlyLLMDecision.decide(earlyInput: "你好", finalInput: "你好", needsLLM: true),
+            .reuse
+        )
+    }
+
+    func testEarlyLLMDecisionReusesTrailingPunctuation() {
+        XCTAssertEqual(
+            EarlyLLMDecision.decide(earlyInput: "你好", finalInput: "你好。", needsLLM: true),
+            .reuse
+        )
+    }
+
+    func testEarlyLLMDecisionRunsFreshForHanCharacterSuffix() {
+        XCTAssertEqual(
+            EarlyLLMDecision.decide(earlyInput: "你好", finalInput: "你好啊", needsLLM: true),
+            .runFresh
+        )
+    }
+
+    func testEarlyLLMDecisionRunsFreshForMiddleChange() {
+        XCTAssertEqual(
+            EarlyLLMDecision.decide(earlyInput: "今天开会", finalInput: "明天开会", needsLLM: true),
+            .runFresh
+        )
+    }
+
+    func testEarlyLLMDecisionRunsFreshWithoutPartial() {
+        XCTAssertEqual(
+            EarlyLLMDecision.decide(earlyInput: nil, finalInput: "你好", needsLLM: true),
+            .runFresh
+        )
+    }
+
+    func testEarlyLLMDecisionSkipsDirectMode() {
+        XCTAssertEqual(
+            EarlyLLMDecision.decide(earlyInput: "你好", finalInput: "你好", needsLLM: false),
+            .noRequest
+        )
+    }
+
+    func testEarlyLLMDecisionSkipsEmptyFinal() {
+        XCTAssertEqual(
+            EarlyLLMDecision.decide(earlyInput: "你好", finalInput: "", needsLLM: true),
+            .noRequest
+        )
+    }
+
+    func testCompletedProvisionalTaskIsReused() async {
+        let provisional = Task<String?, Never> { "provisional" }
+        _ = await provisional.value
+
+        let selection = EarlyLLMTaskSelector.select(
+            earlyInput: "你好",
+            finalInput: "你好。",
+            needsLLM: true,
+            earlyTask: provisional,
+            makeFreshTask: { Task { "fresh" } }
+        )
+
+        XCTAssertTrue(selection.reused)
+        let result = await selection.task?.value
+        XCTAssertEqual(result, "provisional")
+    }
+
+    func testRunningProvisionalTaskIsAwaitableWhenFinalArrivesFirst() async {
+        let provisional = Task<String?, Never> {
+            try? await Task.sleep(for: .milliseconds(20))
+            return "provisional"
+        }
+
+        let selection = EarlyLLMTaskSelector.select(
+            earlyInput: "你好",
+            finalInput: "你好",
+            needsLLM: true,
+            earlyTask: provisional,
+            makeFreshTask: { Task { "fresh" } }
+        )
+
+        XCTAssertTrue(selection.reused)
+        let result = await selection.task?.value
+        XCTAssertEqual(result, "provisional")
+    }
+
+    func testSemanticChangeCancelsProvisionalAndRunsFreshTask() async {
+        let provisional = Task<String?, Never> {
+            try? await Task.sleep(for: .seconds(1))
+            return "stale"
+        }
+
+        let selection = EarlyLLMTaskSelector.select(
+            earlyInput: "今天开会",
+            finalInput: "明天开会",
+            needsLLM: true,
+            earlyTask: provisional,
+            makeFreshTask: { Task { "fresh" } }
+        )
+
+        XCTAssertFalse(selection.reused)
+        XCTAssertTrue(provisional.isCancelled)
+        let result = await selection.task?.value
+        XCTAssertEqual(result, "fresh")
+    }
+
+    func testCancelledNonCooperativeProvisionalCannotBecomeSelectedResult() async {
+        let provisional = Task<String?, Never> {
+            try? await Task.sleep(for: .milliseconds(20))
+            return "stale"
+        }
+
+        let selection = EarlyLLMTaskSelector.select(
+            earlyInput: "你好",
+            finalInput: "你好啊",
+            needsLLM: true,
+            earlyTask: provisional,
+            makeFreshTask: { Task { "fresh" } }
+        )
+
+        XCTAssertTrue(provisional.isCancelled)
+        let result = await selection.task?.value
+        XCTAssertEqual(result, "fresh")
+    }
+
+    func testNoLLMRequestCancelsProvisional() {
+        let provisional = Task<String?, Never> { "stale" }
+
+        let selection = EarlyLLMTaskSelector.select(
+            earlyInput: "你好",
+            finalInput: "你好",
+            needsLLM: false,
+            earlyTask: provisional,
+            makeFreshTask: { Task { "fresh" } }
+        )
+
+        XCTAssertTrue(provisional.isCancelled)
+        XCTAssertNil(selection.task)
+    }
+
+    func testSpeculativeMinimumTextLength() {
+        var throttle = SpeculativeLLMThrottle()
+
+        XCTAssertEqual(throttle.submit("1234567"), .tooShort)
+        XCTAssertEqual(throttle.submit("12345678"), .debounce)
+    }
+
+    func testSpeculativeMinimumCharacterIncrement() {
+        var throttle = SpeculativeLLMThrottle()
+        XCTAssertEqual(throttle.submit("12345678"), .debounce)
+        XCTAssertTrue(throttle.beginDebouncedRequest(for: "12345678"))
+        _ = throttle.requestCompleted(input: "12345678")
+
+        XCTAssertEqual(throttle.submit("123456789012345"), .deltaTooSmall)
+        XCTAssertEqual(throttle.submit("1234567890123456"), .debounce)
+    }
+
+    func testSpeculativeDebounceKeepsNewestCandidate() {
+        var throttle = SpeculativeLLMThrottle()
+        XCTAssertEqual(throttle.submit("12345678"), .debounce)
+        XCTAssertEqual(throttle.submit("abcdefgh"), .debounce)
+
+        XCTAssertFalse(throttle.beginDebouncedRequest(for: "12345678"))
+        XCTAssertTrue(throttle.beginDebouncedRequest(for: "abcdefgh"))
+    }
+
+    func testSpeculativeRequestDoesNotRunConcurrently() {
+        var throttle = SpeculativeLLMThrottle()
+        _ = throttle.submit("12345678")
+        XCTAssertTrue(throttle.beginDebouncedRequest(for: "12345678"))
+
+        XCTAssertEqual(throttle.submit("1234567890123456"), .queued)
+        XCTAssertFalse(throttle.beginDebouncedRequest(for: "1234567890123456"))
+    }
+
+    func testNewestPendingTranscriptIsScheduledAfterCompletion() {
+        var throttle = SpeculativeLLMThrottle()
+        _ = throttle.submit("12345678")
+        _ = throttle.beginDebouncedRequest(for: "12345678")
+        XCTAssertEqual(throttle.submit("1234567890123456"), .queued)
+        XCTAssertEqual(throttle.submit("123456789012345678901234"), .queued)
+
+        let pending = throttle.requestCompleted(input: "12345678")
+
+        XCTAssertEqual(pending, "123456789012345678901234")
+        XCTAssertEqual(throttle.submit(pending!), .debounce)
+    }
+
+    func testStopBypassesSpeculativeDebounce() {
+        var throttle = SpeculativeLLMThrottle()
+        XCTAssertEqual(throttle.submit("12345678"), .debounce)
+
+        throttle.prepareForStop()
+        throttle.markStopTimeRequestStarted(input: "12345678")
+
+        XCTAssertTrue(throttle.inFlight)
+        XCTAssertNil(throttle.debounceText)
+        XCTAssertEqual(throttle.lastStartedText, "12345678")
+    }
+
+    func testStopReusesMatchingInFlightTask() async {
+        let provisional = Task<String?, Never> {
+            try? await Task.sleep(for: .milliseconds(10))
+            return "provisional"
+        }
+
+        let selection = EarlyLLMTaskSelector.select(
+            earlyInput: "12345678",
+            finalInput: "12345678",
+            needsLLM: true,
+            earlyTask: provisional,
+            makeFreshTask: { Task { "fresh" } }
+        )
+
+        XCTAssertTrue(selection.reused)
+        let result = await selection.task?.value
+        XCTAssertEqual(result, "provisional")
+    }
+
+    func testStopCancelsStaleInFlightTask() async {
+        let provisional = Task<String?, Never> {
+            try? await Task.sleep(for: .seconds(1))
+            return "stale"
+        }
+
+        let selection = EarlyLLMTaskSelector.select(
+            earlyInput: "12345678",
+            finalInput: "12345678新内容",
+            needsLLM: true,
+            earlyTask: provisional,
+            makeFreshTask: { Task { "fresh" } }
+        )
+
+        XCTAssertTrue(provisional.isCancelled)
+        XCTAssertFalse(selection.reused)
+        let result = await selection.task?.value
+        XCTAssertEqual(result, "fresh")
+    }
+
+    func testFinalTextCanBeInjectedAtMostOncePerGeneration() {
+        var guardState = FinalInjectionGuard()
+
+        XCTAssertTrue(guardState.claim(generation: 10))
+        XCTAssertFalse(guardState.claim(generation: 10))
+        XCTAssertTrue(guardState.claim(generation: 11))
+    }
+
+    func testCurrentSessionGenerationAcceptsLLMCompletion() {
+        XCTAssertTrue(SessionGenerationGuard.isCurrent(expected: 7, active: 7))
+    }
+
+    func testOldSessionGenerationCannotPolluteNewSession() {
+        XCTAssertFalse(SessionGenerationGuard.isCurrent(expected: 7, active: 8))
+    }
 }

--- a/Type4MeTests/RecognitionSessionTests.swift
+++ b/Type4MeTests/RecognitionSessionTests.swift
@@ -366,6 +366,140 @@ final class RecognitionSessionTests: XCTestCase {
         XCTAssertTrue(guardState.claim(generation: 11))
     }
 
+    func testShortTextDirectOutputForPolishingMode() {
+        XCTAssertEqual(
+            ShortTextDirectPolicy.decide(
+                text: "收到。",
+                mode: .formalWriting,
+                enabled: true,
+                threshold: 8
+            ),
+            .directOutput
+        )
+    }
+
+    func testExactlyEightSemanticCharactersUseDirectOutput() {
+        XCTAssertEqual(
+            ShortTextDirectPolicy.decide(
+                text: "一二三四五六七八。",
+                mode: .formalWriting,
+                enabled: true,
+                threshold: 8
+            ),
+            .directOutput
+        )
+    }
+
+    func testNineSemanticCharactersUseNormalLLMPath() {
+        XCTAssertEqual(
+            ShortTextDirectPolicy.decide(
+                text: "一二三四五六七八九。",
+                mode: .formalWriting,
+                enabled: true,
+                threshold: 8
+            ),
+            .textTooLong
+        )
+    }
+
+    func testSemanticLengthIgnoresPunctuationAndWhitespace() {
+        XCTAssertEqual(
+            ShortTextDirectPolicy.semanticLength(of: " 好的，\n马上。 "),
+            4
+        )
+    }
+
+    func testTranslationModeStillRequiresLLMForShortText() {
+        XCTAssertEqual(
+            ShortTextDirectPolicy.decide(
+                text: "收到。",
+                mode: .translate,
+                enabled: true,
+                threshold: 8
+            ),
+            .modeRequiresLLM
+        )
+    }
+
+    func testCustomizedPolishingPromptStillRequiresLLMForShortText() {
+        var customized = ProcessingMode.formalWriting
+        customized.prompt = "Rewrite this: {text}"
+
+        XCTAssertEqual(
+            ShortTextDirectPolicy.decide(
+                text: "收到。",
+                mode: customized,
+                enabled: true,
+                threshold: 8
+            ),
+            .modeRequiresLLM
+        )
+    }
+
+    func testShortPartialSkipsStopTimeProvisional() {
+        XCTAssertFalse(
+            ShortTextDirectPolicy.shouldStartStopTimeProvisional(
+                partialText: "稍等一下。",
+                mode: .formalWriting,
+                enabled: true,
+                threshold: 8
+            )
+        )
+    }
+
+    func testShortPartialCanStillUseFreshLLMWhenFinalBecomesLong() {
+        XCTAssertFalse(
+            ShortTextDirectPolicy.shouldStartStopTimeProvisional(
+                partialText: "稍等一下。",
+                mode: .formalWriting,
+                enabled: true,
+                threshold: 8
+            )
+        )
+        XCTAssertEqual(
+            ShortTextDirectPolicy.decide(
+                text: "一二三四五六七八九",
+                mode: .formalWriting,
+                enabled: true,
+                threshold: 8
+            ),
+            .textTooLong
+        )
+    }
+
+    func testLongPartialProvisionalIsDiscardedWhenFinalBecomesShort() {
+        XCTAssertTrue(
+            ShortTextDirectPolicy.shouldStartStopTimeProvisional(
+                partialText: "一二三四五六七八九",
+                mode: .formalWriting,
+                enabled: true,
+                threshold: 8
+            )
+        )
+        XCTAssertEqual(
+            ShortTextDirectPolicy.decide(
+                text: "收到。",
+                mode: .formalWriting,
+                enabled: true,
+                threshold: 8
+            ),
+            .directOutput
+        )
+    }
+
+    func testShortDirectSpeculativeMinimumIsThresholdPlusOne() {
+        var throttle = SpeculativeLLMThrottle()
+
+        XCTAssertEqual(
+            throttle.submit("xxxxxxxx", minimumTextLength: 9),
+            .tooShort
+        )
+        XCTAssertEqual(
+            throttle.submit("xxxxxxxxx", minimumTextLength: 9),
+            .debounce
+        )
+    }
+
     func testCurrentSessionGenerationAcceptsLLMCompletion() {
         XCTAssertTrue(SessionGenerationGuard.isCurrent(expected: 7, active: 7))
     }


### PR DESCRIPTION
## Summary

- add a conservative short-text direct-output policy for the built-in polishing mode
- count semantic characters while ignoring whitespace and punctuation
- skip provisional/speculative LLM work when the final text is within the configured threshold
- keep custom prompts and other processing modes on the normal LLM path
- replace the legacy exemption picker with an explicit enable switch and threshold control
- align the setting with the existing settings-card UI

## Why

Very short polishing inputs often do not benefit from an LLM call, but still pay the full request latency. The existing character-count exemption was broad and did not distinguish punctuation, built-in prompts, or speculative requests.

## Impact

The built-in polishing mode defaults to direct final-ASR output for up to eight semantic characters. Users can disable the behavior or change the threshold. Translation and customized polishing prompts continue to use the LLM.

## Dependency

This is a stacked PR and depends on #198, which in turn depends on #197. Merge in that order so this diff narrows to the short-text policy and UI.

## Validation

- `swift test --filter RecognitionSessionTests`
- 47 tests passed
