### PR TITLE
Add Qwen3-only local ASR mode

### DIFF
--- a/Type4Me/ASR/SenseVoiceASRClient.swift
+++ b/Type4Me/ASR/SenseVoiceASRClient.swift
@@ -44,6 +44,7 @@ actor SenseVoiceASRClient: SpeechRecognizer {
     private var recognizer: SherpaOnnxOfflineRecognizer?
     private var vad: SherpaOnnxVoiceActivityDetectorWrapper?
     private var punctProcessor: SherpaPunctuationProcessor?
+    private var streamingPreviewEnabled = true
 
     private var eventContinuation: AsyncStream<RecognitionEvent>.Continuation?
     private var _events: AsyncStream<RecognitionEvent>?
@@ -241,6 +242,13 @@ actor SenseVoiceASRClient: SpeechRecognizer {
         pendingConfirmations = 0
         generation += 1
         vadResidualSamples = []
+        streamingPreviewEnabled = UserDefaults.standard.object(forKey: "tf_sensevoiceEnabled") as? Bool ?? true
+
+        if !streamingPreviewEnabled {
+            eventContinuation?.yield(.ready)
+            logger.info("SenseVoiceASR connected in Qwen3-only mode")
+            return
+        }
 
         let svModelDir = sherpaConfig.senseVoiceModelDir
         let vadModelDir = sherpaConfig.vadModelDir
@@ -340,13 +348,18 @@ actor SenseVoiceASRClient: SpeechRecognizer {
     // MARK: - Send Audio
 
     func sendAudio(_ data: Data) async throws {
+        // Always keep the complete PCM stream for optional Qwen3 final calibration.
+        allAudioData.append(data)
+
+        if !streamingPreviewEnabled {
+            totalSamplesFed += data.count / MemoryLayout<Int16>.size
+            return
+        }
+
         guard let vad, let recognizer else {
             logger.error("sendAudio called but recognizer/VAD is nil — engine not initialized")
             throw SherpaASRError.recognizerInitFailed
         }
-
-        // Accumulate raw PCM for Qwen3 calibration
-        allAudioData.append(data)
 
         var floatSamples = Self.int16ToFloat32(data)
         totalSamplesFed += floatSamples.count
@@ -441,6 +454,11 @@ actor SenseVoiceASRClient: SpeechRecognizer {
     // MARK: - End Audio
 
     func endAudio() async throws {
+        if !streamingPreviewEnabled {
+            await finalizeQwen3Only()
+            return
+        }
+
         guard let vad, let recognizer else {
             DebugFileLogger.log("SenseVoice endAudio: guard failed, vad=\(vad != nil) recognizer=\(recognizer != nil)")
             return
@@ -515,27 +533,8 @@ actor SenseVoiceASRClient: SpeechRecognizer {
         speechBuffer = []
         currentPartialText = ""
 
-        // Qwen3 calibration: if server is running, send full audio for more accurate result
-        let qwen3Enabled = UserDefaults.standard.object(forKey: "tf_qwen3FinalEnabled") as? Bool ?? true
-        if qwen3Enabled, let port = SenseVoiceServerManager.currentQwen3Port, allAudioData.count > 3200 {
-            DebugFileLogger.log("SenseVoice endAudio: Qwen3 calibration starting (\(allAudioData.count) bytes)")
-            if let calibratedText = await qwen3Calibrate(audio: allAudioData, port: port) {
-                let senseVoiceText = confirmedSegments.joined()
-                let sanitizedText = Qwen3HotwordLeakSanitizer.sanitize(
-                    calibratedText,
-                    hotwords: calibrationHotwords,
-                    fallbackText: senseVoiceText
-                )
-                if sanitizedText != calibratedText {
-                    DebugFileLogger.log(
-                        "SenseVoice endAudio: Qwen3 hotword leak sanitized \(calibratedText.count)->\(sanitizedText.count) chars"
-                    )
-                }
-                confirmedSegments = [sanitizedText]
-                DebugFileLogger.log("SenseVoice endAudio: Qwen3 calibration OK (\(sanitizedText.count) chars)")
-            } else {
-                DebugFileLogger.log("SenseVoice endAudio: Qwen3 calibration failed, using SenseVoice result")
-            }
+        if let calibratedText = await runQwen3Calibration(fallbackText: confirmedSegments.joined()) {
+            confirmedSegments = [calibratedText]
         }
         allAudioData = Data()
 
@@ -561,6 +560,7 @@ actor SenseVoiceASRClient: SpeechRecognizer {
         allAudioData = Data()
         calibrationHotwords = []
         vadResidualSamples = []
+        streamingPreviewEnabled = true
         logger.info("SenseVoiceASR disconnected")
     }
 
@@ -603,6 +603,57 @@ actor SenseVoiceASRClient: SpeechRecognizer {
     }
 
     // MARK: - Qwen3 Calibration
+
+    private func finalizeQwen3Only() async {
+        let minBytes = Int(0.3 * 16000) * 2
+        if allAudioData.count < minBytes {
+            DebugFileLogger.log("Qwen3-only endAudio: audio too short (\(allAudioData.count) bytes < \(minBytes)), skipping")
+            allAudioData = Data()
+            confirmedSegments = []
+            currentPartialText = ""
+            emitTranscript(isFinal: true)
+            eventContinuation?.yield(.completed)
+            return
+        }
+
+        if let calibratedText = await runQwen3Calibration(fallbackText: "") {
+            confirmedSegments = [calibratedText]
+        } else {
+            confirmedSegments = []
+        }
+        currentPartialText = ""
+        allAudioData = Data()
+        emitTranscript(isFinal: true)
+        eventContinuation?.yield(.completed)
+        logger.info("Qwen3-only ASR finalized: \(self.confirmedSegments.count) segments, \(self.totalSamplesFed) samples")
+    }
+
+    private func runQwen3Calibration(fallbackText: String) async -> String? {
+        let qwen3Enabled = UserDefaults.standard.object(forKey: "tf_qwen3FinalEnabled") as? Bool ?? true
+        guard qwen3Enabled, let port = SenseVoiceServerManager.currentQwen3Port, allAudioData.count > 3200 else {
+            DebugFileLogger.log("Qwen3 calibration skipped: enabled=\(qwen3Enabled) port=\(SenseVoiceServerManager.currentQwen3Port ?? -1) bytes=\(allAudioData.count)")
+            return nil
+        }
+
+        DebugFileLogger.log("Qwen3 calibration starting (\(allAudioData.count) bytes)")
+        guard let calibratedText = await qwen3Calibrate(audio: allAudioData, port: port) else {
+            DebugFileLogger.log("Qwen3 calibration failed, using fallback")
+            return nil
+        }
+
+        let sanitizedText = Qwen3HotwordLeakSanitizer.sanitize(
+            calibratedText,
+            hotwords: calibrationHotwords,
+            fallbackText: fallbackText
+        )
+        if sanitizedText != calibratedText {
+            DebugFileLogger.log(
+                "Qwen3 hotword leak sanitized \(calibratedText.count)->\(sanitizedText.count) chars"
+            )
+        }
+        DebugFileLogger.log("Qwen3 calibration OK (\(sanitizedText.count) chars)")
+        return sanitizedText
+    }
 
     private func qwen3Calibrate(audio: Data, port: Int) async -> String? {
         let url = URL(string: "http://127.0.0.1:\(port)/transcribe")!

--- a/Type4Me/UI/Settings/ASRSettingsCard.swift
+++ b/Type4Me/UI/Settings/ASRSettingsCard.swift
@@ -302,10 +302,13 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
                     serverRunning = false
                 }
             }
-            // Start both servers when user explicitly switches to local ASR
+            // Start local services when user explicitly switches to local ASR.
+            // Preserve the user's SenseVoice preview preference; if both engines
+            // were off, keep Qwen3 final enabled so local ASR still has an engine.
             if newProvider == .sherpa {
-                sensevoiceEnabled = true
-                qwen3FinalEnabled = true
+                if !sensevoiceEnabled && !qwen3FinalEnabled {
+                    qwen3FinalEnabled = true
+                }
                 startServer()
             }
         }
@@ -413,13 +416,17 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
         VStack(alignment: .leading, spacing: 12) {
             if localModelAvailable {
                 HStack(spacing: 12) {
-                    // Left: 流式识别引擎 (always on)
-                    staticEngineBlock(
+                    // Left: 流式识别引擎
+                    localEngineBlock(
                         icon: "waveform",
                         name: "SenseVoice",
                         subtitle: L("流式识别引擎", "Streaming Engine"),
-                        description: L("基础识别模型，流式识别，支持实时展示。内存占用约 500MB。",
-                                       "Base model, streaming ASR, real-time display. ~500MB memory.")
+                        description: L("录音期间实时出字。关闭后仅使用 Qwen3-ASR 最终识别，可释放约 500MB 内存。",
+                                       "Real-time preview while recording. Turn it off to use only Qwen3-ASR final transcription and free ~500MB."),
+                        isRunning: sensevoiceEnabled,
+                        isToggling: false,
+                        onStart: { toggleSenseVoice(true) },
+                        onStop: { toggleSenseVoice(false) }
                     )
 
                     // Right: 精准识别引擎
@@ -617,9 +624,17 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
     }
 
     private func toggleSenseVoice(_ enabled: Bool) {
-        // SenseVoice is native sherpa-onnx, no server process to manage.
+        if !enabled && !qwen3FinalEnabled {
+            guard hasQwen3ASR else { return }
+            toggleQwen3(true)
+        }
         sensevoiceEnabled = enabled
-        serverRunning = enabled
+        serverRunning = enabled || qwen3Running
+        if !enabled {
+            #if HAS_SHERPA_ONNX
+            SenseVoiceASRClient.releaseCachedModels()
+            #endif
+        }
     }
 
     private func toggleQwen3(_ enabled: Bool) {
@@ -635,6 +650,9 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
                 } catch {
                     NSLog("[ASRSettings] Qwen3 start failed: %@", String(describing: error))
                     qwen3FinalEnabled = false
+                    if !sensevoiceEnabled {
+                        sensevoiceEnabled = true
+                    }
                     qwen3StartError = extractStartError(error)
                 }
             } else {


### PR DESCRIPTION
## Summary
- allow the local SenseVoice streaming preview engine to be stopped from the ASR settings card
- preserve the `tf_sensevoiceEnabled` preference when switching back to local ASR instead of forcing SenseVoice back on
- add a Qwen3-only path in `SenseVoiceASRClient` that buffers PCM audio and sends it directly to Qwen3 final transcription without loading SenseVoice/VAD models
- release cached SenseVoice/VAD/punctuation models when the preview engine is turned off

## Why
When users only care about the Qwen3-ASR final transcript, SenseVoice is currently still treated as always-on for streaming preview. That keeps the native SenseVoice/VAD models resident even though the final Qwen3 result is the only text that matters.

## Validation
- `swift build`
- `swift test` attempted, but the current local Swift toolchain cannot import `XCTest` for the test target (`no such module XCTest`) after the main `Type4Me` target had already built and linked.

Fixes #206