### PR TITLE
fix(elevenlabs): normalize CJK punctuation for English transcripts

### DIFF
--- a/Type4Me/ASR/ElevenLabsASRClient.swift
+++ b/Type4Me/ASR/ElevenLabsASRClient.swift
@@ -38,6 +38,7 @@ actor ElevenLabsASRClient: SpeechRecognizer {
     private var audioPacketCount = 0
     private var didRequestClose = false
     private var pendingFinalCommit = false   // true after endAudio() sends commit
+    private var languageCode = ""
     private var connectionGate: ElevenLabsConnectionGate?
 
     var events: AsyncStream<RecognitionEvent> {
@@ -71,6 +72,7 @@ actor ElevenLabsASRClient: SpeechRecognizer {
         self.sessionDelegate = delegate
         self.session = session
         self.webSocketTask = task
+        self.languageCode = elevenConfig.language
         confirmedSegments = []
         lastTranscript = .empty
         audioPacketCount = 0
@@ -108,6 +110,7 @@ actor ElevenLabsASRClient: SpeechRecognizer {
         eventContinuation = nil
         _events = nil
         connectionGate = nil
+        languageCode = ""
         confirmedSegments = []
         lastTranscript = .empty
         audioPacketCount = 0
@@ -155,7 +158,8 @@ actor ElevenLabsASRClient: SpeechRecognizer {
             if let update = try ElevenLabsProtocol.makeTranscriptUpdate(
                 from: data,
                 confirmedSegments: confirmedSegments,
-                isFinalCommit: pendingFinalCommit
+                isFinalCommit: pendingFinalCommit,
+                languageCode: languageCode
             ) {
                 confirmedSegments = update.confirmedSegments
                 guard update.transcript != lastTranscript else { return }

--- a/Type4Me/Protocol/ElevenLabsProtocol.swift
+++ b/Type4Me/Protocol/ElevenLabsProtocol.swift
@@ -103,7 +103,8 @@ enum ElevenLabsProtocol {
     static func makeTranscriptUpdate(
         from data: Data,
         confirmedSegments: [String],
-        isFinalCommit: Bool = false
+        isFinalCommit: Bool = false,
+        languageCode: String = ""
     ) throws -> ElevenLabsTranscriptUpdate? {
         guard data.first == UInt8(ascii: "{") else { return nil }
         let message = try JSONDecoder().decode(InboundMessage.self, from: data)
@@ -116,7 +117,11 @@ enum ElevenLabsProtocol {
             // ElevenLabs sends cumulative text — strip the already-confirmed prefix to avoid duplication
             let partialOnly = stripConfirmedPrefix(from: text, confirmed: confirmed)
             guard !partialOnly.isEmpty else { return nil }
-            let normalized = normalize(segment: partialOnly, after: confirmed)
+            let punctuated = ScriptPunctuationNormalizer.normalizeIfNeeded(
+                languageCode: languageCode,
+                text: partialOnly
+            )
+            let normalized = normalize(segment: punctuated, after: confirmed)
             let transcript = RecognitionTranscript(
                 confirmedSegments: confirmedSegments,
                 partialText: normalized,
@@ -132,7 +137,11 @@ enum ElevenLabsProtocol {
             if !trimmed.isEmpty {
                 let newOnly = stripConfirmedPrefix(from: trimmed, confirmed: confirmed)
                 if !newOnly.isEmpty {
-                    next.append(normalize(segment: newOnly, after: confirmed))
+                    let punctuated = ScriptPunctuationNormalizer.normalizeIfNeeded(
+                        languageCode: languageCode,
+                        text: newOnly
+                    )
+                    next.append(normalize(segment: punctuated, after: confirmed))
                 }
             }
             // Mid-stream auto-commits (VAD) use isFinal: false so the session keeps recording.

--- a/Type4Me/Protocol/ScriptPunctuationNormalizer.swift
+++ b/Type4Me/Protocol/ScriptPunctuationNormalizer.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Normalizes punctuation style to match the transcript script / configured language.
+enum ScriptPunctuationNormalizer {
+
+    private static let cjkLanguageCodes: Set<String> = ["zh", "zh-tw", "ja", "ko"]
+
+    private static let cjkToLatinMap: [Character: Character] = [
+        "，": ",", "。": ".", "！": "!", "？": "?", "；": ";", "：": ":",
+        "（": "(", "）": ")", "【": "[", "】": "]",
+        "\u{201C}": "\"", "\u{201D}": "\"",
+        "\u{2018}": "'", "\u{2019}": "'",
+        "、": ",",
+    ]
+
+    /// Whether CJK punctuation in `text` should be converted to Latin punctuation.
+    static func shouldUseLatinPunctuation(languageCode: String, text: String) -> Bool {
+        let normalizedLanguage = languageCode.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if cjkLanguageCodes.contains(normalizedLanguage) {
+            return false
+        }
+        if !normalizedLanguage.isEmpty {
+            return true
+        }
+        return !text.contains(where: \.isCJKUnifiedIdeograph)
+    }
+
+    static func normalizeCJKPunctuationToLatin(_ text: String) -> String {
+        String(text.map { cjkToLatinMap[$0] ?? $0 })
+    }
+
+    static func normalizeIfNeeded(languageCode: String, text: String) -> String {
+        guard shouldUseLatinPunctuation(languageCode: languageCode, text: text) else {
+            return text
+        }
+        return normalizeCJKPunctuationToLatin(text)
+    }
+}

--- a/Type4Me/Protocol/ScriptPunctuationNormalizer.swift
+++ b/Type4Me/Protocol/ScriptPunctuationNormalizer.swift
@@ -13,6 +13,8 @@ enum ScriptPunctuationNormalizer {
         "、": ",",
     ]
 
+    private static let spacingAfterPunctuation = ",;:!?"
+
     /// Whether CJK punctuation in `text` should be converted to Latin punctuation.
     static func shouldUseLatinPunctuation(languageCode: String, text: String) -> Bool {
         let normalizedLanguage = languageCode.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
@@ -26,7 +28,7 @@ enum ScriptPunctuationNormalizer {
     }
 
     static func normalizeCJKPunctuationToLatin(_ text: String) -> String {
-        String(text.map { cjkToLatinMap[$0] ?? $0 })
+        insertLatinPunctuationSpacing(mapCJKPunctuationToLatin(text))
     }
 
     static func normalizeIfNeeded(languageCode: String, text: String) -> String {
@@ -34,5 +36,56 @@ enum ScriptPunctuationNormalizer {
             return text
         }
         return normalizeCJKPunctuationToLatin(text)
+    }
+
+    private static func mapCJKPunctuationToLatin(_ text: String) -> String {
+        String(text.map { cjkToLatinMap[$0] ?? $0 })
+    }
+
+    /// Inserts spaces after Latin clause/sentence punctuation when the next character is a word.
+    private static func insertLatinPunctuationSpacing(_ text: String) -> String {
+        let characters = Array(text)
+        guard !characters.isEmpty else { return text }
+
+        var result = ""
+        for index in characters.indices {
+            let character = characters[index]
+            result.append(character)
+
+            guard index + 1 < characters.count else { continue }
+            let next = characters[index + 1]
+            guard shouldInsertSpace(after: character, before: next, previous: index > 0 ? characters[index - 1] : nil) else {
+                continue
+            }
+            result.append(" ")
+        }
+        return result
+    }
+
+    private static func shouldInsertSpace(
+        after punctuation: Character,
+        before next: Character,
+        previous: Character?
+    ) -> Bool {
+        guard !next.isWhitespace, next.isLatinWordCharacter else { return false }
+
+        if spacingAfterPunctuation.contains(punctuation) {
+            return true
+        }
+
+        if punctuation == "." {
+            if let previous, previous.isNumber, next.isNumber {
+                return false
+            }
+            return true
+        }
+
+        return false
+    }
+}
+
+private extension Character {
+    var isLatinWordCharacter: Bool {
+        isLetter && unicodeScalars.allSatisfy { $0.value < 128 }
     }
 }

--- a/Type4MeTests/ElevenLabsProtocolTests.swift
+++ b/Type4MeTests/ElevenLabsProtocolTests.swift
@@ -79,7 +79,7 @@ final class ElevenLabsProtocolTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(update.transcript.partialText, "This is a test,okay?")
+        XCTAssertEqual(update.transcript.partialText, "This is a test, okay?")
     }
 }
 

--- a/Type4MeTests/ElevenLabsProtocolTests.swift
+++ b/Type4MeTests/ElevenLabsProtocolTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import Type4Me
+
+final class ElevenLabsProtocolTests: XCTestCase {
+
+    func testBuildWebSocketURL_includesNoVerbatimAndModel() throws {
+        let config = try XCTUnwrap(ElevenLabsASRConfig(credentials: [
+            "apiKey": "eleven_test_key",
+            "model": "scribe_v2_realtime",
+            "language": "en",
+        ]))
+        let url = try ElevenLabsProtocol.buildWebSocketURL(config: config, options: .init())
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let items = components.queryItems ?? []
+
+        XCTAssertEqual(components.host, "api.elevenlabs.io")
+        XCTAssertEqual(components.path, "/v1/speech-to-text/realtime")
+        XCTAssertEqual(items.value(for: "model_id"), "scribe_v2_realtime")
+        XCTAssertEqual(items.value(for: "audio_format"), "pcm_16000")
+        XCTAssertEqual(items.value(for: "no_verbatim"), "true")
+        XCTAssertEqual(items.value(for: "language_code"), "en")
+    }
+
+    func testMakeTranscriptUpdate_normalizesChinesePunctuationForEnglish() throws {
+        let message = """
+        {
+          "message_type": "committed_transcript",
+          "text": "Hello world。"
+        }
+        """
+
+        let update = try XCTUnwrap(
+            ElevenLabsProtocol.makeTranscriptUpdate(
+                from: Data(message.utf8),
+                confirmedSegments: [],
+                isFinalCommit: true,
+                languageCode: "en"
+            )
+        )
+
+        XCTAssertEqual(update.confirmedSegments, ["Hello world."])
+        XCTAssertEqual(update.transcript.authoritativeText, "Hello world.")
+        XCTAssertTrue(update.transcript.isFinal)
+    }
+
+    func testMakeTranscriptUpdate_keepsChinesePunctuationForChinese() throws {
+        let message = """
+        {
+          "message_type": "committed_transcript",
+          "text": "你好世界。"
+        }
+        """
+
+        let update = try XCTUnwrap(
+            ElevenLabsProtocol.makeTranscriptUpdate(
+                from: Data(message.utf8),
+                confirmedSegments: [],
+                isFinalCommit: true,
+                languageCode: "zh"
+            )
+        )
+
+        XCTAssertEqual(update.confirmedSegments, ["你好世界。"])
+    }
+
+    func testMakeTranscriptUpdate_autoDetectNormalizesLatinOnlyText() throws {
+        let message = """
+        {
+          "message_type": "partial_transcript",
+          "text": "This is a test，okay？"
+        }
+        """
+
+        let update = try XCTUnwrap(
+            ElevenLabsProtocol.makeTranscriptUpdate(
+                from: Data(message.utf8),
+                confirmedSegments: [],
+                languageCode: ""
+            )
+        )
+
+        XCTAssertEqual(update.transcript.partialText, "This is a test,okay?")
+    }
+}
+
+private extension Array where Element == URLQueryItem {
+    func value(for name: String) -> String? {
+        first { $0.name == name }?.value
+    }
+}

--- a/Type4MeTests/ScriptPunctuationNormalizerTests.swift
+++ b/Type4MeTests/ScriptPunctuationNormalizerTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import Type4Me
+
+final class ScriptPunctuationNormalizerTests: XCTestCase {
+
+    func testShouldUseLatinPunctuation_explicitEnglish() {
+        XCTAssertTrue(
+            ScriptPunctuationNormalizer.shouldUseLatinPunctuation(languageCode: "en", text: "你好")
+        )
+    }
+
+    func testShouldUseLatinPunctuation_explicitChinese() {
+        XCTAssertFalse(
+            ScriptPunctuationNormalizer.shouldUseLatinPunctuation(languageCode: "zh", text: "Hello world")
+        )
+    }
+
+    func testShouldUseLatinPunctuation_autoDetectLatinOnly() {
+        XCTAssertTrue(
+            ScriptPunctuationNormalizer.shouldUseLatinPunctuation(languageCode: "", text: "Hello world")
+        )
+    }
+
+    func testShouldUseLatinPunctuation_autoDetectWithCJK() {
+        XCTAssertFalse(
+            ScriptPunctuationNormalizer.shouldUseLatinPunctuation(languageCode: "", text: "你好 world")
+        )
+    }
+
+    func testNormalizeCJKPunctuationToLatin_convertsCommonMarks() {
+        let input = "Hello world。How are you？Great！"
+        XCTAssertEqual(
+            ScriptPunctuationNormalizer.normalizeCJKPunctuationToLatin(input),
+            "Hello world.How are you?Great!"
+        )
+    }
+
+    func testNormalizeIfNeeded_keepsChineseWhenConfigured() {
+        let input = "你好世界。"
+        XCTAssertEqual(
+            ScriptPunctuationNormalizer.normalizeIfNeeded(languageCode: "zh", text: input),
+            input
+        )
+    }
+
+    func testNormalizeIfNeeded_convertsForAutoDetectedEnglish() {
+        XCTAssertEqual(
+            ScriptPunctuationNormalizer.normalizeIfNeeded(languageCode: "", text: "Hello world。"),
+            "Hello world."
+        )
+    }
+}

--- a/Type4MeTests/ScriptPunctuationNormalizerTests.swift
+++ b/Type4MeTests/ScriptPunctuationNormalizerTests.swift
@@ -27,11 +27,25 @@ final class ScriptPunctuationNormalizerTests: XCTestCase {
         )
     }
 
-    func testNormalizeCJKPunctuationToLatin_convertsCommonMarks() {
+    func testNormalizeCJKPunctuationToLatin_convertsCommonMarksAndAddsSpacing() {
         let input = "Hello world。How are you？Great！"
         XCTAssertEqual(
             ScriptPunctuationNormalizer.normalizeCJKPunctuationToLatin(input),
-            "Hello world.How are you?Great!"
+            "Hello world. How are you? Great!"
+        )
+    }
+
+    func testNormalizeCJKPunctuationToLatin_addsSpaceAfterComma() {
+        XCTAssertEqual(
+            ScriptPunctuationNormalizer.normalizeCJKPunctuationToLatin("He can come to Vancouver,but need a good reason"),
+            "He can come to Vancouver, but need a good reason"
+        )
+    }
+
+    func testNormalizeCJKPunctuationToLatin_preservesDecimalPoint() {
+        XCTAssertEqual(
+            ScriptPunctuationNormalizer.normalizeCJKPunctuationToLatin("The value is 3.14 today"),
+            "The value is 3.14 today"
         )
     }
 


### PR DESCRIPTION
## Summary
- ElevenLabs Scribe can return Chinese punctuation (。，？) even when the spoken sentence is entirely English
- Add `ScriptPunctuationNormalizer` to convert CJK punctuation to Latin equivalents when:
  - language is explicitly set to a non-CJK code (e.g. `en`), or
  - language is auto-detect and the transcript contains no CJK ideographs
- Preserve Chinese punctuation when language is set to `zh`, `zh-TW`, `ja`, or `ko`
- Wire normalization into ElevenLabs partial/committed transcript handling

## Test plan
- [x] `swift test --filter ScriptPunctuationNormalizerTests`
- [x] `swift test --filter ElevenLabsProtocolTests`
- [ ] Manual: speak an English sentence with ElevenLabs (auto-detect or `en`) and confirm `. , ? !` instead of `。 ， ？ ！`
- [ ] Manual: speak Chinese with language set to `zh` and confirm Chinese punctuation is preserved


Made with [Cursor](https://cursor.com)