### PR TITLE
feat(asr): add StepFun batch transcription

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 macOS menu bar voice input tool with dual-engine local ASR, multi-provider cloud ASR, and LLM post-processing.
 Local ASR: SenseVoice via native sherpa-onnx (streaming) + Qwen3-ASR (final calibration, Python WebSocket service managed by `SenseVoiceServerManager`).
-Cloud ASR: 8 providers implemented (Volcano, OpenAI, Deepgram, AssemblyAI, ElevenLabs, Soniox, Bailian, Baidu).
+Cloud ASR: 9 providers implemented (Volcano, StepFun batch, OpenAI, Deepgram, AssemblyAI, ElevenLabs, Soniox, Bailian, Baidu).
 Swift Package Manager project, no Xcode project file. Optional `sherpa-onnx.xcframework` for punctuation restoration.
 
 ## Build & Run
@@ -80,10 +80,10 @@ All subscription/cloud-proxy code lives in `Type4Me/CloudSubscription/` (13 file
 
 Multi-provider ASR support via `ASRProvider` enum + `ASRProviderConfig` protocol + `ASRProviderRegistry`.
 
-- `ASRProvider` enum: 15 cases + conditional `cloud` case (sherpa/openai/azure/google/aws/deepgram/assemblyai/elevenlabs/volcano/aliyun/bailian/tencent/baidu/iflytek/custom, plus `cloud` when `HAS_CLOUD_SUBSCRIPTION`)
+- `ASRProvider` enum: 16 cases + conditional `cloud` case (sherpa/openai/azure/google/aws/deepgram/assemblyai/elevenlabs/volcano/stepfunBatch/aliyun/bailian/tencent/baidu/iflytek/custom, plus `cloud` when `HAS_CLOUD_SUBSCRIPTION`)
 - Each provider has its own Config type (e.g., `SherpaASRConfig`, `VolcanoASRConfig`) defining `credentialFields` for dynamic UI rendering
 - `ASRProviderRegistry`: maps provider to config type + client factory; `capabilities` indicates availability and streaming support
-- **Fully implemented**: sherpa (local, batch), volcano (streaming), deepgram (streaming), assemblyai (streaming), elevenlabs (streaming), soniox (streaming), bailian (streaming), baidu (streaming), openai (batch)
+- **Fully implemented**: sherpa (local, batch), volcano (streaming), StepFun (batch; Step Plan or standard endpoint), deepgram (streaming), assemblyai (streaming), elevenlabs (streaming), soniox (streaming), bailian (streaming), baidu (streaming), openai (batch)
 - **Config only (no client)**: azure, google, aws, aliyun, tencent, iflytek, custom
 
 ### Adding a New Provider

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Steps 2-3 are optional. Skipping them disables local ASR, but cloud ASR works fi
 
 - **Swift Package Manager** project, no `.xcodeproj` needed
 - **Local ASR**: dual-engine design. SenseVoice (streaming partial results) + Qwen3-ASR (final calibration via MLX/Metal). Both run as Python WebSocket servers managed by `SenseVoiceServerManager`
-- **Cloud ASR**: 7 providers implemented (Volcano, OpenAI, Deepgram, AssemblyAI, Soniox, Bailian, Baidu)
+- **Cloud ASR**: 9 providers implemented (Volcano, StepFun batch, OpenAI, Deepgram, AssemblyAI, ElevenLabs, Soniox, Bailian, Baidu)
 - **Credentials**: stored at `~/Library/Application Support/Type4Me/credentials.json` (mode 0600), never in code or environment variables. GUI apps cannot read shell env vars from `~/.zshrc`
 - **ASR provider architecture**: plugin-based. To add a new provider: implement `ASRProviderConfig` + `SpeechRecognizer` protocol, register in `ASRProviderRegistry.all`. See `CLAUDE.md` for details
 - **Audio format**: 16kHz mono PCM16-LE, 200ms chunks (6400 bytes)

--- a/Type4Me/ASR/ASRProvider.swift
+++ b/Type4Me/ASR/ASRProvider.swift
@@ -17,6 +17,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
     case soniox
     // China
     case volcano
+    case stepfunBatch
     case aliyun
     case bailian
     case tencent
@@ -42,6 +43,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
         case .elevenlabs: return "ElevenLabs"
         case .soniox:   return "Soniox"
         case .volcano:  return L("火山引擎 (Doubao)", "Volcano (Doubao)")
+        case .stepfunBatch: return L("阶跃星辰（非实时）", "StepFun (Batch)")
         case .aliyun:   return L("阿里云", "Alibaba Cloud")
         case .bailian:  return L("阿里云百炼", "Alibaba Cloud Bailian")
         case .tencent:  return L("腾讯云", "Tencent Cloud")

--- a/Type4Me/ASR/ASRProviderRegistry.swift
+++ b/Type4Me/ASR/ASRProviderRegistry.swift
@@ -58,6 +58,11 @@ enum ASRProviderRegistry {
                 createClient: { VolcASRClient() },
                 capabilities: .streaming()
             ),
+            .stepfunBatch: ProviderEntry(
+                configType: StepFunBatchASRConfig.self,
+                createClient: { StepFunBatchASRClient() },
+                capabilities: .batch()
+            ),
             .deepgram: ProviderEntry(
                 configType: DeepgramASRConfig.self,
                 createClient: { DeepgramASRClient() },

--- a/Type4Me/ASR/Providers/StepFunBatchASRConfig.swift
+++ b/Type4Me/ASR/Providers/StepFunBatchASRConfig.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+enum StepFunBatchAccessMode: String, Sendable, CaseIterable {
+    case stepPlan
+    case standard
+
+    var displayName: String {
+        switch self {
+        case .stepPlan:
+            return "Step Plan"
+        case .standard:
+            return L("标准按量付费", "Standard pay-as-you-go")
+        }
+    }
+
+    var endpoint: String {
+        switch self {
+        case .stepPlan:
+            return StepFunBatchASRConfig.stepPlanEndpoint
+        case .standard:
+            return StepFunBatchASRConfig.standardEndpoint
+        }
+    }
+}
+
+struct StepFunBatchASRConfig: ASRProviderConfig, Sendable {
+
+    static let provider = ASRProvider.stepfunBatch
+    static let displayName = L("阶跃星辰（非实时）", "StepFun (Batch)")
+    static let defaultModel = "stepaudio-2.5-asr"
+    static let stepPlanEndpoint = "https://api.stepfun.com/step_plan/v1/audio/asr/sse"
+    static let standardEndpoint = "https://api.stepfun.com/v1/audio/asr/sse"
+
+    static var credentialFields: [CredentialField] {[
+        CredentialField(
+            key: "apiKey",
+            label: "API Key",
+            placeholder: "sk-...",
+            isSecure: true,
+            isOptional: false,
+            defaultValue: ""
+        ),
+        CredentialField(
+            key: "accessMode",
+            label: L("接入方式", "Access Mode"),
+            placeholder: "",
+            isSecure: false,
+            isOptional: false,
+            defaultValue: StepFunBatchAccessMode.stepPlan.rawValue,
+            options: StepFunBatchAccessMode.allCases.map {
+                FieldOption(value: $0.rawValue, label: $0.displayName)
+            }
+        ),
+    ]}
+
+    let apiKey: String
+    let accessMode: StepFunBatchAccessMode
+
+    init?(credentials: [String: String]) {
+        guard let apiKey = credentials["apiKey"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !apiKey.isEmpty
+        else {
+            return nil
+        }
+        self.apiKey = apiKey
+        self.accessMode = StepFunBatchAccessMode(rawValue: credentials["accessMode"] ?? "") ?? .stepPlan
+    }
+
+    func toCredentials() -> [String: String] {
+        [
+            "apiKey": apiKey,
+            "accessMode": accessMode.rawValue,
+        ]
+    }
+
+    var isValid: Bool { !apiKey.isEmpty }
+}

--- a/Type4Me/ASR/StepFunBatchASRClient.swift
+++ b/Type4Me/ASR/StepFunBatchASRClient.swift
@@ -1,0 +1,147 @@
+import Foundation
+import os
+
+/// StepFun batch ASR using a complete PCM upload and an SSE text response.
+/// Audio is buffered during recording and submitted when endAudio() is called.
+actor StepFunBatchASRClient: SpeechRecognizer {
+
+    private let logger = Logger(subsystem: "com.type4me.asr", category: "StepFunBatchASRClient")
+
+    private var config: StepFunBatchASRConfig?
+    private var options = ASRRequestOptions()
+    private var session: URLSession?
+    private var audioBuffer = Data()
+    private var eventContinuation: AsyncStream<RecognitionEvent>.Continuation?
+    private var _events: AsyncStream<RecognitionEvent>?
+
+    var events: AsyncStream<RecognitionEvent> {
+        if let existing = _events { return existing }
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        eventContinuation = continuation
+        _events = stream
+        return stream
+    }
+
+    func connect(config: any ASRProviderConfig, options: ASRRequestOptions) async throws {
+        guard let stepFunConfig = config as? StepFunBatchASRConfig else {
+            throw StepFunBatchASRError.invalidConfig
+        }
+
+        self.config = stepFunConfig
+        self.options = options
+        session = options.resolvedSession
+        audioBuffer = Data()
+
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        eventContinuation = continuation
+        _events = stream
+
+        continuation.yield(.ready)
+        continuation.yield(.transcript(RecognitionTranscript(
+            confirmedSegments: [],
+            partialText: L("录音中…", "Recording…"),
+            authoritativeText: "",
+            isFinal: false
+        )))
+    }
+
+    func sendAudio(_ data: Data) async throws {
+        audioBuffer.append(data)
+    }
+
+    func endAudio() async throws {
+        do {
+            guard let config, let session else {
+                throw StepFunBatchASRError.invalidConfig
+            }
+            guard !audioBuffer.isEmpty else {
+                throw StepFunBatchASRError.emptyAudio
+            }
+
+            let request = try StepFunBatchASRProtocol.buildRequest(
+                pcmData: audioBuffer,
+                config: config,
+                options: options
+            )
+            logger.info(
+                "Sending \(self.audioBuffer.count) bytes PCM to StepFun batch ASR via \(config.accessMode.rawValue, privacy: .public)"
+            )
+
+            try await transcribe(request: request, session: session)
+            eventContinuation?.yield(.completed)
+            eventContinuation?.finish()
+        } catch {
+            eventContinuation?.yield(.error(error))
+            eventContinuation?.yield(.completed)
+            eventContinuation?.finish()
+            throw error
+        }
+    }
+
+    func disconnect() {
+        eventContinuation?.finish()
+        eventContinuation = nil
+        _events = nil
+        audioBuffer = Data()
+        session = nil
+        config = nil
+    }
+
+    private func transcribe(request: URLRequest, session: URLSession) async throws {
+        let (bytes, response) = try await session.bytes(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw StepFunBatchASRError.requestFailed(code: 0, message: nil)
+        }
+
+        guard http.statusCode == 200 else {
+            var body = Data()
+            for try await byte in bytes {
+                body.append(byte)
+                if body.count >= 500 { break }
+            }
+            let message = String(data: body, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            throw StepFunBatchASRError.requestFailed(code: http.statusCode, message: message)
+        }
+
+        var accumulatedText = ""
+        var didReceiveDone = false
+
+        for try await line in bytes.lines {
+            guard let event = try StepFunBatchASRProtocol.parseSSELine(line) else {
+                continue
+            }
+
+            switch event {
+            case .delta(let delta):
+                accumulatedText += delta
+                eventContinuation?.yield(.transcript(RecognitionTranscript(
+                    confirmedSegments: [],
+                    partialText: accumulatedText,
+                    authoritativeText: accumulatedText,
+                    isFinal: false
+                )))
+
+            case .done(let text):
+                let finalText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                eventContinuation?.yield(.transcript(RecognitionTranscript(
+                    confirmedSegments: finalText.isEmpty ? [] : [finalText],
+                    partialText: "",
+                    authoritativeText: finalText,
+                    isFinal: true
+                )))
+                didReceiveDone = true
+
+            case .error(let message):
+                throw StepFunBatchASRError.serverError(message)
+            }
+
+            if didReceiveDone { break }
+        }
+
+        guard didReceiveDone else {
+            throw StepFunBatchASRError.invalidResponse
+        }
+        logger.info("StepFun batch ASR completed")
+    }
+}

--- a/Type4Me/Protocol/StepFunBatchASRProtocol.swift
+++ b/Type4Me/Protocol/StepFunBatchASRProtocol.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+enum StepFunBatchASRError: Error, LocalizedError, Equatable {
+    case invalidConfig
+    case emptyAudio
+    case invalidEndpoint
+    case requestFailed(code: Int, message: String?)
+    case invalidResponse
+    case serverError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidConfig:
+            return "StepFun batch ASR requires StepFunBatchASRConfig"
+        case .emptyAudio:
+            return L("没有录到音频", "No audio data recorded")
+        case .invalidEndpoint:
+            return "Invalid StepFun batch ASR endpoint"
+        case .requestFailed(let code, let message):
+            if let message, !message.isEmpty {
+                return "StepFun API returned HTTP \(code): \(message)"
+            }
+            return "StepFun API returned HTTP \(code)"
+        case .invalidResponse:
+            return L("阶跃星辰返回了无法解析的识别结果", "StepFun returned an invalid transcription response")
+        case .serverError(let message):
+            return message
+        }
+    }
+}
+
+enum StepFunBatchSSEEvent: Equatable {
+    case delta(String)
+    case done(String)
+    case error(String)
+}
+
+enum StepFunBatchASRProtocol {
+
+    static func buildRequest(
+        pcmData: Data,
+        config: StepFunBatchASRConfig,
+        options: ASRRequestOptions
+    ) throws -> URLRequest {
+        guard let url = URL(string: config.accessMode.endpoint) else {
+            throw StepFunBatchASRError.invalidEndpoint
+        }
+
+        let transcription = Transcription(
+            hotwords: options.hotwords.isEmpty ? nil : options.hotwords,
+            model: StepFunBatchASRConfig.defaultModel,
+            enableITN: true
+        )
+        let body = RequestBody(
+            audio: Audio(
+                data: pcmData.base64EncodedString(),
+                input: Input(
+                    transcription: transcription,
+                    format: AudioFormat(
+                        type: "pcm",
+                        codec: "pcm_s16le",
+                        rate: 16_000,
+                        bits: 16,
+                        channel: 1
+                    )
+                )
+            )
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 120
+        request.httpBody = try JSONEncoder().encode(body)
+        return request
+    }
+
+    static func parseSSELine(_ line: String) throws -> StepFunBatchSSEEvent? {
+        guard line.hasPrefix("data:") else { return nil }
+
+        var payload = line.dropFirst(5)
+        if payload.first == " " {
+            payload = payload.dropFirst()
+        }
+        guard !payload.isEmpty, payload != "[DONE]" else { return nil }
+
+        guard let data = String(payload).data(using: .utf8),
+              let message = try? JSONDecoder().decode(SSEMessage.self, from: data)
+        else {
+            throw StepFunBatchASRError.invalidResponse
+        }
+
+        switch message.type {
+        case "transcript.text.delta":
+            guard let delta = message.delta else {
+                throw StepFunBatchASRError.invalidResponse
+            }
+            return .delta(delta)
+
+        case "transcript.text.done":
+            guard let text = message.text else {
+                throw StepFunBatchASRError.invalidResponse
+            }
+            return .done(text)
+
+        case "error":
+            let detail = message.message ?? message.error?.message
+            if let detail, !detail.isEmpty {
+                return .error(detail)
+            }
+            return .error(L("阶跃星辰识别失败", "StepFun transcription failed"))
+
+        default:
+            return nil
+        }
+    }
+}
+
+private extension StepFunBatchASRProtocol {
+    struct RequestBody: Encodable {
+        let audio: Audio
+    }
+
+    struct Audio: Encodable {
+        let data: String
+        let input: Input
+    }
+
+    struct Input: Encodable {
+        let transcription: Transcription
+        let format: AudioFormat
+    }
+
+    struct Transcription: Encodable {
+        let hotwords: [String]?
+        let model: String
+        let enableITN: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case hotwords
+            case model
+            case enableITN = "enable_itn"
+        }
+    }
+
+    struct AudioFormat: Encodable {
+        let type: String
+        let codec: String
+        let rate: Int
+        let bits: Int
+        let channel: Int
+    }
+
+    struct SSEMessage: Decodable {
+        let type: String
+        let delta: String?
+        let text: String?
+        let message: String?
+        let error: ErrorDetail?
+    }
+
+    struct ErrorDetail: Decodable {
+        let message: String?
+    }
+}

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -140,6 +140,8 @@ actor RecognitionSession {
         switch provider {
         case .volcano:
             return "https://openspeech.bytedance.com"
+        case .stepfunBatch:
+            return "https://api.stepfun.com"
         case .soniox:
             return "https://stt-rt.soniox.com"
         case .deepgram:

--- a/Type4Me/UI/Settings/ASRSettingsCard.swift
+++ b/Type4Me/UI/Settings/ASRSettingsCard.swift
@@ -89,6 +89,11 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
                 (L("可用模型", "Models"), L("查看", "view"), URL(string: "https://help.aliyun.com/zh/model-studio/fun-asr-realtime-websocket-api")!),
                 ("API Key", L("获取", "get"), URL(string: "https://help.aliyun.com/zh/model-studio/get-api-key")!),
             ]
+        case .stepfunBatch:
+            return [
+                (L("接入文档", "Setup guide"), L("查看", "view"), URL(string: "https://platform.stepfun.com/docs/zh/api-reference/audio/asr-sse")!),
+                ("API Key", L("获取", "get"), URL(string: "https://platform.stepfun.com/interface-key")!),
+            ]
         default:
             return []
         }
@@ -108,6 +113,11 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
         switch selectedASRProvider {
         case .deepgram:
             return L("受接口限制，热词仅取前 30 个", "Due to API limits, only the first 30 hotwords are used")
+        case .stepfunBatch:
+            return L(
+                "松开快捷键后提交完整录音；Step Plan 与标准按量付费需显式选择",
+                "The complete recording is submitted after you release the hotkey; explicitly choose Step Plan or standard pay-as-you-go"
+            )
         default:
             return nil
         }
@@ -142,6 +152,12 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
                     }
                 }
                 .padding(.bottom, 4)
+            }
+            if let note = currentProviderNote {
+                Text(note)
+                    .font(.system(size: 10))
+                    .foregroundStyle(TF.settingsTextTertiary)
+                    .padding(.bottom, 4)
             }
             SettingsDivider()
 

--- a/Type4MeTests/ASRProviderRegistryTests.swift
+++ b/Type4MeTests/ASRProviderRegistryTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class ASRProviderRegistryTests: XCTestCase {
 
     func testAvailableProvidersSupportDirectMode() {
-        for provider in [ASRProvider.volcano, .baidu, .bailian, .deepgram, .assemblyai, .soniox, .openai] {
+        for provider in [ASRProvider.volcano, .stepfunBatch, .baidu, .bailian, .deepgram, .assemblyai, .soniox, .openai] {
             XCTAssertTrue(ASRProviderRegistry.supports(.direct, for: provider))
         }
     }

--- a/Type4MeTests/StepFunBatchASRConfigTests.swift
+++ b/Type4MeTests/StepFunBatchASRConfigTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import Type4Me
+
+final class StepFunBatchASRConfigTests: XCTestCase {
+
+    func testInit_acceptsAPIKeyAndDefaultsToStepPlan() throws {
+        let config = try XCTUnwrap(StepFunBatchASRConfig(credentials: [
+            "apiKey": "  sk-stepfun-test  ",
+        ]))
+
+        XCTAssertEqual(config.apiKey, "sk-stepfun-test")
+        XCTAssertEqual(config.accessMode, .stepPlan)
+        XCTAssertTrue(config.isValid)
+    }
+
+    func testInit_acceptsStandardAccessMode() throws {
+        let config = try XCTUnwrap(StepFunBatchASRConfig(credentials: [
+            "apiKey": "sk-stepfun-test",
+            "accessMode": "standard",
+        ]))
+
+        XCTAssertEqual(config.accessMode, .standard)
+    }
+
+    func testInit_defaultsUnknownAccessModeToStepPlan() throws {
+        let config = try XCTUnwrap(StepFunBatchASRConfig(credentials: [
+            "apiKey": "sk-stepfun-test",
+            "accessMode": "unknown",
+        ]))
+
+        XCTAssertEqual(config.accessMode, .stepPlan)
+    }
+
+    func testInit_rejectsMissingOrBlankAPIKey() {
+        XCTAssertNil(StepFunBatchASRConfig(credentials: [:]))
+        XCTAssertNil(StepFunBatchASRConfig(credentials: ["apiKey": "   "]))
+    }
+
+    func testToCredentials_roundTripsAPIKeyAndAccessMode() throws {
+        let config = try XCTUnwrap(StepFunBatchASRConfig(credentials: [
+            "apiKey": "sk-stepfun-test",
+            "accessMode": "standard",
+        ]))
+
+        XCTAssertEqual(config.toCredentials(), [
+            "apiKey": "sk-stepfun-test",
+            "accessMode": "standard",
+        ])
+    }
+
+    func testCredentialFieldsExposeAccessModePicker() throws {
+        let fields = StepFunBatchASRConfig.credentialFields
+        XCTAssertEqual(fields.map(\.key), ["apiKey", "accessMode"])
+        XCTAssertFalse(try XCTUnwrap(fields.first).isOptional)
+
+        let accessMode = try XCTUnwrap(fields.first { $0.key == "accessMode" })
+        XCTAssertEqual(accessMode.defaultValue, "stepPlan")
+        XCTAssertEqual(accessMode.options.map(\.value), ["stepPlan", "standard"])
+    }
+
+    func testRegistry_exposesBatchStepFunProvider() {
+        let entry = ASRProviderRegistry.entry(for: .stepfunBatch)
+
+        XCTAssertNotNil(entry)
+        XCTAssertTrue(entry?.isAvailable ?? false)
+        XCTAssertTrue(ASRProviderRegistry.configType(for: .stepfunBatch) == StepFunBatchASRConfig.self)
+        XCTAssertNotNil(ASRProviderRegistry.createClient(for: .stepfunBatch))
+        XCTAssertEqual(ASRProviderRegistry.capabilities(for: .stepfunBatch), .batch())
+    }
+}

--- a/Type4MeTests/StepFunBatchASRProtocolTests.swift
+++ b/Type4MeTests/StepFunBatchASRProtocolTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import Type4Me
+
+final class StepFunBatchASRProtocolTests: XCTestCase {
+
+    func testBuildRequest_usesStepPlanEndpointAndPCMBody() throws {
+        let config = try XCTUnwrap(StepFunBatchASRConfig(credentials: [
+            "apiKey": "sk-stepfun-test",
+        ]))
+        let pcm = Data([0x01, 0x02, 0x03, 0x04])
+        let request = try StepFunBatchASRProtocol.buildRequest(
+            pcmData: pcm,
+            config: config,
+            options: ASRRequestOptions(hotwords: ["Type4Me", "阶跃星辰"])
+        )
+
+        XCTAssertEqual(request.url?.absoluteString, StepFunBatchASRConfig.stepPlanEndpoint)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer sk-stepfun-test")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "text/event-stream")
+
+        let root = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: XCTUnwrap(request.httpBody)) as? [String: Any]
+        )
+        let audio = try XCTUnwrap(root["audio"] as? [String: Any])
+        XCTAssertEqual(audio["data"] as? String, pcm.base64EncodedString())
+
+        let input = try XCTUnwrap(audio["input"] as? [String: Any])
+        let transcription = try XCTUnwrap(input["transcription"] as? [String: Any])
+        XCTAssertEqual(transcription["model"] as? String, "stepaudio-2.5-asr")
+        XCTAssertEqual(transcription["enable_itn"] as? Bool, true)
+        XCTAssertEqual(transcription["hotwords"] as? [String], ["Type4Me", "阶跃星辰"])
+        XCTAssertNil(transcription["language"])
+
+        let format = try XCTUnwrap(input["format"] as? [String: Any])
+        XCTAssertEqual(format["type"] as? String, "pcm")
+        XCTAssertEqual(format["codec"] as? String, "pcm_s16le")
+        XCTAssertEqual(format["rate"] as? Int, 16_000)
+        XCTAssertEqual(format["bits"] as? Int, 16)
+        XCTAssertEqual(format["channel"] as? Int, 1)
+    }
+
+    func testBuildRequest_usesStandardEndpointWhenSelected() throws {
+        let config = try XCTUnwrap(StepFunBatchASRConfig(credentials: [
+            "apiKey": "sk-stepfun-test",
+            "accessMode": "standard",
+        ]))
+        let request = try StepFunBatchASRProtocol.buildRequest(
+            pcmData: Data([0x00]),
+            config: config,
+            options: ASRRequestOptions()
+        )
+
+        XCTAssertEqual(request.url?.absoluteString, StepFunBatchASRConfig.standardEndpoint)
+    }
+
+    func testBuildRequest_omitsEmptyHotwordList() throws {
+        let config = try XCTUnwrap(StepFunBatchASRConfig(credentials: [
+            "apiKey": "sk-stepfun-test",
+        ]))
+        let request = try StepFunBatchASRProtocol.buildRequest(
+            pcmData: Data([0x00]),
+            config: config,
+            options: ASRRequestOptions()
+        )
+
+        let root = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: XCTUnwrap(request.httpBody)) as? [String: Any]
+        )
+        let audio = try XCTUnwrap(root["audio"] as? [String: Any])
+        let input = try XCTUnwrap(audio["input"] as? [String: Any])
+        let transcription = try XCTUnwrap(input["transcription"] as? [String: Any])
+        XCTAssertNil(transcription["hotwords"])
+    }
+
+    func testParseSSELine_decodesDeltaAndDoneEvents() throws {
+        let delta = try StepFunBatchASRProtocol.parseSSELine(
+            #"data: {"type":"transcript.text.delta","delta":"你好"}"#
+        )
+        let done = try StepFunBatchASRProtocol.parseSSELine(
+            #"data:{"type":"transcript.text.done","text":"你好，Type4Me。"}"#
+        )
+
+        XCTAssertEqual(delta, .delta("你好"))
+        XCTAssertEqual(done, .done("你好，Type4Me。"))
+    }
+
+    func testParseSSELine_decodesTopLevelAndNestedErrors() throws {
+        XCTAssertEqual(
+            try StepFunBatchASRProtocol.parseSSELine(
+                #"data: {"type":"error","message":"invalid api key"}"#
+            ),
+            .error("invalid api key")
+        )
+        XCTAssertEqual(
+            try StepFunBatchASRProtocol.parseSSELine(
+                #"data: {"type":"error","error":{"message":"quota exceeded"}}"#
+            ),
+            .error("quota exceeded")
+        )
+    }
+
+    func testParseSSELine_ignoresSSEMetadataAndUnknownEvents() throws {
+        XCTAssertNil(try StepFunBatchASRProtocol.parseSSELine("event: transcript"))
+        XCTAssertNil(try StepFunBatchASRProtocol.parseSSELine(""))
+        XCTAssertNil(try StepFunBatchASRProtocol.parseSSELine("data: [DONE]"))
+        XCTAssertNil(try StepFunBatchASRProtocol.parseSSELine(
+            #"data: {"type":"session.created"}"#
+        ))
+    }
+
+    func testParseSSELine_rejectsMalformedPayload() {
+        XCTAssertThrowsError(
+            try StepFunBatchASRProtocol.parseSSELine("data: not-json")
+        ) { error in
+            XCTAssertEqual(error as? StepFunBatchASRError, .invalidResponse)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add StepFun as a dedicated batch ASR provider
- let users explicitly choose between the Step Plan endpoint and the standard pay-as-you-go endpoint
- buffer Type4Me's 16 kHz mono PCM16 audio while recording, then submit it when recording ends
- parse incremental and final SSE transcription events
- support the existing Type4Me hotword list and enable ITN
- clearly explain that live partial transcription is unavailable

## Why

StepFun exposes `stepaudio-2.5-asr` through two HTTP + SSE endpoints:

- Step Plan: `/step_plan/v1/audio/asr/sse`
- standard pay-as-you-go: `/v1/audio/asr/sse`

Both endpoints use the same request and response protocol. The integration therefore models them as one batch provider with an explicit access-mode picker instead of duplicating providers or silently falling back to a potentially billable endpoint.

The provider is named `stepfunBatch` to leave a clear boundary for a future independent realtime StepFun provider.

## Implementation

- `StepFunBatchASRConfig` stores the API key and selected access mode
- missing or unknown access-mode values safely default to Step Plan
- `StepFunBatchASRProtocol` selects the endpoint, builds the Base64 PCM request, and parses `transcript.text.delta`, `transcript.text.done`, and error events
- `StepFunBatchASRClient` implements the existing `SpeechRecognizer` lifecycle by buffering audio during recording and submitting it from `endAudio()`
- the registry marks the provider with `.batch()` capabilities
- the existing data-driven `CredentialField.options` UI renders the access-mode picker in both Settings and the setup wizard

## Validation

- `swift test --filter StepFunBatch`: 14 tests passed
- `swift test`: 257 XCTest tests and 5 Swift Testing tests passed
- `swift build -c release`: succeeded
- verified Step Plan end-to-end speech-to-text with a signed packaged macOS app and a real API key
- verified both endpoint selections and request payloads with unit tests against the current StepFun API contract

## Non-goals

This PR does not add StepFun's regular-platform realtime WebSocket ASR (`stepaudio-2.5-asr-stream`) or any StepFun LLM presets. Those can be reviewed independently.
