### PR TITLE
Improve history usage details

### DIFF
--- a/Type4Me/Database/HistoryStore.swift
+++ b/Type4Me/Database/HistoryStore.swift
@@ -350,7 +350,7 @@ actor HistoryStore {
         let lastDay = iso.string(from: now.addingTimeInterval(-24 * 60 * 60))
         let last7Days = iso.string(from: now.addingTimeInterval(-7 * 24 * 60 * 60))
         let last30Days = iso.string(from: now.addingTimeInterval(-30 * 24 * 60 * 60))
-        let unknown = L("未知模型/引擎", "Unknown model/engine")
+        let unknown = L("未知", "Unknown")
 
         let sql = """
         SELECT
@@ -365,7 +365,9 @@ actor HistoryStore {
             COUNT(*)
         FROM recognition_history
         GROUP BY 1
-        ORDER BY 4 DESC, 2 DESC, model_name COLLATE NOCASE ASC;
+        ORDER BY CASE WHEN model_name = ? THEN 1 ELSE 0 END,
+                 5 DESC,
+                 model_name COLLATE NOCASE ASC;
         """
 
         var stmt: OpaquePointer?
@@ -376,6 +378,7 @@ actor HistoryStore {
         bind(stmt, 2, lastDay)
         bind(stmt, 3, last7Days)
         bind(stmt, 4, last30Days)
+        bind(stmt, 5, unknown)
 
         var rows: [UsageBreakdown] = []
         while sqlite3_step(stmt) == SQLITE_ROW {

--- a/Type4Me/Database/HistoryStore.swift
+++ b/Type4Me/Database/HistoryStore.swift
@@ -302,6 +302,7 @@ actor HistoryStore {
         let lastDayDuration: Double
         let last7DaysDuration: Double
         let last30DaysDuration: Double
+        let allTimeDuration: Double
         let recordCount: Int
 
         var id: String { modelName }
@@ -353,10 +354,14 @@ actor HistoryStore {
 
         let sql = """
         SELECT
-            COALESCE(NULLIF(asr_model, ''), NULLIF(asr_provider, ''), ?) AS model_name,
+            CASE
+                WHEN lower(trim(COALESCE(asr_provider, ''))) = 'elevenlabs' THEN 'ElevenLabs'
+                ELSE COALESCE(NULLIF(asr_model, ''), NULLIF(asr_provider, ''), ?)
+            END AS model_name,
             COALESCE(SUM(CASE WHEN created_at >= ? THEN duration_seconds ELSE 0 END), 0),
             COALESCE(SUM(CASE WHEN created_at >= ? THEN duration_seconds ELSE 0 END), 0),
             COALESCE(SUM(CASE WHEN created_at >= ? THEN duration_seconds ELSE 0 END), 0),
+            COALESCE(SUM(duration_seconds), 0),
             COUNT(*)
         FROM recognition_history
         GROUP BY 1
@@ -379,7 +384,8 @@ actor HistoryStore {
                 lastDayDuration: sqlite3_column_double(stmt, 1),
                 last7DaysDuration: sqlite3_column_double(stmt, 2),
                 last30DaysDuration: sqlite3_column_double(stmt, 3),
-                recordCount: Int(sqlite3_column_int(stmt, 4))
+                allTimeDuration: sqlite3_column_double(stmt, 4),
+                recordCount: Int(sqlite3_column_int(stmt, 5))
             ))
         }
         return rows

--- a/Type4Me/UI/Settings/HistoryTab.swift
+++ b/Type4Me/UI/Settings/HistoryTab.swift
@@ -1060,9 +1060,6 @@ struct HistoryTab: View {
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(TF.settingsText)
                     .lineLimit(1)
-                Text(L("\(row.recordCount) 条记录", "\(row.recordCount) records"))
-                    .font(.system(size: 9))
-                    .foregroundStyle(TF.settingsTextTertiary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -1072,8 +1069,13 @@ struct HistoryTab: View {
                 .frame(width: 78, alignment: .trailing)
             Text(formatUsageDuration(row.last30DaysDuration))
                 .frame(width: 78, alignment: .trailing)
-            Text(formatUsageDuration(row.allTimeDuration))
-                .frame(width: 78, alignment: .trailing)
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(formatUsageDuration(row.allTimeDuration))
+                Text(L("\(row.recordCount) 条记录", "\(row.recordCount) records"))
+                    .font(.system(size: 9))
+                    .foregroundStyle(TF.settingsTextTertiary)
+            }
+            .frame(width: 78, alignment: .trailing)
         }
         .font(.system(size: 11, weight: .medium, design: .rounded))
         .foregroundStyle(TF.settingsText)

--- a/Type4Me/UI/Settings/HistoryTab.swift
+++ b/Type4Me/UI/Settings/HistoryTab.swift
@@ -1030,7 +1030,7 @@ struct HistoryTab: View {
             }
         }
         .padding(16)
-        .frame(width: 460)
+        .frame(width: 550)
     }
 
     private var usageDetailsHeader: some View {
@@ -1042,6 +1042,8 @@ struct HistoryTab: View {
             Text(L("7天", "7 days"))
                 .frame(width: 78, alignment: .trailing)
             Text(L("30天", "30 days"))
+                .frame(width: 78, alignment: .trailing)
+            Text(L("全部", "All time"))
                 .frame(width: 78, alignment: .trailing)
         }
         .font(.system(size: 10, weight: .semibold))
@@ -1069,6 +1071,8 @@ struct HistoryTab: View {
             Text(formatUsageDuration(row.last7DaysDuration))
                 .frame(width: 78, alignment: .trailing)
             Text(formatUsageDuration(row.last30DaysDuration))
+                .frame(width: 78, alignment: .trailing)
+            Text(formatUsageDuration(row.allTimeDuration))
                 .frame(width: 78, alignment: .trailing)
         }
         .font(.system(size: 11, weight: .medium, design: .rounded))

--- a/Type4MeTests/HistoryStoreTests.swift
+++ b/Type4MeTests/HistoryStoreTests.swift
@@ -173,6 +173,18 @@ final class HistoryStoreTests: XCTestCase {
                 id: "old", createdAt: now.addingTimeInterval(-40 * 24 * 60 * 60), durationSeconds: 300,
                 rawText: "d", processingMode: nil, processedText: nil,
                 finalText: "d", status: "completed", characterCount: 1, asrProvider: "Old"
+            ),
+            HistoryRecord(
+                id: "elevenlabs-scribe", createdAt: now.addingTimeInterval(-2 * 24 * 60 * 60), durationSeconds: 45,
+                rawText: "e", processingMode: nil, processedText: nil,
+                finalText: "e", status: "completed", characterCount: 1, asrProvider: "ElevenLabs",
+                asrModel: "ElevenLabs · scribe_v2_realtime"
+            ),
+            HistoryRecord(
+                id: "elevenlabs-default", createdAt: now.addingTimeInterval(-40 * 24 * 60 * 60), durationSeconds: 75,
+                rawText: "f", processingMode: nil, processedText: nil,
+                finalText: "f", status: "completed", characterCount: 1, asrProvider: "ElevenLabs",
+                asrModel: "ElevenLabs"
             )
         ]
 
@@ -186,9 +198,16 @@ final class HistoryStoreTests: XCTestCase {
         XCTAssertEqual(byModel["Soniox · stt-rt-v5"]?.lastDayDuration ?? 0, 30, accuracy: 0.01)
         XCTAssertEqual(byModel["Soniox · stt-rt-v5"]?.last7DaysDuration ?? 0, 120, accuracy: 0.01)
         XCTAssertEqual(byModel["Soniox · stt-rt-v5"]?.last30DaysDuration ?? 0, 120, accuracy: 0.01)
+        XCTAssertEqual(byModel["Soniox · stt-rt-v5"]?.allTimeDuration ?? 0, 120, accuracy: 0.01)
         XCTAssertEqual(byModel["OpenAI"]?.lastDayDuration ?? 0, 0, accuracy: 0.01)
         XCTAssertEqual(byModel["OpenAI"]?.last7DaysDuration ?? 0, 0, accuracy: 0.01)
         XCTAssertEqual(byModel["OpenAI"]?.last30DaysDuration ?? 0, 120, accuracy: 0.01)
+        XCTAssertEqual(byModel["OpenAI"]?.allTimeDuration ?? 0, 120, accuracy: 0.01)
         XCTAssertEqual(byModel["Old"]?.last30DaysDuration ?? 0, 0, accuracy: 0.01)
+        XCTAssertEqual(byModel["Old"]?.allTimeDuration ?? 0, 300, accuracy: 0.01)
+        XCTAssertEqual(rows.filter { $0.modelName == "ElevenLabs" }.count, 1)
+        XCTAssertEqual(byModel["ElevenLabs"]?.recordCount, 2)
+        XCTAssertEqual(byModel["ElevenLabs"]?.last30DaysDuration ?? 0, 45, accuracy: 0.01)
+        XCTAssertEqual(byModel["ElevenLabs"]?.allTimeDuration ?? 0, 120, accuracy: 0.01)
     }
 }

--- a/Type4MeTests/HistoryStoreTests.swift
+++ b/Type4MeTests/HistoryStoreTests.swift
@@ -185,6 +185,11 @@ final class HistoryStoreTests: XCTestCase {
                 rawText: "f", processingMode: nil, processedText: nil,
                 finalText: "f", status: "completed", characterCount: 1, asrProvider: "ElevenLabs",
                 asrModel: "ElevenLabs"
+            ),
+            HistoryRecord(
+                id: "unknown", createdAt: now.addingTimeInterval(-60), durationSeconds: 60,
+                rawText: "g", processingMode: nil, processedText: nil,
+                finalText: "g", status: "completed", characterCount: 1, asrProvider: nil
             )
         ]
 
@@ -209,5 +214,7 @@ final class HistoryStoreTests: XCTestCase {
         XCTAssertEqual(byModel["ElevenLabs"]?.recordCount, 2)
         XCTAssertEqual(byModel["ElevenLabs"]?.last30DaysDuration ?? 0, 45, accuracy: 0.01)
         XCTAssertEqual(byModel["ElevenLabs"]?.allTimeDuration ?? 0, 120, accuracy: 0.01)
+        XCTAssertEqual(rows.last?.modelName, "Unknown")
+        XCTAssertEqual(rows.dropLast().map(\.allTimeDuration), rows.dropLast().map(\.allTimeDuration).sorted(by: >))
     }
 }


### PR DESCRIPTION
## Summary
- Add an All time usage column.
- Merge ElevenLabs usage rows by provider, ignoring model-name differences.
- Sort known usage rows by all-time duration descending and keep Unknown last.
- Move record counts beneath the All time duration.

## Tests
- `swift test --filter HistoryStoreTests`

Before (current)
<img width="526" height="388" alt="image" src="https://github.com/user-attachments/assets/d6b379cc-091b-40a9-9039-f154879ad09c" />

With this PR
<img width="581" height="416" alt="image" src="https://github.com/user-attachments/assets/59bfddf3-b935-4fba-b13a-64a231b63c62" />
