### PR TITLE
fix: migrate Volcano ASR to single X-Api-Key auth

### DIFF
--- a/Type4Me/ASR/Providers/VolcanoASRConfig.swift
+++ b/Type4Me/ASR/Providers/VolcanoASRConfig.swift
@@ -12,9 +12,11 @@ struct VolcanoASRConfig: ASRProviderConfig, Sendable {
     /// Auto: prefer 2.0, fall back to 1.0
     static let resourceIdAuto = "auto"
 
+    /// Credential keys retired when Volcengine moved to single-API-Key auth.
+    static let retiredCredentialKeys = ["appKey", "accessKey"]
+
     static var credentialFields: [CredentialField] {[
-        CredentialField(key: "appKey", label: "App ID", placeholder: "APPID", isSecure: false, isOptional: false, defaultValue: ""),
-        CredentialField(key: "accessKey", label: "Access Token", placeholder: L("访问令牌", "Access token"), isSecure: true, isOptional: false, defaultValue: ""),
+        CredentialField(key: "apiKey", label: "API Key", placeholder: L("粘贴 API Key", "Paste your API Key"), isSecure: true, isOptional: false, defaultValue: ""),
         CredentialField(
             key: "resourceId",
             label: L("识别模型", "Model"),
@@ -30,17 +32,13 @@ struct VolcanoASRConfig: ASRProviderConfig, Sendable {
         ),
     ]}
 
-    let appKey: String
-    let accessKey: String
+    let apiKey: String
     let resourceId: String
     let uid: String
 
     init?(credentials: [String: String]) {
-        guard let appKey = credentials["appKey"], !appKey.isEmpty,
-              let accessKey = credentials["accessKey"], !accessKey.isEmpty
-        else { return nil }
-        self.appKey = appKey
-        self.accessKey = accessKey
+        guard let apiKey = credentials["apiKey"], !apiKey.isEmpty else { return nil }
+        self.apiKey = apiKey
         let raw = credentials["resourceId"] ?? Self.resourceIdAuto
         if raw == Self.resourceIdAuto || raw.isEmpty {
             // Use resolved value from auto-detect, or default to seed
@@ -54,10 +52,10 @@ struct VolcanoASRConfig: ASRProviderConfig, Sendable {
     }
 
     func toCredentials() -> [String: String] {
-        ["appKey": appKey, "accessKey": accessKey, "resourceId": resourceId]
+        ["apiKey": apiKey, "resourceId": resourceId]
     }
 
     var isValid: Bool {
-        !appKey.isEmpty && !accessKey.isEmpty
+        !apiKey.isEmpty
     }
 }

--- a/Type4Me/ASR/VolcASRClient.swift
+++ b/Type4Me/ASR/VolcASRClient.swift
@@ -78,10 +78,14 @@ actor VolcASRClient: SpeechRecognizer {
         var request = URLRequest(url: targetURL)
         if !isCloudProxy {
             // Direct connection: inject vendor credentials
-            request.setValue(volcConfig.appKey, forHTTPHeaderField: "X-Api-App-Key")
-            request.setValue(volcConfig.accessKey, forHTTPHeaderField: "X-Api-Access-Key")
-            request.setValue(volcConfig.resourceId, forHTTPHeaderField: "X-Api-Resource-Id")
-            request.setValue(connectId, forHTTPHeaderField: "X-Api-Connect-Id")
+            let headers = VolcProtocol.authHeaders(
+                apiKey: volcConfig.apiKey,
+                resourceId: volcConfig.resourceId,
+                connectId: connectId
+            )
+            for (field, value) in headers {
+                request.setValue(value, forHTTPHeaderField: field)
+            }
         }
 
         // Send full_client_request (no compression, plain JSON)

--- a/Type4Me/CloudSubscription/CloudASRClient.swift
+++ b/Type4Me/CloudSubscription/CloudASRClient.swift
@@ -63,7 +63,7 @@ actor CloudASRClient: SpeechRecognizer {
         if region == .cn {
             // China: speak Volcengine protocol through our proxy
             let volcConfig = VolcanoASRConfig(credentials: [
-                "appKey": "cloud", "accessKey": "cloud", "resourceId": VolcanoASRConfig.resourceIdSeedASR
+                "apiKey": "cloud", "resourceId": VolcanoASRConfig.resourceIdSeedASR
             ])!
             let client = VolcASRClient()
             try await client.connect(config: volcConfig, options: proxyOptions)

--- a/Type4Me/Protocol/VolcProtocol.swift
+++ b/Type4Me/Protocol/VolcProtocol.swift
@@ -22,6 +22,20 @@ struct VolcServerResponse: Sendable, Equatable {
 
 enum VolcProtocol: Sendable {
 
+    // MARK: - Auth Headers
+
+    /// Builds the WebSocket handshake auth headers.
+    ///
+    /// New-console auth takes a single `X-Api-Key`. The former
+    /// `X-Api-App-Key` + `X-Api-Access-Key` pair is retired.
+    static func authHeaders(apiKey: String, resourceId: String, connectId: String) -> [String: String] {
+        [
+            "X-Api-Key": apiKey,
+            "X-Api-Resource-Id": resourceId,
+            "X-Api-Connect-Id": connectId,
+        ]
+    }
+
     // MARK: - Build Client Request JSON
 
     static func buildClientRequest(

--- a/Type4Me/Services/KeychainService.swift
+++ b/Type4Me/Services/KeychainService.swift
@@ -163,14 +163,6 @@ enum KeychainService {
 
     // MARK: - Legacy ASR convenience (volcano-specific, kept for migration)
 
-    static func saveASRCredentials(appKey: String, accessKey: String, resourceId: String) throws {
-        try saveASRCredentials(for: .volcano, values: [
-            "appKey": appKey,
-            "accessKey": accessKey,
-            "resourceId": resourceId,
-        ])
-    }
-
     static func loadASRConfig() -> VolcanoASRConfig? {
         loadASRConfig(for: .volcano) as? VolcanoASRConfig
     }
@@ -288,6 +280,11 @@ enum KeychainService {
         var mutableDict = dict
         var legacyExternalKeysToClean = Set<String>()
 
+        // Volcano moved to single-API-Key auth: purge the retired App ID +
+        // Access Token pair so the token cannot be demoted to plaintext JSON
+        // by a later save (it is no longer a `isSecure` field).
+        migrated = purgeRetiredVolcanoAuthFields(in: &mutableDict) || migrated
+
         // Migrate ASR: tf_appKey/tf_accessKey/tf_resourceId → tf_asr_volcano
         let legacyASRKeys = ["tf_appKey", "tf_accessKey", "tf_resourceId"]
         let legacyASR = legacyVolcanoASRCredentials(in: dict)
@@ -363,6 +360,42 @@ enum KeychainService {
     }
 
     @discardableResult
+    /// Removes the retired Volcano App ID / Access Token from both stores.
+    /// Returns true when the plaintext file dict was modified.
+    private static func purgeRetiredVolcanoAuthFields(in dict: inout [String: Any]) -> Bool {
+        let storageKey = asrStorageKey(for: .volcano)
+        let retired = VolcanoASRConfig.retiredCredentialKeys
+
+        // Keychain: rewrite the grouped blob without the retired keys.
+        let secure = loadSecureValues(account: storageKey)
+        if retired.contains(where: { secure[$0] != nil }) {
+            var cleaned = secure
+            for key in retired {
+                cleaned.removeValue(forKey: key)
+            }
+            if cleaned.isEmpty {
+                deleteSecureValue(service: keychainGroupedService, account: storageKey)
+            } else {
+                try? saveSecureValues(cleaned, account: storageKey)
+            }
+            NSLog("[KeychainService] Purged retired Volcano auth fields from Keychain")
+        }
+
+        // Plaintext file: drop the retired keys from the provider bucket.
+        var plaintext = stringDictionary(dict[storageKey])
+        guard retired.contains(where: { plaintext[$0] != nil }) else { return false }
+        for key in retired {
+            plaintext.removeValue(forKey: key)
+        }
+        if plaintext.isEmpty {
+            dict.removeValue(forKey: storageKey)
+        } else {
+            dict[storageKey] = plaintext
+        }
+        NSLog("[KeychainService] Purged retired Volcano auth fields from credentials.json")
+        return true
+    }
+
     private static func removeLegacyFileKeys(_ keys: [String], from dict: inout [String: Any]) -> Bool {
         var changed = false
         for key in keys {
@@ -492,7 +525,13 @@ enum KeychainService {
         legacy: [String: String] = [:]
     ) -> [String: String] {
         let fields = ASRProviderRegistry.configType(for: provider)?.credentialFields ?? []
-        return compatibleCredentialValues(stored: stored, legacy: legacy, fields: fields)
+        let retired = provider == .volcano ? VolcanoASRConfig.retiredCredentialKeys : []
+        return compatibleCredentialValues(
+            stored: stored,
+            legacy: legacy,
+            fields: fields,
+            retiredKeys: retired
+        )
     }
 
     static func compatibleLLMCredentials(
@@ -507,11 +546,15 @@ enum KeychainService {
     private static func compatibleCredentialValues(
         stored: [String: String],
         legacy: [String: String],
-        fields: [CredentialField]
+        fields: [CredentialField],
+        retiredKeys: [String] = []
     ) -> [String: String] {
         var result: [String: String] = [:]
         mergeNonEmpty(legacy, into: &result)
         mergeNonEmpty(stored, into: &result)
+        for key in retiredKeys {
+            result.removeValue(forKey: key)
+        }
 
         guard !result.isEmpty else { return [:] }
         for field in fields where !field.defaultValue.isEmpty {
@@ -541,10 +584,10 @@ enum KeychainService {
         return result
     }
 
+    /// Only `resourceId` carries over: `tf_appKey` / `tf_accessKey` held the
+    /// retired App ID + Access Token pair.
     private static func legacyVolcanoASRCredentials(in dict: [String: Any]) -> [String: String] {
         var values: [String: String] = [:]
-        setLegacyValue("tf_appKey", as: "appKey", in: dict, values: &values)
-        setLegacyValue("tf_accessKey", as: "accessKey", in: dict, values: &values)
         setLegacyValue("tf_resourceId", as: "resourceId", in: dict, values: &values)
         return values
     }

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -323,15 +323,15 @@ actor RecognitionSession {
             config = savedConfig
             NSLog("[Session] Loaded %@ credentials from file store", provider.rawValue)
         } else if provider == .volcano,
-                  let appKey = ProcessInfo.processInfo.environment["VOLC_APP_KEY"],
-                  let accessKey = ProcessInfo.processInfo.environment["VOLC_ACCESS_KEY"] {
+                  let apiKey = ProcessInfo.processInfo.environment["VOLC_API_KEY"],
+                  let volcConfig = VolcanoASRConfig(credentials: [
+                      "apiKey": apiKey,
+                      "resourceId": ProcessInfo.processInfo.environment["VOLC_RESOURCE_ID"]
+                          ?? VolcanoASRConfig.resourceIdSeedASR,
+                  ]) {
             // Env var fallback (volcano only, for dev convenience)
-            let resourceId = ProcessInfo.processInfo.environment["VOLC_RESOURCE_ID"] ?? VolcanoASRConfig.resourceIdSeedASR
-            let volcConfig = VolcanoASRConfig(credentials: [
-                "appKey": appKey, "accessKey": accessKey, "resourceId": resourceId,
-            ])!
             do {
-                try KeychainService.saveASRCredentials(appKey: appKey, accessKey: accessKey, resourceId: resourceId)
+                try KeychainService.saveASRCredentials(for: .volcano, values: volcConfig.toCredentials())
                 NSLog("[Session] Loaded credentials from env vars and persisted to file")
             } catch {
                 NSLog("[Session] WARNING: env var credentials loaded but failed to persist: %@", String(describing: error))

--- a/Type4Me/UI/Settings/ASRSettingsCard.swift
+++ b/Type4Me/UI/Settings/ASRSettingsCard.swift
@@ -803,7 +803,7 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
         }
 
         // Both failed
-        asrTestStatus = .failed(L("连接失败，请检查 App ID 和 Access Token", "Connection failed, check App ID & Access Token"))
+        asrTestStatus = .failed(L("连接失败，请检查 API Key", "Connection failed, check API Key"))
     }
 
     private func testVolcResource(baseValues: [String: String], resourceId: String, options: ASRRequestOptions) async -> Bool {

--- a/Type4MeTests/KeychainServiceTests.swift
+++ b/Type4MeTests/KeychainServiceTests.swift
@@ -75,15 +75,13 @@ final class KeychainServiceTests: XCTestCase {
         }
 
         try KeychainService.saveASRCredentials(for: .volcano, values: [
-            "appKey": "myAppKey",
-            "accessKey": "myAccessKey",
+            "apiKey": "myApiKey",
             "resourceId": "myResource",
         ])
 
         let config = KeychainService.loadASRConfig()
         XCTAssertNotNil(config)
-        XCTAssertEqual(config?.appKey, "myAppKey")
-        XCTAssertEqual(config?.accessKey, "myAccessKey")
+        XCTAssertEqual(config?.apiKey, "myApiKey")
         XCTAssertEqual(config?.resourceId, "myResource")
     }
 
@@ -91,15 +89,30 @@ final class KeychainServiceTests: XCTestCase {
         let values = KeychainService.compatibleASRCredentials(
             for: .volcano,
             stored: [
-                "appKey": "myAppKey",
-                "accessKey": "myAccessKey",
+                "apiKey": "myApiKey",
             ]
         )
 
-        XCTAssertEqual(values["appKey"], "myAppKey")
-        XCTAssertEqual(values["accessKey"], "myAccessKey")
+        XCTAssertEqual(values["apiKey"], "myApiKey")
         XCTAssertEqual(values["resourceId"], VolcanoASRConfig.resourceIdAuto)
         XCTAssertNotNil(VolcanoASRConfig(credentials: values))
+    }
+
+    /// Volcano switched to a single API Key; the retired App ID / Access Token
+    /// fields must not survive into the loaded credential set.
+    func testCompatibleASRCredentials_dropsRetiredVolcanoAuthFields() throws {
+        let values = KeychainService.compatibleASRCredentials(
+            for: .volcano,
+            stored: [
+                "apiKey": "myApiKey",
+                "appKey": "staleAppID",
+                "accessKey": "staleAccessToken",
+            ]
+        )
+
+        XCTAssertEqual(values["apiKey"], "myApiKey")
+        XCTAssertNil(values["appKey"])
+        XCTAssertNil(values["accessKey"])
     }
 
     func testCompatibleLLMCredentials_backfillsModelAndBaseURLForOldValues() throws {
@@ -117,16 +130,14 @@ final class KeychainServiceTests: XCTestCase {
     func testCompatibleCredentialsPreferStoredValuesOverLegacyFallbacks() throws {
         let values = KeychainService.compatibleASRCredentials(
             for: .volcano,
-            stored: ["appKey": "newAppKey"],
+            stored: ["apiKey": "newApiKey"],
             legacy: [
-                "appKey": "oldAppKey",
-                "accessKey": "oldAccessKey",
+                "apiKey": "oldApiKey",
                 "resourceId": "oldResourceId",
             ]
         )
 
-        XCTAssertEqual(values["appKey"], "newAppKey")
-        XCTAssertEqual(values["accessKey"], "oldAccessKey")
+        XCTAssertEqual(values["apiKey"], "newApiKey")
         XCTAssertEqual(values["resourceId"], "oldResourceId")
     }
 
@@ -141,13 +152,11 @@ final class KeychainServiceTests: XCTestCase {
         }
 
         try KeychainService.saveASRCredentials(for: .volcano, values: [
-            "appKey": "myAppKey",
-            "accessKey": "myAccessKey",
+            "apiKey": "myApiKey",
         ])
 
         let values = try XCTUnwrap(KeychainService.loadASRCredentials(for: .volcano))
-        XCTAssertEqual(values["appKey"], "myAppKey")
-        XCTAssertEqual(values["accessKey"], "myAccessKey")
+        XCTAssertEqual(values["apiKey"], "myApiKey")
         XCTAssertEqual(values["resourceId"], VolcanoASRConfig.resourceIdAuto)
         XCTAssertNotNil(KeychainService.loadASRConfig(for: .volcano))
     }
@@ -200,9 +209,11 @@ final class KeychainServiceTests: XCTestCase {
         KeychainService.migrateStoredCredentials()
 
         let values = try XCTUnwrap(KeychainService.loadASRCredentials(for: .volcano))
-        XCTAssertEqual(values["appKey"], "legacyAppKey")
-        XCTAssertEqual(values["accessKey"], "legacyAccessKey")
+        // Only resourceId carries over — the flat App ID / Access Token keys
+        // hold retired credentials and are dropped, not migrated.
         XCTAssertEqual(values["resourceId"], "legacyResource")
+        XCTAssertNil(values["appKey"])
+        XCTAssertNil(values["accessKey"])
         XCTAssertNil(UserDefaults.standard.object(forKey: "tf_appKey"))
         XCTAssertNil(UserDefaults.standard.object(forKey: "tf_resourceId"))
         XCTAssertNil(KeychainService.load(key: "tf_accessKey"))
@@ -245,8 +256,7 @@ final class KeychainServiceTests: XCTestCase {
 
     func testSaveASRCredentials_storesSecureFieldsOutsideCredentialsFile() throws {
         try KeychainService.saveASRCredentials(for: .volcano, values: [
-            "appKey": "myAppKey",
-            "accessKey": "myAccessKey",
+            "apiKey": "myApiKey",
             "resourceId": "myResource",
         ])
 
@@ -254,10 +264,9 @@ final class KeychainServiceTests: XCTestCase {
         let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: fileData) as? [String: Any])
         let stored = try XCTUnwrap(json["tf_asr_volcano"] as? [String: String])
 
-        XCTAssertEqual(stored["appKey"], "myAppKey")
         XCTAssertEqual(stored["resourceId"], "myResource")
-        XCTAssertNil(stored["accessKey"])
-        XCTAssertEqual(KeychainService.loadASRCredentials(for: .volcano)?["accessKey"], "myAccessKey")
+        XCTAssertNil(stored["apiKey"])
+        XCTAssertEqual(KeychainService.loadASRCredentials(for: .volcano)?["apiKey"], "myApiKey")
     }
 
     func testSelectedASRProviderPostsNotificationOnChange() {

--- a/Type4MeTests/VolcASRClientTests.swift
+++ b/Type4MeTests/VolcASRClientTests.swift
@@ -2,6 +2,30 @@ import XCTest
 @testable import Type4Me
 
 final class VolcASRClientTests: XCTestCase {
+    func testAuthHeadersUseSingleAPIKey() {
+        let headers = VolcProtocol.authHeaders(
+            apiKey: "my-api-key",
+            resourceId: VolcanoASRConfig.resourceIdSeedASR,
+            connectId: "connect-123"
+        )
+
+        XCTAssertEqual(headers["X-Api-Key"], "my-api-key")
+        XCTAssertEqual(headers["X-Api-Resource-Id"], VolcanoASRConfig.resourceIdSeedASR)
+        XCTAssertEqual(headers["X-Api-Connect-Id"], "connect-123")
+    }
+
+    func testAuthHeadersOmitRetiredCredentialHeaders() {
+        let headers = VolcProtocol.authHeaders(
+            apiKey: "my-api-key",
+            resourceId: VolcanoASRConfig.resourceIdSeedASR,
+            connectId: "connect-123"
+        )
+
+        XCTAssertNil(headers["X-Api-App-Key"])
+        XCTAssertNil(headers["X-Api-Access-Key"])
+        XCTAssertEqual(headers.count, 3)
+    }
+
     func testWebSocketUpgradeProbeMessageIsIgnored() {
         let message = #"Bad Request("error", "cannot upgrade to websocket: websocket: the client is not using the websocket protocol: 'upgrade' token not found in 'Connection' header")"#
 


### PR DESCRIPTION
## 背景

火山引擎（豆包）语音识别已停用 `X-Api-App-Key` + `X-Api-Access-Key` 这对鉴权参数，改为在新版控制台签发单个 **API Key**，通过 `X-Api-Key` 传递。目前 `main` 分支发送的仍是旧的两个 header。

参考依据：
- 火山官方文档 6561/2277844 的公共参数表列出 `X-Api-Key`（「使用火山引擎控制台获取的 API Key」，必须）
- 两个第三方实现已完成同样迁移：[univoice-rs](https://github.com/shenjingnan/univoice-rs) 的 `sauc.rs` 明确注释「旧版 `X-Api-App-Key` + `X-Api-Access-Key` 已废弃」并有测试断言旧 header 不存在；[voicestick](https://github.com/78/voicestick) 的 `docs/volcengine-asr.md` header 表同样只列 `X-Api-Key`

接入点、资源 ID、二进制帧格式与请求 payload 均无需改动，本 PR 只碰鉴权。

## 改动

- **`VolcProtocol`**：新增 `authHeaders(apiKey:resourceId:connectId:)`。原先 header 内联在 `VolcASRClient.connect()` 里无法单测，抽成纯函数后可以断言「旧 header 确实不存在」
- **`VolcanoASRConfig`**：`appKey` + `accessKey` 收敛为单个 `apiKey`（`isSecure: true`），与 `DeepgramASRConfig` 等既有 provider 的写法对齐
- **`KeychainService`**：迁移时从钥匙串和 `credentials.json` 中清除废弃的 App ID / Access Token。这一步是必要的而非洁癖 —— `accessKey` 不再是 `isSecure` 字段后，`splitCredentials` 会把残留值当普通字段写入明文 JSON，等于把用户原本加密存储的 token 降级落盘。另外删掉了迁移后已无调用者的 `saveASRCredentials(appKey:accessKey:resourceId:)`
- **`RecognitionSession`**：开发用的环境变量兜底路径原本是 `VolcanoASRConfig(credentials: [...])!` 强制解包，字段变更后必然崩溃，改为 `guard let`；变量名同步改为 `VOLC_API_KEY`
- **`CloudASRClient`**：同步构造参数（该目录当前因 marker 归档而不参与编译，但保证恢复后不会挂）
- **测试**：新增鉴权 header 与凭据迁移用例，涵盖「只发 API Key」「废弃字段不残留」「legacy flat key 只搬 `resourceId`」

## 兼容性

这是**破坏性变更**：升级后火山用户需要到控制台创建 API Key 并重新填写。设置面板会因 `apiKey` 缺失而自动进入编辑态，无需额外引导 UI。

采用硬切换而非「新旧双轨并存」，是提交者与使用者商定的取舍。如果你倾向保留回落逻辑（有 `apiKey` 走新 header，否则发旧两个 header），我可以改成双轨 —— 这样老用户在旧凭据仍处服务期内可以无感继续使用。请告知偏好。

## 验证

- `swift build` 通过
- 单元测试**未能执行**：提交者的机器只装了 Command Line Tools 而没有完整 Xcode，SDK 中不含 XCTest，`swift test` 会报 `no such module 'XCTest'`。在未改动的 tree 上同样如此，属既有环境限制。测试代码已写但需要在有 Xcode 的环境中跑一遍
- 真机连通性由使用者用自己的火山 API Key 在「测试连接」中验证通过（含 auto resource 的双 ID 探测路径）
