### PR TITLE
Add configurable Deepgram WebSocket base URL

### DIFF
--- a/Type4Me/ASR/DeepgramASRClient.swift
+++ b/Type4Me/ASR/DeepgramASRClient.swift
@@ -105,7 +105,11 @@ actor DeepgramASRClient: SpeechRecognizer {
             options: options
         )
         var request = URLRequest(url: url)
-        request.setValue("Token \(deepgramConfig.apiKey)", forHTTPHeaderField: "Authorization")
+        if deepgramConfig.baseURL == DeepgramASRConfig.defaultBaseURL {
+            request.setValue("Token \(deepgramConfig.apiKey)", forHTTPHeaderField: "Authorization")
+        } else {
+            request.setValue(deepgramConfig.apiKey, forHTTPHeaderField: "X-API-Key")
+        }
 
         let connectionGate = DeepgramConnectionGate()
         let closeTracker = DeepgramCloseTracker()

--- a/Type4Me/ASR/Providers/DeepgramASRConfig.swift
+++ b/Type4Me/ASR/Providers/DeepgramASRConfig.swift
@@ -6,6 +6,7 @@ struct DeepgramASRConfig: ASRProviderConfig, Sendable {
     static let displayName = "Deepgram"
     static let defaultModel = "nova-3"
     static let defaultLanguage = "zh"
+    static let defaultBaseURL = "wss://api.deepgram.com/v1/listen"
 
     static let supportedModels = [
         "nova-3",
@@ -25,6 +26,7 @@ struct DeepgramASRConfig: ASRProviderConfig, Sendable {
 
     static var credentialFields: [CredentialField] {[
         CredentialField(key: "apiKey", label: L("API Key", "API Key"), placeholder: L("粘贴 API Key", "Paste your API Key"), isSecure: true, isOptional: false, defaultValue: ""),
+        CredentialField(key: "baseURL", label: "Base URL", placeholder: defaultBaseURL, isSecure: false, isOptional: false, defaultValue: defaultBaseURL),
         CredentialField(key: "model", label: L("模型", "Model"), placeholder: defaultModel, isSecure: false, isOptional: false, defaultValue: defaultModel,
             options: supportedModels.map { FieldOption(value: $0, label: $0) }),
         CredentialField(key: "language", label: L("语言", "Language"), placeholder: defaultLanguage, isSecure: false, isOptional: false, defaultValue: defaultLanguage,
@@ -34,6 +36,7 @@ struct DeepgramASRConfig: ASRProviderConfig, Sendable {
     ]}
 
     let apiKey: String
+    let baseURL: String
     let model: String
     let language: String
     let numerals: Bool
@@ -47,6 +50,8 @@ struct DeepgramASRConfig: ASRProviderConfig, Sendable {
         let language = credentials["language"]?.trimmingCharacters(in: .whitespacesAndNewlines)
 
         self.apiKey = apiKey
+        let configuredBaseURL = credentials["baseURL"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        self.baseURL = configuredBaseURL.isEmpty ? Self.defaultBaseURL : configuredBaseURL
         self.model = model?.isEmpty == false ? model! : Self.defaultModel
         self.language = language?.isEmpty == false ? language! : Self.defaultLanguage
         self.numerals = credentials["numerals"] == "true"
@@ -55,6 +60,7 @@ struct DeepgramASRConfig: ASRProviderConfig, Sendable {
     func toCredentials() -> [String: String] {
         [
             "apiKey": apiKey,
+            "baseURL": baseURL,
             "model": model,
             "language": language,
             "numerals": numerals ? "true" : "false",

--- a/Type4Me/Database/HistoryStore.swift
+++ b/Type4Me/Database/HistoryStore.swift
@@ -539,6 +539,8 @@ actor HistoryStore {
         SELECT
             CASE
                 WHEN lower(trim(COALESCE(asr_provider, ''))) = 'elevenlabs' THEN 'ElevenLabs'
+                WHEN lower(trim(COALESCE(asr_provider, ''))) = 'deepgram'
+                     OR lower(trim(COALESCE(asr_model, ''))) LIKE 'deepgram%' THEN 'Deepgram'
                 ELSE COALESCE(NULLIF(asr_model, ''), NULLIF(asr_provider, ''), ?)
             END AS model_name,
             COALESCE(SUM(CASE WHEN created_at >= ? THEN duration_seconds ELSE 0 END), 0),

--- a/Type4Me/Protocol/DeepgramProtocol.swift
+++ b/Type4Me/Protocol/DeepgramProtocol.swift
@@ -18,7 +18,6 @@ struct DeepgramTranscriptUpdate: Sendable, Equatable {
 
 enum DeepgramProtocol {
 
-    private static let endpoint = "wss://api.deepgram.com/v1/listen"
     private static let keywordIntensity = 2
     private static let maxURLKeyterms = 30
 
@@ -26,7 +25,9 @@ enum DeepgramProtocol {
         config: DeepgramASRConfig,
         options: ASRRequestOptions
     ) throws -> URL {
-        guard var components = URLComponents(string: endpoint) else {
+        guard var components = URLComponents(string: config.baseURL),
+              components.scheme?.lowercased() == "wss",
+              components.host != nil else {
             throw DeepgramProtocolError.invalidEndpoint
         }
 
@@ -60,7 +61,7 @@ enum DeepgramProtocol {
             })
         }
 
-        components.queryItems = queryItems
+        components.queryItems = (components.queryItems ?? []) + queryItems
 
         guard let url = components.url else {
             throw DeepgramProtocolError.invalidEndpoint

--- a/Type4Me/UI/Settings/ASRSettingsCard.swift
+++ b/Type4Me/UI/Settings/ASRSettingsCard.swift
@@ -413,8 +413,11 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
                 }
             )
             let savedVal = savedASRValues[field.key] ?? ""
-            let placeholder = savedVal.isEmpty ? field.placeholder : maskedSecret(savedVal)
-            settingsSecureField(field.label, text: binding, prompt: placeholder)
+            settingsSecureField(
+                field.label,
+                text: binding,
+                prompt: secureFieldPlaceholder(field: field, savedValue: savedVal)
+            )
         } else {
             let binding = Binding<String>(
                 get: {
@@ -431,6 +434,19 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
             )
             settingsField(field.label, text: binding, prompt: field.placeholder)
         }
+    }
+
+    private var deepgramUsesOfficialEndpoint: Bool {
+        let endpoint = effectiveASRValues["baseURL"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return endpoint?.isEmpty == false ? endpoint == DeepgramASRConfig.defaultBaseURL : true
+    }
+
+    private func secureFieldPlaceholder(field: CredentialField, savedValue: String) -> String {
+        if field.key == "apiKey", selectedASRProvider == .deepgram,
+           !deepgramUsesOfficialEndpoint {
+            return L("API 密钥或令牌", "API key or token")
+        }
+        return savedValue.isEmpty ? field.placeholder : maskedSecret(savedValue)
     }
 
     private var asrSummaryRows: [(String, String)] {

--- a/Type4MeTests/DeepgramASRConfigTests.swift
+++ b/Type4MeTests/DeepgramASRConfigTests.swift
@@ -11,6 +11,7 @@ final class DeepgramASRConfigTests: XCTestCase {
         XCTAssertEqual(config.apiKey, "dg_test_key")
         XCTAssertEqual(config.model, DeepgramASRConfig.defaultModel)
         XCTAssertEqual(config.language, DeepgramASRConfig.defaultLanguage)
+        XCTAssertEqual(config.baseURL, DeepgramASRConfig.defaultBaseURL)
         XCTAssertTrue(config.isValid)
     }
 
@@ -34,6 +35,14 @@ final class DeepgramASRConfigTests: XCTestCase {
         XCTAssertEqual(config.toCredentials()["apiKey"], "dg_test_key")
         XCTAssertEqual(config.toCredentials()["model"], "nova-2")
         XCTAssertEqual(config.toCredentials()["language"], DeepgramASRConfig.defaultLanguage)
+        XCTAssertEqual(config.toCredentials()["baseURL"], DeepgramASRConfig.defaultBaseURL)
+    }
+
+    func testCustomBaseURL_roundTrips() throws {
+        let endpoint = "wss://example.test/proxy/deepgram/v1/listen"
+        let config = try XCTUnwrap(DeepgramASRConfig(credentials: ["apiKey": "proxy-token", "baseURL": endpoint]))
+        XCTAssertEqual(config.baseURL, endpoint)
+        XCTAssertEqual(config.toCredentials()["baseURL"], endpoint)
     }
 
     func testRegistry_exposesDeepgramProvider() {

--- a/Type4MeTests/DeepgramProtocolTests.swift
+++ b/Type4MeTests/DeepgramProtocolTests.swift
@@ -35,6 +35,13 @@ final class DeepgramProtocolTests: XCTestCase {
         XCTAssertNil(items.value(for: "keyterm"))
     }
 
+    func testBuildWebSocketURL_usesCustomEndpoint() throws {
+        let endpoint = "wss://example.test/proxy/deepgram/v1/listen"
+        let config = try XCTUnwrap(DeepgramASRConfig(credentials: ["apiKey": "proxy-token", "baseURL": endpoint]))
+        let url = try DeepgramProtocol.buildWebSocketURL(config: config, options: ASRRequestOptions())
+        XCTAssertEqual(url.absoluteString.components(separatedBy: "?").first, endpoint)
+    }
+
     func testBuildWebSocketURL_usesKeytermForNova3Models() throws {
         let config = try XCTUnwrap(DeepgramASRConfig(credentials: [
             "apiKey": "dg_test_key",

--- a/Type4MeTests/HistoryStoreTests.swift
+++ b/Type4MeTests/HistoryStoreTests.swift
@@ -311,6 +311,18 @@ final class HistoryStoreTests: XCTestCase {
                 asrModel: "ElevenLabs"
             ),
             HistoryRecord(
+                id: "deepgram-provider", createdAt: now.addingTimeInterval(-2 * 24 * 60 * 60), durationSeconds: 40,
+                rawText: "dg", processingMode: nil, processedText: nil,
+                finalText: "dg", status: "completed", characterCount: 1, asrProvider: "Deepgram",
+                asrModel: nil
+            ),
+            HistoryRecord(
+                id: "deepgram-model", createdAt: now.addingTimeInterval(-40 * 24 * 60 * 60), durationSeconds: 20,
+                rawText: "dg2", processingMode: nil, processedText: nil,
+                finalText: "dg2", status: "completed", characterCount: 1, asrProvider: nil,
+                asrModel: "Deepgram · nova-3"
+            ),
+            HistoryRecord(
                 id: "unknown", createdAt: now.addingTimeInterval(-60), durationSeconds: 60,
                 rawText: "g", processingMode: nil, processedText: nil,
                 finalText: "g", status: "completed", characterCount: 1, asrProvider: nil
@@ -338,6 +350,11 @@ final class HistoryStoreTests: XCTestCase {
         XCTAssertEqual(byModel["ElevenLabs"]?.recordCount, 2)
         XCTAssertEqual(byModel["ElevenLabs"]?.last30DaysDuration ?? 0, 45, accuracy: 0.01)
         XCTAssertEqual(byModel["ElevenLabs"]?.allTimeDuration ?? 0, 120, accuracy: 0.01)
+        XCTAssertEqual(rows.filter { $0.modelName == "Deepgram" }.count, 1)
+        XCTAssertEqual(rows.filter { $0.modelName == "Deepgram · nova-3" }.count, 0)
+        XCTAssertEqual(byModel["Deepgram"]?.recordCount, 2)
+        XCTAssertEqual(byModel["Deepgram"]?.last30DaysDuration ?? 0, 40, accuracy: 0.01)
+        XCTAssertEqual(byModel["Deepgram"]?.allTimeDuration ?? 0, 60, accuracy: 0.01)
         XCTAssertEqual(rows.last?.modelName, L("未知", "Unknown"))
         XCTAssertEqual(rows.dropLast().map(\.allTimeDuration), rows.dropLast().map(\.allTimeDuration).sorted(by: >))
     }


### PR DESCRIPTION
## Summary
- add a configurable Deepgram WebSocket base URL beside the API key setting
- default to the official Deepgram streaming endpoint
- use the proxy API-key header for custom endpoints and the official token header for the official endpoint
- avoid provider-specific API-key placeholder text when a custom endpoint is configured

## Validation
- updated tests use a synthetic public WebSocket URL and do not include internal proxy endpoints
- branch contains the implementation and regression tests

## Testing
Tested locally with the custom development proxy endpoint.