### PR TITLE
fix: support custom OpenAI ASR base URL

### DIFF
--- a/Type4Me/ASR/Providers/OpenAIASRConfig.swift
+++ b/Type4Me/ASR/Providers/OpenAIASRConfig.swift
@@ -5,6 +5,7 @@ struct OpenAIASRConfig: ASRProviderConfig, Sendable {
     static let provider = ASRProvider.openai
     static let displayName = "OpenAI"
     static let defaultModel = "gpt-4o-transcribe"
+    static let defaultBaseURL = "https://api.openai.com/v1"
 
     static let credentialFields: [CredentialField] = [
         CredentialField(key: "apiKey", label: L("API Key", "API Key"), placeholder: "sk-...", isSecure: true, isOptional: false, defaultValue: ""),
@@ -18,9 +19,12 @@ struct OpenAIASRConfig: ASRProviderConfig, Sendable {
                 FieldOption(value: "whisper-1", label: "Whisper ($0.36/hr)"),
             ]
         ),
+        CredentialField(
+            key: "baseURL", label: L("Base URL", "Base URL"),
+            placeholder: defaultBaseURL,
+            isSecure: false, isOptional: true, defaultValue: defaultBaseURL
+        ),
     ]
-
-    private static let defaultBaseURL = "https://api.openai.com/v1"
 
     let apiKey: String
     let model: String
@@ -32,9 +36,14 @@ struct OpenAIASRConfig: ASRProviderConfig, Sendable {
         self.model = credentials["model"]?.isEmpty == false
             ? credentials["model"]!
             : Self.defaultModel
-        self.baseURL = credentials["baseURL"]?.isEmpty == false
-            ? credentials["baseURL"]!
+        let configuredBaseURL = credentials["baseURL"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedBaseURL = configuredBaseURL?.isEmpty == false
+            ? configuredBaseURL!
             : Self.defaultBaseURL
+        self.baseURL = resolvedBaseURL.hasSuffix("/")
+            ? String(resolvedBaseURL.dropLast())
+            : resolvedBaseURL
     }
 
     func toCredentials() -> [String: String] {

--- a/Type4MeTests/OpenAIASRConfigTests.swift
+++ b/Type4MeTests/OpenAIASRConfigTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import Type4Me
+
+final class OpenAIASRConfigTests: XCTestCase {
+
+    func testCredentialFieldsExposeConfigurableBaseURL() throws {
+        let field = try XCTUnwrap(
+            OpenAIASRConfig.credentialFields.first { $0.key == "baseURL" }
+        )
+
+        XCTAssertEqual(field.defaultValue, OpenAIASRConfig.defaultBaseURL)
+        XCTAssertEqual(field.placeholder, OpenAIASRConfig.defaultBaseURL)
+        XCTAssertTrue(field.isOptional)
+        XCTAssertFalse(field.isSecure)
+    }
+
+    func testInitDefaultsToOfficialBaseURL() throws {
+        let config = try XCTUnwrap(OpenAIASRConfig(credentials: [
+            "apiKey": "sk-test-key",
+        ]))
+
+        XCTAssertEqual(config.baseURL, OpenAIASRConfig.defaultBaseURL)
+    }
+
+    func testInitAcceptsAndRoundTripsCustomBaseURL() throws {
+        let customBaseURL = "http://localhost:8000/v1"
+        let config = try XCTUnwrap(OpenAIASRConfig(credentials: [
+            "apiKey": "sk-test-key",
+            "model": "whisper-local",
+            "baseURL": "  \(customBaseURL)/\n",
+        ]))
+
+        XCTAssertEqual(config.baseURL, customBaseURL)
+        XCTAssertEqual(config.toCredentials()["baseURL"], customBaseURL)
+    }
+
+    func testInitFallsBackForBlankBaseURL() throws {
+        let config = try XCTUnwrap(OpenAIASRConfig(credentials: [
+            "apiKey": "sk-test-key",
+            "baseURL": "  \n",
+        ]))
+
+        XCTAssertEqual(config.baseURL, OpenAIASRConfig.defaultBaseURL)
+    }
+}


### PR DESCRIPTION
## Summary

- expose an editable `Base URL` field for the OpenAI ASR provider
- keep `https://api.openai.com/v1` as the backward-compatible default
- trim surrounding whitespace and a trailing slash before building the transcription endpoint
- add regression coverage for field metadata, default fallback, custom URLs, and credential round-tripping

## Validation

- `swift build` ✅
- production-source smoke checks for default, custom, blank, and trailing-slash URLs ✅
- test source syntax parsing ✅
- `swift test --filter OpenAIASRConfigTests` could not start locally because the active Command Line Tools installation does not include the XCTest module; the added XCTest cases are included for CI/full-Xcode validation

Closes #213