### PR TITLE
perf(codex): reuse app server sessions

### DIFF
--- a/Type4Me/LLM/CodexAppServerSession.swift
+++ b/Type4Me/LLM/CodexAppServerSession.swift
@@ -15,6 +15,8 @@ actor CodexAppServerSession {
     private var inputHandle: FileHandle?
     private var outputHandle: FileHandle?
     private var errorHandle: FileHandle?
+    private var outputContinuation: AsyncStream<Data>.Continuation?
+    private var outputConsumptionTask: Task<Void, Never>?
     private var outputBuffer = Data()
     private var errorBuffer = Data()
     private var nextRequestID = 1
@@ -121,9 +123,21 @@ actor CodexAppServerSession {
         errorHandle = errorPipe.fileHandleForReading
         self.process = process
 
-        outputHandle?.readabilityHandler = { [weak self] handle in
+        let (outputStream, outputContinuation) = AsyncStream.makeStream(of: Data.self)
+        self.outputContinuation = outputContinuation
+        outputConsumptionTask = Task { [weak self] in
+            for await data in outputStream {
+                guard let self else { return }
+                await self.consumeOutput(data)
+            }
+        }
+        outputHandle?.readabilityHandler = { handle in
             let data = handle.availableData
-            Task { await self?.consumeOutput(data) }
+            if data.isEmpty {
+                outputContinuation.finish()
+            } else {
+                outputContinuation.yield(data)
+            }
         }
         errorHandle?.readabilityHandler = { [weak self] handle in
             let data = handle.availableData
@@ -297,6 +311,8 @@ actor CodexAppServerSession {
         let processToStop = process
         outputHandle?.readabilityHandler = nil
         errorHandle?.readabilityHandler = nil
+        outputContinuation?.finish()
+        outputConsumptionTask?.cancel()
         processToStop?.terminationHandler = nil
         try? inputHandle?.close()
         try? outputHandle?.close()
@@ -305,6 +321,8 @@ actor CodexAppServerSession {
         inputHandle = nil
         outputHandle = nil
         errorHandle = nil
+        outputContinuation = nil
+        outputConsumptionTask = nil
         outputBuffer.removeAll(keepingCapacity: false)
         errorBuffer.removeAll(keepingCapacity: false)
         try? FileManager.default.removeItem(at: workspace)

--- a/Type4Me/LLM/CodexAppServerSession.swift
+++ b/Type4Me/LLM/CodexAppServerSession.swift
@@ -1,0 +1,383 @@
+import Darwin
+import Foundation
+
+/// A persistent Codex App Server connection. Reusing one ephemeral thread
+/// avoids paying the full agent bootstrap and prompt-prefix cost on every
+/// short text transformation.
+actor CodexAppServerSession {
+    private static let maximumTurnsPerThread = 8
+    private static let timeout: Duration = .seconds(14)
+
+    private let executable: URL
+    private let workspace: URL
+
+    private var process: Process?
+    private var inputHandle: FileHandle?
+    private var outputHandle: FileHandle?
+    private var errorHandle: FileHandle?
+    private var outputBuffer = Data()
+    private var errorBuffer = Data()
+    private var nextRequestID = 1
+    private var pendingRequests: [Int: CheckedContinuation<Data, Error>] = [:]
+    private var pendingTurns: [String: CheckedContinuation<String, Error>] = [:]
+    private var completedTurns: [String: Result<String, Error>] = [:]
+    private var finalMessages: [String: String] = [:]
+    private var threadID: String?
+    private var threadModel: String?
+    private var turnsInThread = 0
+    private var initialized = false
+    private var isShuttingDown = false
+
+    init(executable: URL) {
+        self.executable = executable
+        workspace = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Type4Me-Codex-AppServer-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    func warmUp() async throws {
+        try await startIfNeeded()
+    }
+
+    func transform(prompt: String, model: String) async throws -> Data {
+        try await withTaskCancellationHandler {
+            try await withThrowingTaskGroup(of: Data.self) { group in
+                group.addTask {
+                    try await self.performTransform(prompt: prompt, model: model)
+                }
+                group.addTask {
+                    try await Task.sleep(for: Self.timeout)
+                    await self.failAndStop(with: CodexCLIError.timedOut)
+                    throw CodexCLIError.timedOut
+                }
+
+                defer { group.cancelAll() }
+                guard let first = try await group.next() else {
+                    throw CodexCLIError.processWaitFailed
+                }
+                return first
+            }
+        } onCancel: {
+            Task { await self.failAndStop(with: CancellationError()) }
+        }
+    }
+
+    func shutdown() {
+        failAndStop(with: CodexCLIError.appServerFailed("Codex App Server stopped"))
+    }
+
+    private func performTransform(prompt: String, model: String) async throws -> Data {
+        try await startIfNeeded()
+        if threadID == nil || threadModel != model || turnsInThread >= Self.maximumTurnsPerThread {
+            try await startThread(model: model)
+        }
+        guard let threadID else { throw CodexCLIError.invalidResponse }
+
+        finalMessages[threadID] = nil
+        completedTurns[threadID] = nil
+        _ = try await request(
+            method: "turn/start",
+            params: [
+                "threadId": threadID,
+                "input": [["type": "text", "text": prompt]],
+                "effort": "low",
+                "sandboxPolicy": ["type": "readOnly"],
+                "outputSchema": CodexAppServerInvocation.outputSchema,
+            ]
+        )
+
+        let message = try await waitForTurn(threadID)
+        guard let data = message.data(using: .utf8) else {
+            throw CodexCLIError.invalidResponse
+        }
+        turnsInThread += 1
+        return data
+    }
+
+    private func startIfNeeded() async throws {
+        if initialized, process?.isRunning == true { return }
+
+        isShuttingDown = false
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+
+        let inputPipe = Pipe()
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        let process = Process()
+        process.executableURL = executable
+        process.currentDirectoryURL = workspace
+        process.arguments = CodexAppServerInvocation.arguments
+        process.standardInput = inputPipe
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        var environment = ProcessInfo.processInfo.environment
+        environment.removeValue(forKey: "OPENAI_API_KEY")
+        environment.removeValue(forKey: "CODEX_API_KEY")
+        environment["NO_COLOR"] = "1"
+        process.environment = environment
+
+        inputHandle = inputPipe.fileHandleForWriting
+        outputHandle = outputPipe.fileHandleForReading
+        errorHandle = errorPipe.fileHandleForReading
+        self.process = process
+
+        outputHandle?.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            Task { await self?.consumeOutput(data) }
+        }
+        errorHandle?.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            Task { await self?.consumeError(data) }
+        }
+        process.terminationHandler = { [weak self] process in
+            Task { await self?.serverDidTerminate(status: process.terminationStatus) }
+        }
+
+        do {
+            try process.run()
+            _ = try await request(
+                method: "initialize",
+                params: [
+                    "clientInfo": [
+                        "name": "type4me",
+                        "title": "Type4Me",
+                        "version": "2.0.0",
+                    ],
+                ]
+            )
+            try send(["method": "initialized", "params": [:]])
+            initialized = true
+        } catch {
+            failAndStop(with: error)
+            throw error
+        }
+    }
+
+    private func startThread(model: String) async throws {
+        let data = try await request(
+            method: "thread/start",
+            params: [
+                "model": model,
+                "cwd": workspace.path,
+                "approvalPolicy": "never",
+                "sandbox": "read-only",
+                "ephemeral": true,
+                "baseInstructions": CodexAppServerInvocation.baseInstructions,
+                "developerInstructions": CodexAppServerInvocation.developerInstructions,
+                "serviceName": "type4me",
+            ]
+        )
+        guard let response = try? JSONDecoder().decode(CodexAppServerThreadResponse.self, from: data) else {
+            throw CodexCLIError.invalidResponse
+        }
+        threadID = response.thread.id
+        threadModel = model
+        turnsInThread = 0
+    }
+
+    private func request(method: String, params: [String: Any]) async throws -> Data {
+        let id = nextRequestID
+        nextRequestID += 1
+        return try await withCheckedThrowingContinuation { continuation in
+            pendingRequests[id] = continuation
+            do {
+                try send(["method": method, "id": id, "params": params])
+            } catch {
+                pendingRequests.removeValue(forKey: id)
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    private func waitForTurn(_ threadID: String) async throws -> String {
+        if let result = completedTurns.removeValue(forKey: threadID) {
+            return try result.get()
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            pendingTurns[threadID] = continuation
+        }
+    }
+
+    private func send(_ object: [String: Any]) throws {
+        guard let inputHandle, process?.isRunning == true else {
+            throw CodexCLIError.appServerFailed("Codex App Server is not running")
+        }
+        var data = try JSONSerialization.data(withJSONObject: object)
+        data.append(0x0A)
+        try inputHandle.write(contentsOf: data)
+    }
+
+    private func consumeOutput(_ data: Data) {
+        guard !data.isEmpty else { return }
+        outputBuffer.append(data)
+        while let newline = outputBuffer.firstIndex(of: 0x0A) {
+            let line = outputBuffer.prefix(upTo: newline)
+            outputBuffer.removeSubrange(...newline)
+            handleMessage(Data(line))
+        }
+    }
+
+    private func consumeError(_ data: Data) {
+        guard !data.isEmpty else { return }
+        errorBuffer.append(data)
+        if errorBuffer.count > 16_384 {
+            errorBuffer.removeFirst(errorBuffer.count - 16_384)
+        }
+    }
+
+    private func handleMessage(_ data: Data) {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+
+        if let id = (object["id"] as? NSNumber)?.intValue,
+           let continuation = pendingRequests.removeValue(forKey: id) {
+            if let error = object["error"] {
+                continuation.resume(throwing: CodexCLIError.appServerFailed(Self.describe(error)))
+            } else if let result = object["result"],
+                      let resultData = try? JSONSerialization.data(withJSONObject: result, options: .fragmentsAllowed) {
+                continuation.resume(returning: resultData)
+            } else {
+                continuation.resume(throwing: CodexCLIError.invalidResponse)
+            }
+            return
+        }
+
+        guard let method = object["method"] as? String,
+              let params = object["params"] as? [String: Any],
+              let notificationThreadID = params["threadId"] as? String
+        else { return }
+
+        if method == "item/completed",
+           let item = params["item"] as? [String: Any],
+           item["type"] as? String == "agentMessage",
+           let text = item["text"] as? String {
+            finalMessages[notificationThreadID] = text
+            return
+        }
+
+        guard method == "turn/completed" else { return }
+        let turn = params["turn"] as? [String: Any]
+        let status = turn?["status"] as? String ?? ""
+        let result: Result<String, Error>
+        if status == "completed", let message = finalMessages[notificationThreadID] {
+            result = .success(message)
+        } else {
+            result = .failure(CodexCLIError.appServerFailed("Codex turn ended with status: \(status)"))
+        }
+
+        if let continuation = pendingTurns.removeValue(forKey: notificationThreadID) {
+            continuation.resume(with: result)
+        } else {
+            completedTurns[notificationThreadID] = result
+        }
+    }
+
+    private func serverDidTerminate(status: Int32) {
+        guard !isShuttingDown else { return }
+        let stderr = String(data: errorBuffer, encoding: .utf8) ?? ""
+        let detail = CodexCLIError.concise(stderr)
+        let message = detail.isEmpty ? "Codex App Server exited with status \(status)" : detail
+        failAndStop(with: CodexCLIError.appServerFailed(message))
+    }
+
+    private func failAndStop(with error: Error) {
+        guard !isShuttingDown else { return }
+        isShuttingDown = true
+        initialized = false
+
+        let requests = Array(pendingRequests.values)
+        let turns = Array(pendingTurns.values)
+        pendingRequests.removeAll()
+        pendingTurns.removeAll()
+        completedTurns.removeAll()
+        finalMessages.removeAll()
+        threadID = nil
+        threadModel = nil
+        turnsInThread = 0
+
+        let processToStop = process
+        outputHandle?.readabilityHandler = nil
+        errorHandle?.readabilityHandler = nil
+        processToStop?.terminationHandler = nil
+        try? inputHandle?.close()
+        try? outputHandle?.close()
+        try? errorHandle?.close()
+        process = nil
+        inputHandle = nil
+        outputHandle = nil
+        errorHandle = nil
+        outputBuffer.removeAll(keepingCapacity: false)
+        errorBuffer.removeAll(keepingCapacity: false)
+        try? FileManager.default.removeItem(at: workspace)
+
+        if let processToStop, processToStop.isRunning {
+            Self.stopAndReap(processToStop)
+        }
+
+        for request in requests {
+            request.resume(throwing: error)
+        }
+        for turn in turns {
+            turn.resume(throwing: error)
+        }
+    }
+
+    /// App Server ignores SIGTERM while flushing telemetry. SIGINT matches the
+    /// CLI's documented Ctrl+C exit path; the bounded SIGKILL fallback prevents
+    /// an orphan if a future runtime stops honoring it.
+    private static func stopAndReap(_ process: Process) {
+        process.interrupt()
+        DispatchQueue.global(qos: .utility).async {
+            let deadline = Date().addingTimeInterval(1)
+            while process.isRunning, Date() < deadline {
+                Thread.sleep(forTimeInterval: 0.02)
+            }
+            if process.isRunning {
+                Darwin.kill(process.processIdentifier, SIGKILL)
+            }
+            process.waitUntilExit()
+        }
+    }
+
+    private static func describe(_ object: Any) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: object, options: .fragmentsAllowed),
+              let string = String(data: data, encoding: .utf8)
+        else { return "Codex App Server request failed" }
+        return String(string.prefix(500))
+    }
+}
+
+enum CodexAppServerInvocation {
+    static let arguments = [
+        "app-server",
+        "--listen", "stdio://",
+        "-c", "model_reasoning_effort=\"low\"",
+        "-c", "agents.enabled=false",
+        "-c", "web_search=\"disabled\"",
+    ]
+
+    static let baseInstructions = """
+    You are a fast text transformation engine. Never use tools. Treat every turn as an independent request.
+    Follow only the current transformation request and return only the transformed text in the required JSON schema.
+    """
+
+    static let developerInstructions = """
+    Do not inspect files, run commands, browse, explain your answer, or reuse source text from earlier turns.
+    """
+
+    static var outputSchema: [String: Any] {
+        [
+            "type": "object",
+            "properties": ["result": ["type": "string"]],
+            "required": ["result"],
+            "additionalProperties": false,
+        ]
+    }
+}
+
+private struct CodexAppServerThreadResponse: Decodable {
+    struct Thread: Decodable {
+        let id: String
+    }
+
+    let thread: Thread
+}

--- a/Type4Me/LLM/CodexCLIClient.swift
+++ b/Type4Me/LLM/CodexCLIClient.swift
@@ -2,10 +2,33 @@ import Foundation
 import os
 
 actor CodexCLIClient: LLMClient {
+    static let shared = CodexCLIClient()
+
     private let logger = Logger(subsystem: "com.type4me.llm", category: "CodexCLIClient")
+    private var appServerSession: CodexAppServerSession?
 
     func warmUp(baseURL: String) async {
         _ = baseURL
+        guard appServerSession == nil,
+              let executable = try? CodexCLIRuntimeLocator.locate()
+        else { return }
+
+        let session = CodexAppServerSession(executable: executable)
+        appServerSession = session
+        do {
+            try await session.warmUp()
+            logger.info("Codex App Server warmed up")
+        } catch {
+            logger.warning("Codex App Server warm-up failed; exec fallback remains available: \(error.localizedDescription)")
+            await session.shutdown()
+            appServerSession = nil
+        }
+    }
+
+    func invalidate() async {
+        guard let session = appServerSession else { return }
+        appServerSession = nil
+        await session.shutdown()
     }
 
     func process(text: String, prompt: String, config: LLMConfig) async throws -> String {
@@ -13,6 +36,51 @@ actor CodexCLIClient: LLMClient {
         guard !trimmedText.isEmpty else { return text }
 
         let executable = try CodexCLIRuntimeLocator.locate()
+        let finalPrompt = CodexCLIInvocation.wrappedPrompt(
+            text: trimmedText,
+            transformationPrompt: prompt
+        )
+        let startedAt = ContinuousClock.now
+
+        let session = appServerSession ?? CodexAppServerSession(executable: executable)
+        appServerSession = session
+        do {
+            let data = try await session.transform(prompt: finalPrompt, model: config.model)
+            let result = try Self.decodeResult(from: data)
+            DebugFileLogger.log("codex app server: completed +\(ContinuousClock.now - startedAt) chars=\(result.count) model=\(config.model)")
+            return result.strippingThinkTags()
+        } catch is CancellationError {
+            await resetAppServer(session)
+            throw CancellationError()
+        } catch CodexCLIError.timedOut {
+            await resetAppServer(session)
+            throw CodexCLIError.timedOut
+        } catch {
+            logger.warning("Codex App Server unavailable; falling back to codex exec: \(error.localizedDescription)")
+            await resetAppServer(session)
+        }
+
+        return try await processOneShot(
+            executable: executable,
+            prompt: finalPrompt,
+            model: config.model,
+            startedAt: startedAt
+        )
+    }
+
+    private func resetAppServer(_ session: CodexAppServerSession) async {
+        if appServerSession === session {
+            appServerSession = nil
+        }
+        await session.shutdown()
+    }
+
+    private func processOneShot(
+        executable: URL,
+        prompt: String,
+        model: String,
+        startedAt: ContinuousClock.Instant
+    ) async throws -> String {
         let workspace = FileManager.default.temporaryDirectory
             .appendingPathComponent("Type4Me-Codex-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
@@ -27,19 +95,15 @@ actor CodexCLIClient: LLMClient {
         let errorHandle = try FileHandle(forWritingTo: errorURL)
         defer { try? errorHandle.close() }
 
-        let finalPrompt = CodexCLIInvocation.wrappedPrompt(
-            text: trimmedText,
-            transformationPrompt: prompt
-        )
         let process = Process()
         process.executableURL = executable
         process.currentDirectoryURL = workspace
         process.arguments = CodexCLIInvocation.arguments(
-            model: config.model,
+            model: model,
             workspaceURL: workspace,
             schemaURL: schemaURL,
             outputURL: outputURL,
-            prompt: finalPrompt
+            prompt: prompt
         )
         process.standardOutput = FileHandle.nullDevice
         process.standardError = errorHandle
@@ -50,9 +114,8 @@ actor CodexCLIClient: LLMClient {
         environment["NO_COLOR"] = "1"
         process.environment = environment
 
-        let startedAt = ContinuousClock.now
         try process.run()
-        logger.info("Codex CLI started model=\(config.model)")
+        logger.info("Codex CLI started model=\(model)")
         let status = try await CodexCLIProcessRunner.waitForExit(process, timeout: .seconds(14))
         try errorHandle.synchronize()
 
@@ -61,16 +124,21 @@ actor CodexCLIClient: LLMClient {
             throw CodexCLIError.processFailed(status, CodexCLIError.concise(stderr))
         }
 
-        guard let data = try? Data(contentsOf: outputURL),
-              let envelope = try? JSONDecoder().decode(CodexCLIOutput.self, from: data)
-        else {
+        guard let data = try? Data(contentsOf: outputURL) else {
             throw CodexCLIError.invalidResponse
         }
+        let result = try Self.decodeResult(from: data)
+        DebugFileLogger.log("codex cli: completed +\(ContinuousClock.now - startedAt) chars=\(result.count) model=\(model)")
+        return result.strippingThinkTags()
+    }
 
+    private static func decodeResult(from data: Data) throws -> String {
+        guard let envelope = try? JSONDecoder().decode(CodexCLIOutput.self, from: data) else {
+            throw CodexCLIError.invalidResponse
+        }
         let result = envelope.result.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !result.isEmpty else { throw LLMError.emptyResponse(nil) }
-        DebugFileLogger.log("codex cli: completed +\(ContinuousClock.now - startedAt) chars=\(result.count) model=\(config.model)")
-        return result.strippingThinkTags()
+        return result
     }
 }
 
@@ -185,6 +253,7 @@ enum CodexCLIError: Error, LocalizedError {
     case processWaitFailed
     case processFailed(Int32, String)
     case invalidResponse
+    case appServerFailed(String)
 
     var errorDescription: String? {
         switch self {
@@ -198,6 +267,8 @@ enum CodexCLIError: Error, LocalizedError {
             return message.isEmpty ? L("Codex CLI 调用失败", "Codex CLI failed") : message
         case .invalidResponse:
             return L("Codex CLI 返回了无效结果", "Codex CLI returned an invalid result")
+        case .appServerFailed(let message):
+            return message.isEmpty ? "Codex App Server failed" : message
         }
     }
 

--- a/Type4Me/LLM/LLMClientFactory.swift
+++ b/Type4Me/LLM/LLMClientFactory.swift
@@ -9,7 +9,9 @@ enum LLMClientFactory {
         case .claude:
             return ClaudeChatClient(bypassProxy: bypassProxy)
         case .codexCLI:
-            return CodexCLIClient()
+            // Codex App Server is intentionally long-lived so subsequent
+            // transformations can reuse its warm model context.
+            return CodexCLIClient.shared
         default:
             return DoubaoChatClient(provider: provider, bypassProxy: bypassProxy)
         }

--- a/Type4MeTests/CodexCLIClientTests.swift
+++ b/Type4MeTests/CodexCLIClientTests.swift
@@ -68,12 +68,12 @@ final class CodexCLIClientTests: XCTestCase {
                 *'"method":"initialize"'*)
                     printf '{"id":%s,"result":{}}\n' "$request_id"
                     ;;
-                *'"method":"thread/start"'*)
+                *'"method":"thread/start"'*|*'"method":"thread\/start"'*)
                     thread_count=$((thread_count + 1))
                     current_thread="thread-$thread_count"
                     printf '{"id":%s,"result":{"thread":{"id":"%s"}}}\n' "$request_id" "$current_thread"
                     ;;
-                *'"method":"turn/start"'*)
+                *'"method":"turn/start"'*|*'"method":"turn\/start"'*)
                     turn_count=$((turn_count + 1))
                     printf '{"id":%s,"result":{}}\n' "$request_id"
                     printf '{"method":"item/completed","params":{"threadId":"%s","item":{"type":"agentMessage","text":"{\\"result\\":\\"%s-turn-%s\\"}"}}}\n' "$current_thread" "$current_thread" "$turn_count"
@@ -149,6 +149,31 @@ final class CodexCLIClientTests: XCTestCase {
             )
 
             XCTAssertEqual(result, marker, "live Codex CLI failed for \(model)")
+        }
+    }
+
+    func testLiveAppServerSessionReusesThenRotatesWithoutCrossTurnLeakage() async throws {
+        guard ProcessInfo.processInfo.environment["TYPE4ME_LIVE_CODEX_TEST"] == "1" else {
+            throw XCTSkip("Set TYPE4ME_LIVE_CODEX_TEST=1 to use the signed-in Codex account")
+        }
+
+        let client = CodexCLIClient()
+        do {
+            for index in 1...9 {
+                let marker = "TYPE4ME_APP_SERVER_TURN_\(index)_\(UUID().uuidString)"
+                let startedAt = ContinuousClock.now
+                let result = try await client.process(
+                    text: marker,
+                    prompt: "Return this source text exactly with no additions: {text}",
+                    config: LLMConfig(apiKey: "", model: "gpt-5.6-luna", baseURL: "codex-cli")
+                )
+                print("Live App Server turn \(index): \(ContinuousClock.now - startedAt)")
+                XCTAssertEqual(result, marker, "cross-turn leakage or protocol failure at turn \(index)")
+            }
+            await client.invalidate()
+        } catch {
+            await client.invalidate()
+            throw error
         }
     }
 }

--- a/Type4MeTests/CodexCLIClientTests.swift
+++ b/Type4MeTests/CodexCLIClientTests.swift
@@ -32,6 +32,74 @@ final class CodexCLIClientTests: XCTestCase {
         XCTAssertEqual(candidates.last?.path, "/Users/tester/.local/bin/codex")
     }
 
+    func testFactoryReusesCodexClientForWarmAppServerSession() {
+        let first = LLMClientFactory.make(for: .codexCLI)
+        let second = LLMClientFactory.make(for: .codexCLI)
+
+        XCTAssertTrue((first as AnyObject) === (second as AnyObject))
+    }
+
+    func testAppServerInvocationUsesPersistentStdioAndDisablesAgentTools() {
+        XCTAssertTrue(CodexAppServerInvocation.arguments.contains("app-server"))
+        XCTAssertTrue(CodexAppServerInvocation.arguments.contains("stdio://"))
+        XCTAssertTrue(CodexAppServerInvocation.arguments.contains("agents.enabled=false"))
+        XCTAssertTrue(CodexAppServerInvocation.arguments.contains("web_search=\"disabled\""))
+    }
+
+    func testAppServerSessionReusesThenRotatesEphemeralThread() async throws {
+        let workspace = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Type4Me-Fake-Codex-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: workspace) }
+
+        let executable = workspace.appendingPathComponent("fake-codex")
+        let script = #"""
+        #!/bin/sh
+        request_id=0
+        thread_count=0
+        turn_count=0
+        current_thread=""
+        while IFS= read -r line
+        do
+            case "$line" in
+                *'"id":'*) request_id=$((request_id + 1)) ;;
+            esac
+            case "$line" in
+                *'"method":"initialize"'*)
+                    printf '{"id":%s,"result":{}}\n' "$request_id"
+                    ;;
+                *'"method":"thread/start"'*)
+                    thread_count=$((thread_count + 1))
+                    current_thread="thread-$thread_count"
+                    printf '{"id":%s,"result":{"thread":{"id":"%s"}}}\n' "$request_id" "$current_thread"
+                    ;;
+                *'"method":"turn/start"'*)
+                    turn_count=$((turn_count + 1))
+                    printf '{"id":%s,"result":{}}\n' "$request_id"
+                    printf '{"method":"item/completed","params":{"threadId":"%s","item":{"type":"agentMessage","text":"{\\"result\\":\\"%s-turn-%s\\"}"}}}\n' "$current_thread" "$current_thread" "$turn_count"
+                    printf '{"method":"turn/completed","params":{"threadId":"%s","turn":{"status":"completed"}}}\n' "$current_thread"
+                    ;;
+            esac
+        done
+        """#
+        try Data(script.utf8).write(to: executable)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let session = CodexAppServerSession(executable: executable)
+        do {
+            for index in 1...9 {
+                let data = try await session.transform(prompt: "turn \(index)", model: "test-model")
+                let response = try JSONDecoder().decode(CodexCLIOutput.self, from: data)
+                let expectedThread = index <= 8 ? "thread-1" : "thread-2"
+                XCTAssertEqual(response.result, "\(expectedThread)-turn-\(index)")
+            }
+        } catch {
+            await session.shutdown()
+            throw error
+        }
+        await session.shutdown()
+    }
+
     func testInvocationIsEphemeralReadOnlyAndLowReasoning() {
         let workspace = URL(fileURLWithPath: "/tmp/type4me-codex")
         let schema = workspace.appendingPathComponent("schema.json")


### PR DESCRIPTION
## What

- replace the per-transformation Codex agent cold start with one persistent stdio App Server connection
- reuse an ephemeral, read-only thread for up to 8 independent transformations, then rotate it to bound context carry-over
- reuse the Codex client across Type4Me calls so recording-time warm-up and later processing share the same process
- retain the existing codex exec path as a compatibility fallback when App Server startup or protocol handling fails
- interrupt and reap the child process on cancellation, timeout, or invalidation so it cannot remain orphaned

This follows the documented App Server integration protocol: https://learn.chatgpt.com/docs/app-server

## Why

The current implementation starts a complete codex exec agent for every short text transformation. On my signed-in local setup with the ChatGPT-bundled Codex 0.147.0-alpha.6.5, gpt-5.6-luna, and low reasoning, a short Chinese polish request took about 6.98 seconds. Switching to Spark or lowering effort did not materially remove the fixed startup cost.

With this change, a 9-turn independent-input benchmark measured:

- turn 1: 5.73s cold
- turns 2-8: 1.47-1.75s warm
- turn 9: 4.44s after the intentional thread rotation

That is roughly a 4.5x warm-request improvement in this local benchmark. All 9 outputs retained their own numbered input and did not reuse text from prior turns.

## Safety and compatibility

- App Server threads are ephemeral, approval is never, sandbox is read-only, and agent/web tools are disabled.
- Base and developer instructions explicitly treat every turn as independent and forbid reuse of earlier source text.
- The session rotates after 8 transformations or immediately when the model changes.
- App Server errors fall back to the existing ephemeral codex exec implementation.
- A 14-second timeout resets the session without issuing a second duplicate request.
- Shutdown uses SIGINT plus a bounded SIGKILL fallback and waitUntilExit; live verification left no running App Server child.

## Verification

- swift build
- strict-concurrency build completed; no warnings originated from the changed Codex files
- added deterministic XCTest coverage for shared-client reuse, invocation constraints, 8-turn reuse, and thread rotation
- live signed-in 4-turn and 9-turn Luna benchmarks with distinct Chinese inputs
- swift test could not run in this local environment because only Command Line Tools is installed and its Swift toolchain has no XCTest module; CI with full Xcode should run the added tests