### PR TITLE
feat: add per-mode punctuation handling

### DIFF
--- a/Type4Me/Services/ModeStorage.swift
+++ b/Type4Me/Services/ModeStorage.swift
@@ -42,12 +42,14 @@ struct ModeStorage {
                 var d = ProcessingMode.direct
                 d.hotkeyBindings = mode.hotkeyBindings
                 d.shortTextExemption = mode.shortTextExemption
+                d.punctuationMode = mode.punctuationMode
                 return d
             }
             if mode.id == ProcessingMode.intelliSenseId {
                 var d = ProcessingMode.intelliSense
                 d.hotkeyBindings = mode.hotkeyBindings
                 d.shortTextExemption = mode.shortTextExemption
+                d.punctuationMode = mode.punctuationMode
                 return d
             }
             if mode.id == ProcessingMode.smartDirectId {
@@ -70,6 +72,7 @@ struct ModeStorage {
                 d.hotkeyBindings = mode.hotkeyBindings
                 d.description = mode.description
                 d.shortTextExemption = mode.shortTextExemption
+                d.punctuationMode = mode.punctuationMode
                 // If user customized the prompt, keep theirs
                 if !isLegacy {
                     d.name = mode.name
@@ -81,6 +84,7 @@ struct ModeStorage {
             if mode.id == ProcessingMode.selectionAskId {
                 var d = ProcessingMode.selectionAsk
                 d.hotkeyBindings = mode.hotkeyBindings
+                d.punctuationMode = mode.punctuationMode
                 if mode.prompt != ProcessingMode.selectionAsk.prompt,
                    !selectionAskPromptIsLegacy(mode.prompt) {
                     d.name = mode.name
@@ -92,11 +96,13 @@ struct ModeStorage {
             if mode.id == ProcessingMode.macActionId {
                 var d = ProcessingMode.macAction
                 d.hotkeyBindings = mode.hotkeyBindings
+                d.punctuationMode = mode.punctuationMode
                 return d
             }
             if mode.id == ProcessingMode.translationModeId {
                 var canonical = ProcessingMode.translation()
                 canonical.hotkeyBindings = mode.hotkeyBindings
+                canonical.punctuationMode = mode.punctuationMode
                 let storedCode = mode.translationTargetLanguageCode?
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 canonical.translationTargetLanguageCode =
@@ -112,6 +118,7 @@ struct ModeStorage {
                     var migrated = ProcessingMode.promptOptimize
                     migrated.hotkeyBindings = mode.hotkeyBindings
                     migrated.description = mode.description
+                    migrated.punctuationMode = mode.punctuationMode
                     return migrated
                 }
                 return mode
@@ -211,6 +218,7 @@ struct ModeStorage {
         }
         migrated.hotkeyBindings = mode.hotkeyBindings
         migrated.shortTextExemption = mode.shortTextExemption
+        migrated.punctuationMode = mode.punctuationMode
         migrated.isBuiltin = false
         return migrated
     }

--- a/Type4Me/Services/TextOutputFormatter.swift
+++ b/Type4Me/Services/TextOutputFormatter.swift
@@ -39,21 +39,82 @@ enum TrailingPunctuationMode: String {
     case all
 }
 
+enum ModePunctuationMode: String, Codable, CaseIterable, Sendable {
+    case inherit
+    case preserve
+    case stripTrailing
+    case questionsAndExclamationsOnly
+    case removeAll
+
+    fileprivate var override: OutputPunctuationMode? {
+        switch self {
+        case .inherit: nil
+        case .preserve: .preserve
+        case .stripTrailing: .stripTrailing
+        case .questionsAndExclamationsOnly: .questionsAndExclamationsOnly
+        case .removeAll: .removeAll
+        }
+    }
+}
+
+enum OutputPunctuationMode: Equatable {
+    case preserve
+    case stripPeriods
+    case stripTrailing
+    case questionsAndExclamationsOnly
+    case removeAll
+}
+
 struct TextOutputFormattingOptions: Equatable {
     var cjkSpacingMode: CJKSpacingMode
     var usesCornerQuotes: Bool
-    var trailingPunctuationMode: TrailingPunctuationMode
+    var punctuationMode: OutputPunctuationMode
 
-    static func current(userDefaults: UserDefaults = .standard) -> Self {
+    init(
+        cjkSpacingMode: CJKSpacingMode,
+        usesCornerQuotes: Bool,
+        punctuationMode: OutputPunctuationMode
+    ) {
+        self.cjkSpacingMode = cjkSpacingMode
+        self.usesCornerQuotes = usesCornerQuotes
+        self.punctuationMode = punctuationMode
+    }
+
+    /// Compatibility initializer for callers that still express the global
+    /// trailing-punctuation preference directly.
+    init(
+        cjkSpacingMode: CJKSpacingMode,
+        usesCornerQuotes: Bool,
+        trailingPunctuationMode: TrailingPunctuationMode
+    ) {
+        self.init(
+            cjkSpacingMode: cjkSpacingMode,
+            usesCornerQuotes: usesCornerQuotes,
+            punctuationMode: Self.outputMode(for: trailingPunctuationMode)
+        )
+    }
+
+    static func current(
+        userDefaults: UserDefaults = .standard,
+        modePunctuation: ModePunctuationMode = .inherit
+    ) -> Self {
         let usesCornerQuotes = userDefaults.object(forKey: CornerQuotePreference.storageKey) as? Bool
             ?? CornerQuotePreference.defaultValue
-        let punctuation = userDefaults.string(forKey: "tf_stripTrailingPunctuation")
+        let trailing = userDefaults.string(forKey: "tf_stripTrailingPunctuation")
             .flatMap(TrailingPunctuationMode.init(rawValue:)) ?? .off
         return Self(
             cjkSpacingMode: CJKSpacingMode.current(userDefaults: userDefaults),
             usesCornerQuotes: usesCornerQuotes,
-            trailingPunctuationMode: punctuation
+            punctuationMode: modePunctuation.override ?? outputMode(for: trailing)
         )
+    }
+
+    private static func outputMode(for mode: TrailingPunctuationMode) -> OutputPunctuationMode {
+        switch mode {
+        case .off: .preserve
+        case .period: .stripPeriods
+        case .all: .stripTrailing
+        }
     }
 }
 
@@ -71,7 +132,20 @@ enum TextOutputFormatter {
         case .remove:
             result = removingSpacesAdjacentToHan(in: result)
         }
-        return strippingTrailingPunctuation(from: result, mode: options.trailingPunctuationMode)
+        result = applyingPunctuationMode(options.punctuationMode, to: result)
+
+        // Removing punctuation can create a new CJK/Latin boundary that did not
+        // exist during the spacing pass. Stabilize that boundary inside the
+        // punctuation stage so formatting remains idempotent.
+        if options.cjkSpacingMode == .pangu {
+            switch options.punctuationMode {
+            case .questionsAndExclamationsOnly, .removeAll:
+                result = PanguSpacing.spacingText(result)
+            case .preserve, .stripPeriods, .stripTrailing:
+                break
+            }
+        }
+        return result
     }
 
     static func format(_ text: String, userDefaults: UserDefaults = .standard) -> String {
@@ -122,26 +196,49 @@ enum TextOutputFormatter {
         return result
     }
 
-    private static func strippingTrailingPunctuation(
-        from text: String,
-        mode: TrailingPunctuationMode
+    private static let cjkPunctuation = CharacterSet(charactersIn:
+        "\u{3002}\u{FF0C}\u{FF01}\u{FF1F}\u{FF1B}\u{FF1A}\u{3001}\u{2026}\u{2014}\u{FF5E}\u{00B7}" +
+        "\u{300C}\u{300D}\u{300E}\u{300F}\u{3010}\u{3011}\u{FF08}\u{FF09}\u{300A}\u{300B}" +
+        "\u{201C}\u{201D}\u{2018}\u{2019}"
+    )
+    private static let punctuation = CharacterSet.punctuationCharacters.union(cjkPunctuation)
+    private static let questionAndExclamationMarks = CharacterSet(charactersIn: "!?！？")
+
+    private static func applyingPunctuationMode(
+        _ mode: OutputPunctuationMode,
+        to text: String
     ) -> String {
-        guard mode != .off, !text.isEmpty else { return text }
-        var result = text
-        if mode == .period {
+        guard !text.isEmpty else { return text }
+
+        switch mode {
+        case .preserve:
+            return text
+        case .stripPeriods:
+            var result = text
             while result.hasSuffix("。") || result.hasSuffix(".") {
                 result.removeLast()
             }
             return result
+        case .stripTrailing:
+            var result = text
+            while let last = result.unicodeScalars.last, punctuation.contains(last) {
+                result.unicodeScalars.removeLast()
+            }
+            return result
+        case .questionsAndExclamationsOnly:
+            return removingPunctuation(from: text, preserving: questionAndExclamationMarks)
+        case .removeAll:
+            return removingPunctuation(from: text, preserving: nil)
         }
+    }
 
-        let cjkPunctuation = "\u{3002}\u{FF0C}\u{FF01}\u{FF1F}\u{FF1B}\u{FF1A}\u{3001}\u{2026}\u{2014}\u{FF5E}\u{00B7}\u{300C}\u{300D}\u{300E}\u{300F}\u{3010}\u{3011}\u{FF08}\u{FF09}\u{300A}\u{300B}\u{201C}\u{201D}\u{2018}\u{2019}"
-        let trailing = CharacterSet.punctuationCharacters
-            .union(CharacterSet(charactersIn: cjkPunctuation))
-        while let last = result.unicodeScalars.last, trailing.contains(last) {
-            result.unicodeScalars.removeLast()
-        }
-        return result
+    private static func removingPunctuation(
+        from text: String,
+        preserving preserved: CharacterSet?
+    ) -> String {
+        String(text.unicodeScalars.filter { scalar in
+            !punctuation.contains(scalar) || preserved?.contains(scalar) == true
+        })
     }
 }
 

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -145,6 +145,22 @@ actor RecognitionSession {
         await promptForCurrentMode(text: text)
     }
 
+    /// Pure formatting seam used to verify that every session completion path
+    /// resolves punctuation from the mode selected for processing.
+    static func formattedOutputText(
+        _ text: String,
+        mode: ProcessingMode,
+        userDefaults: UserDefaults = .standard
+    ) -> String {
+        TextOutputFormatter.format(
+            text,
+            options: .current(
+                userDefaults: userDefaults,
+                modePunctuation: mode.punctuationMode
+            )
+        )
+    }
+
     // MARK: - Dependencies
 
     private let audioEngine = AudioCaptureEngine()
@@ -1849,7 +1865,7 @@ actor RecognitionSession {
                 }
             }
 
-            finalText = TextOutputFormatter.format(finalText)
+            finalText = formattedOutputText(finalText)
 
             state = .injecting
             let defaults = UserDefaults.standard
@@ -2169,7 +2185,11 @@ actor RecognitionSession {
     }
 
     private func normalizedRecoveryText(_ text: String) -> String {
-        TextOutputFormatter.format(text.trimmingCharacters(in: .whitespacesAndNewlines))
+        formattedOutputText(text.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    private func formattedOutputText(_ text: String) -> String {
+        Self.formattedOutputText(text, mode: currentMode)
     }
 
     private func injectRecoveryPartial(_ text: String) {

--- a/Type4Me/UI/AppState.swift
+++ b/Type4Me/UI/AppState.swift
@@ -186,6 +186,9 @@ struct ProcessingMode: Codable, Identifiable, Equatable, Hashable {
     /// BCP 47 target code used only by the built-in Translation mode. Keeping
     /// this as a String preserves future codes written by newer app versions.
     var translationTargetLanguageCode: String?
+    /// Per-mode punctuation behavior. `.inherit` preserves the existing global
+    /// output-formatting preference for backwards compatibility.
+    var punctuationMode: ModePunctuationMode
 
     enum HotkeyStyle: String, Codable, CaseIterable {
         case hold    // press and hold to record
@@ -221,7 +224,8 @@ struct ProcessingMode: Codable, Identifiable, Equatable, Hashable {
         hotkeyBindings: [HotkeyBinding] = [],
         shortTextExemption: Int = 0,
         executionKind: ExecutionKind = .recording,
-        translationTargetLanguageCode: String? = nil
+        translationTargetLanguageCode: String? = nil,
+        punctuationMode: ModePunctuationMode = .inherit
     ) {
         self.id = id
         self.name = name
@@ -233,11 +237,13 @@ struct ProcessingMode: Codable, Identifiable, Equatable, Hashable {
         self.shortTextExemption = shortTextExemption
         self.executionKind = executionKind
         self.translationTargetLanguageCode = translationTargetLanguageCode
+        self.punctuationMode = punctuationMode
     }
 
     enum CodingKeys: String, CodingKey {
         case id, name, description, prompt, isBuiltin, processingLabel
         case hotkeyBindings, shortTextExemption, executionKind, translationTargetLanguageCode
+        case punctuationMode
         // Legacy single-hotkey keys, decoded for backward compatibility only.
         case hotkeyCode, hotkeyModifiers, hotkeyStyle
     }
@@ -271,6 +277,12 @@ struct ProcessingMode: Codable, Identifiable, Equatable, Hashable {
             String.self,
             forKey: .translationTargetLanguageCode
         )
+        let punctuationRawValue = try? container.decodeIfPresent(
+            String.self,
+            forKey: .punctuationMode
+        )
+        punctuationMode = punctuationRawValue
+            .flatMap(ModePunctuationMode.init(rawValue:)) ?? .inherit
     }
 
     func encode(to encoder: Encoder) throws {
@@ -289,6 +301,7 @@ struct ProcessingMode: Codable, Identifiable, Equatable, Hashable {
             translationTargetLanguageCode,
             forKey: .translationTargetLanguageCode
         )
+        try container.encode(punctuationMode.rawValue, forKey: .punctuationMode)
     }
 
     // MARK: - Built-in Mode IDs (stable, never change)
@@ -408,6 +421,13 @@ struct ProcessingMode: Codable, Identifiable, Equatable, Hashable {
     }
 
     var isSmartDirect: Bool { id == Self.smartDirectId }
+
+    /// Only modes whose result is pasted into the target application expose
+    /// per-mode output formatting. Ask Anything renders in its own panel, while
+    /// Mac Action executes a tool call instead of producing pasted text.
+    var supportsOutputFormatting: Bool {
+        executionKind == .recording && id != Self.macActionId
+    }
 
     // MARK: - Default Custom Mode IDs (stable, for fresh installs)
     static let promptOptimizeId = UUID(uuidString: "5D0A24D4-ECE9-4C13-9FC5-F9C81BD6B1C3")!

--- a/Type4Me/UI/Settings/ModesSettingsTab.swift
+++ b/Type4Me/UI/Settings/ModesSettingsTab.swift
@@ -425,15 +425,21 @@ struct ModesSettingsTab: View {
         if mode.id == ProcessingMode.translationModeId {
             translationModeDetail(mode)
         } else if mode.id == ProcessingMode.intelliSenseId {
-            IntelliSenseModeDetail(
-                mode: mode,
-                onEditBinding: { editBinding(mode, $0) },
-                onDeleteBinding: { deleteBinding(mode.id, $0) },
-                onAddBinding: { addBinding(mode) }
-            )
+            VStack(alignment: .leading, spacing: 18) {
+                IntelliSenseModeDetail(
+                    mode: mode,
+                    onEditBinding: { editBinding(mode, $0) },
+                    onDeleteBinding: { deleteBinding(mode.id, $0) },
+                    onAddBinding: { addBinding(mode) }
+                )
+                PunctuationModeSection(selection: punctuationModeBinding(for: mode.id))
+            }
         } else if mode.isBuiltin && mode.id != ProcessingMode.formalWritingId {
             VStack(alignment: .leading, spacing: 18) {
                 builtinModeDetail(mode)
+                if mode.supportsOutputFormatting {
+                    PunctuationModeSection(selection: punctuationModeBinding(for: mode.id))
+                }
                 HotkeySectionView(
                     bindings: mode.hotkeyBindings,
                     onEdit: { editBinding(mode, $0) },
@@ -594,6 +600,8 @@ struct ModesSettingsTab: View {
                 }
             }
 
+            PunctuationModeSection(selection: punctuationModeBinding(for: mode.id))
+
             HotkeySectionView(
                 bindings: mode.hotkeyBindings,
                 onEdit: { editBinding(mode, $0) },
@@ -627,6 +635,21 @@ struct ModesSettingsTab: View {
                 )
             }
         }
+    }
+
+    private func punctuationModeBinding(for modeId: UUID) -> Binding<ModePunctuationMode> {
+        Binding(
+            get: {
+                modes.first(where: { $0.id == modeId })?.punctuationMode ?? .inherit
+            },
+            set: { newValue in
+                guard let index = modes.firstIndex(where: { $0.id == modeId }),
+                      modes[index].supportsOutputFormatting
+                else { return }
+                modes[index].punctuationMode = newValue
+                persistModes()
+            }
+        )
     }
 
     private var selectionAskDescription: some View {
@@ -1525,6 +1548,68 @@ private struct HotkeyRecordingSheet: View {
     }
 }
 
+// MARK: - Output Formatting
+
+private struct PunctuationModeSection: View {
+    @Binding var selection: ModePunctuationMode
+
+    private let options: [(ModePunctuationMode, String)] = [
+        (.inherit, L("跟随通用设置", "Follow General Settings")),
+        (.preserve, L("保留全部标点", "Keep All Punctuation")),
+        (.stripTrailing, L("去掉句末标点", "Remove Trailing Punctuation")),
+        (.questionsAndExclamationsOnly, L("仅保留问号和感叹号", "Keep Only ? and !")),
+        (.removeAll, L("去掉全部标点", "Remove All Punctuation")),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(L("输出格式", "Output Format").uppercased())
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(TF.settingsTextTertiary)
+
+            Text(L("标点处理", "Punctuation"))
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(TF.settingsTextSecondary)
+
+            Menu {
+                ForEach(options, id: \.0) { option in
+                    Button {
+                        selection = option.0
+                    } label: {
+                        if option.0 == selection {
+                            Label(option.1, systemImage: "checkmark")
+                        } else {
+                            Text(option.1)
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Text(options.first(where: { $0.0 == selection })?.1 ?? selection.rawValue)
+                        .font(.system(size: 13))
+                        .foregroundStyle(TF.settingsText)
+                    Spacer()
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(TF.settingsTextTertiary)
+                }
+                .padding(.horizontal, 12)
+                .frame(height: 36)
+                .background(RoundedRectangle(cornerRadius: 8).fill(TF.settingsCardAlt))
+            }
+            .buttonStyle(.plain)
+
+            Text(L(
+                "仅覆盖当前模式；“跟随通用设置”会继续使用通用设置中的句末标点规则。",
+                "Applies only to this mode. Follow General Settings keeps using the global trailing-punctuation preference."
+            ))
+            .font(.system(size: 10))
+            .foregroundStyle(TF.settingsTextTertiary)
+            .lineSpacing(2)
+        }
+    }
+}
+
 // MARK: - Mode Detail Inner
 
 private struct ModeDetailInner: View {
@@ -1541,6 +1626,7 @@ private struct ModeDetailInner: View {
     @State private var modeDescription = ""
     @State private var processingLabel = ""
     @State private var prompt = ""
+    @State private var punctuationMode: ModePunctuationMode = .inherit
     @State private var saveStatus: SaveStatus = .clean
 
     private enum SaveStatus: Equatable {
@@ -1553,6 +1639,7 @@ private struct ModeDetailInner: View {
             || processingLabel != mode.processingLabel
             || prompt != mode.prompt
             || (Int(shortTextExemption) ?? 0) != mode.shortTextExemption
+            || punctuationMode != mode.punctuationMode
     }
 
     private let exemptionOptions: [(value: String, label: String)] = [
@@ -1632,6 +1719,7 @@ private struct ModeDetailInner: View {
                     updated.processingLabel = processingLabel
                     updated.prompt = prompt
                     updated.shortTextExemption = Int(shortTextExemption) ?? 0
+                    updated.punctuationMode = punctuationMode
                     onSave(updated)
                     withAnimation { saveStatus = .saved }
                     onDraftChange(updated, false)
@@ -1688,6 +1776,11 @@ private struct ModeDetailInner: View {
                 }
                 .frame(width: 176)
             }
+
+            if mode.supportsOutputFormatting {
+                PunctuationModeSection(selection: $punctuationMode)
+            }
+
             HotkeySectionView(
                 bindings: mode.hotkeyBindings,
                 onEdit: onEditBinding,
@@ -1722,6 +1815,7 @@ private struct ModeDetailInner: View {
         .onChange(of: processingLabel) { _, _ in reportDraft() }
         .onChange(of: prompt) { _, _ in reportDraft() }
         .onChange(of: shortTextExemption) { _, _ in reportDraft() }
+        .onChange(of: punctuationMode) { _, _ in reportDraft() }
     }
 
     private func reportDraft() {
@@ -1732,6 +1826,7 @@ private struct ModeDetailInner: View {
         updated.processingLabel = processingLabel
         updated.prompt = prompt
         updated.shortTextExemption = Int(shortTextExemption) ?? 0
+        updated.punctuationMode = punctuationMode
         onDraftChange(updated, isDirty)
     }
 
@@ -1741,6 +1836,7 @@ private struct ModeDetailInner: View {
         processingLabel = mode.processingLabel
         prompt = mode.prompt
         shortTextExemption = String(mode.shortTextExemption)
+        punctuationMode = mode.punctuationMode
         saveStatus = .clean
         onDraftChange(mode, false)
     }
@@ -1762,6 +1858,7 @@ private struct FormalWritingDetailInner: View {
     @State private var modeDescription = ""
     @State private var processingLabel = ""
     @State private var prompt = ""
+    @State private var punctuationMode: ModePunctuationMode = .inherit
     @State private var saveStatus: SaveStatus = .clean
     @State private var promptBeforeUpdate: String?
 
@@ -1775,6 +1872,7 @@ private struct FormalWritingDetailInner: View {
             || processingLabel != mode.processingLabel
             || prompt != mode.prompt
             || (Int(shortTextExemption) ?? 0) != mode.shortTextExemption
+            || punctuationMode != mode.punctuationMode
     }
 
     private var isLatestPrompt: Bool {
@@ -1869,6 +1967,7 @@ private struct FormalWritingDetailInner: View {
                     updated.processingLabel = processingLabel
                     updated.prompt = prompt
                     updated.shortTextExemption = Int(shortTextExemption) ?? 0
+                    updated.punctuationMode = punctuationMode
                     onSave(updated)
                     promptBeforeUpdate = nil
                     withAnimation { saveStatus = .saved }
@@ -1929,6 +2028,8 @@ private struct FormalWritingDetailInner: View {
                 .frame(width: 176)
             }
 
+            PunctuationModeSection(selection: $punctuationMode)
+
             // Hotkeys
             HotkeySectionView(
                 bindings: mode.hotkeyBindings,
@@ -1964,6 +2065,7 @@ private struct FormalWritingDetailInner: View {
         .onChange(of: processingLabel) { _, _ in reportDraft() }
         .onChange(of: prompt) { _, _ in reportDraft() }
         .onChange(of: shortTextExemption) { _, _ in reportDraft() }
+        .onChange(of: punctuationMode) { _, _ in reportDraft() }
     }
 
     private func reportDraft() {
@@ -1974,6 +2076,7 @@ private struct FormalWritingDetailInner: View {
         updated.processingLabel = processingLabel
         updated.prompt = prompt
         updated.shortTextExemption = Int(shortTextExemption) ?? 0
+        updated.punctuationMode = punctuationMode
         onDraftChange(updated, isDirty)
     }
 
@@ -2014,6 +2117,7 @@ private struct FormalWritingDetailInner: View {
         processingLabel = mode.processingLabel
         prompt = mode.prompt
         shortTextExemption = String(mode.shortTextExemption)
+        punctuationMode = mode.punctuationMode
         saveStatus = .clean
         onDraftChange(mode, false)
     }

--- a/Type4MeTests/ModeStorageTests.swift
+++ b/Type4MeTests/ModeStorageTests.swift
@@ -35,6 +35,77 @@ final class ModeStorageTests: XCTestCase {
         XCTAssertTrue(savedJSON.contains("\"description\""))
     }
 
+    func testMissingAndUnknownPunctuationModesDefaultToInherit() throws {
+        let id = UUID()
+        let missing = """
+        {"id":"\(id.uuidString)","name":"Legacy","prompt":"Do {text}","isBuiltin":false,"processingLabel":"处理中"}
+        """
+        let unknown = """
+        {"id":"\(id.uuidString)","name":"Future","prompt":"Do {text}","isBuiltin":false,"processingLabel":"处理中","punctuationMode":"future-mode"}
+        """
+
+        XCTAssertEqual(
+            try JSONDecoder().decode(ProcessingMode.self, from: Data(missing.utf8)).punctuationMode,
+            .inherit
+        )
+        XCTAssertEqual(
+            try JSONDecoder().decode(ProcessingMode.self, from: Data(unknown.utf8)).punctuationMode,
+            .inherit
+        )
+    }
+
+    func testPunctuationModePersistsAcrossBuiltinMigrationsAndCustomModes() throws {
+        let suite = "ModeStorageTests.Punctuation.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(true, forKey: "tf_agentModeSeeded")
+        defaults.set(true, forKey: "tf_shortTextExemptionMigrated")
+
+        let styles: [ModePunctuationMode] = [
+            .preserve,
+            .stripTrailing,
+            .questionsAndExclamationsOnly,
+            .removeAll,
+            .preserve,
+            .stripTrailing,
+        ]
+        var modes = ProcessingMode.builtins
+        for index in modes.indices {
+            modes[index].punctuationMode = styles[index]
+        }
+        let custom = ProcessingMode(
+            id: UUID(),
+            name: "Casual",
+            prompt: "Do {text}",
+            isBuiltin: false,
+            punctuationMode: .removeAll
+        )
+        modes.append(custom)
+
+        let storage = ModeStorage(fileURL: testURL, userDefaults: defaults)
+        try storage.save(modes)
+        let loaded = storage.load()
+
+        for (index, mode) in modes.dropLast().enumerated() {
+            XCTAssertEqual(
+                loaded.first(where: { $0.id == mode.id })?.punctuationMode,
+                styles[index],
+                mode.name
+            )
+        }
+        XCTAssertEqual(loaded.first(where: { $0.id == custom.id })?.punctuationMode, .removeAll)
+    }
+
+    func testOutputFormattingCapabilityMatchesModeBehavior() {
+        XCTAssertTrue(ProcessingMode.direct.supportsOutputFormatting)
+        XCTAssertTrue(ProcessingMode.intelliSense.supportsOutputFormatting)
+        XCTAssertTrue(ProcessingMode.translation().supportsOutputFormatting)
+        XCTAssertTrue(ProcessingMode.formalWriting.supportsOutputFormatting)
+        XCTAssertTrue(ProcessingMode.agentMode.supportsOutputFormatting)
+        XCTAssertFalse(ProcessingMode.selectionAsk.supportsOutputFormatting)
+        XCTAssertFalse(ProcessingMode.macAction.supportsOutputFormatting)
+    }
+
     func testReorderedModesKeepExactOrderAcrossRestartLoad() throws {
         let preferenceKeys = [
             "tf_translateToChineseModeSeeded",

--- a/Type4MeTests/RecognitionSessionTests.swift
+++ b/Type4MeTests/RecognitionSessionTests.swift
@@ -191,4 +191,63 @@ final class RecognitionSessionTests: XCTestCase {
         ))
     }
 
+    func testSessionFormattingUsesTheSelectedModeAcrossOutputKinds() throws {
+        let suite = "RecognitionSessionTests.Formatting.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(CJKSpacingMode.off.rawValue, forKey: CJKSpacingMode.storageKey)
+        defaults.set(TrailingPunctuationMode.period.rawValue, forKey: "tf_stripTrailingPunctuation")
+
+        var quick = ProcessingMode.direct
+        quick.punctuationMode = .inherit
+        XCTAssertEqual(
+            RecognitionSession.formattedOutputText("快速模式。", mode: quick, userDefaults: defaults),
+            "快速模式"
+        )
+
+        var polished = ProcessingMode.formalWriting
+        polished.punctuationMode = .removeAll
+        XCTAssertEqual(
+            RecognitionSession.formattedOutputText("润色：完成！", mode: polished, userDefaults: defaults),
+            "润色完成"
+        )
+
+        var intelliSense = ProcessingMode.intelliSense
+        intelliSense.punctuationMode = .questionsAndExclamationsOnly
+        XCTAssertEqual(
+            RecognitionSession.formattedOutputText("智能，完成？Yes!", mode: intelliSense, userDefaults: defaults),
+            "智能完成？Yes!"
+        )
+
+        var translation = ProcessingMode.translation(target: .english)
+        translation.punctuationMode = .stripTrailing
+        XCTAssertEqual(
+            RecognitionSession.formattedOutputText("Translation complete?!", mode: translation, userDefaults: defaults),
+            "Translation complete"
+        )
+    }
+
+    func testCrossModeFinishFormatsWithTheEndingMode() throws {
+        let suite = "RecognitionSessionTests.CrossModeFormatting.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(CJKSpacingMode.off.rawValue, forKey: CJKSpacingMode.storageKey)
+
+        var startingMode = ProcessingMode.direct
+        startingMode.punctuationMode = .preserve
+        var endingMode = ProcessingMode.formalWriting
+        endingMode.punctuationMode = .removeAll
+        let processingMode = CrossModeFinishPreference.processingMode(
+            startingMode: startingMode,
+            endingMode: endingMode,
+            isEnabled: true
+        )
+
+        XCTAssertEqual(processingMode.id, endingMode.id)
+        XCTAssertEqual(
+            RecognitionSession.formattedOutputText("跨模式，完成！", mode: processingMode, userDefaults: defaults),
+            "跨模式完成"
+        )
+    }
+
 }

--- a/Type4MeTests/TextOutputFormatterTests.swift
+++ b/Type4MeTests/TextOutputFormatterTests.swift
@@ -176,6 +176,97 @@ final class TextOutputFormatterTests: XCTestCase {
         )
     }
 
+    func testPerModePunctuationStrategiesCoverCJKAndASCII() {
+        let input = "你好，world. 真的？Yes, really! 太棒了！"
+
+        XCTAssertEqual(
+            TextOutputFormatter.format(
+                input,
+                options: .init(
+                    cjkSpacingMode: .off,
+                    usesCornerQuotes: false,
+                    punctuationMode: .preserve
+                )
+            ),
+            input
+        )
+        XCTAssertEqual(
+            TextOutputFormatter.format(
+                "真的吗？当然可以……",
+                options: .init(
+                    cjkSpacingMode: .off,
+                    usesCornerQuotes: false,
+                    punctuationMode: .stripTrailing
+                )
+            ),
+            "真的吗？当然可以"
+        )
+        XCTAssertEqual(
+            TextOutputFormatter.format(
+                input,
+                options: .init(
+                    cjkSpacingMode: .off,
+                    usesCornerQuotes: false,
+                    punctuationMode: .questionsAndExclamationsOnly
+                )
+            ),
+            "你好world 真的？Yes really! 太棒了！"
+        )
+        XCTAssertEqual(
+            TextOutputFormatter.format(
+                "第一项：Codex CLI——完成！\n第二项：继续？🚀",
+                options: .init(
+                    cjkSpacingMode: .off,
+                    usesCornerQuotes: false,
+                    punctuationMode: .removeAll
+                )
+            ),
+            "第一项Codex CLI完成\n第二项继续🚀"
+        )
+    }
+
+    func testPerModePunctuationRunsAfterQuotesAndSpacingAndIsIdempotent() {
+        let options = TextOutputFormattingOptions(
+            cjkSpacingMode: .pangu,
+            usesCornerQuotes: true,
+            punctuationMode: .questionsAndExclamationsOnly
+        )
+        let once = TextOutputFormatter.format("他说“版本3”，真的吗？！", options: options)
+
+        XCTAssertEqual(once, "他说版本 3 真的吗？！")
+        XCTAssertEqual(TextOutputFormatter.format(once, options: options), once)
+    }
+
+    func testModePunctuationOverrideResolvesAgainstLegacyGlobalSetting() throws {
+        let suite = "TextOutputFormatterTests.Punctuation.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(CJKSpacingMode.off.rawValue, forKey: CJKSpacingMode.storageKey)
+        defaults.set("period", forKey: "tf_stripTrailingPunctuation")
+
+        XCTAssertEqual(
+            TextOutputFormatter.format(
+                "你好！。",
+                options: .current(userDefaults: defaults, modePunctuation: .inherit)
+            ),
+            "你好！"
+        )
+        XCTAssertEqual(
+            TextOutputFormatter.format(
+                "你好！。",
+                options: .current(userDefaults: defaults, modePunctuation: .preserve)
+            ),
+            "你好！。"
+        )
+        XCTAssertEqual(
+            TextOutputFormatter.format(
+                "你好！。",
+                options: .current(userDefaults: defaults, modePunctuation: .stripTrailing)
+            ),
+            "你好"
+        )
+    }
+
     func testSpacingPreferenceMigration() throws {
         let suite = "TextOutputFormatterTests.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))


### PR DESCRIPTION
## Summary

- Add per-mode punctuation policies to the existing TextOutputFormatter pipeline instead of keeping the old standalone normalizer.
- Support inherit, preserve, strip trailing, keep only question/exclamation marks, and remove all punctuation.
- Keep existing users on inherit so the global trailing-punctuation preference remains unchanged.
- Apply the same mode-aware formatter to normal transcription, LLM output/fallback, translation, Intelli Sense, cross-mode finish, and stream recovery.

## Settings behavior

- Quick, Intelli Sense, Translation, Voice Polish, default text modes, and custom recording modes support independent punctuation settings.
- Ask Anything and Mac Action intentionally hide this setting.
- Immutable built-ins save immediately; Voice Polish and custom modes use the existing draft/save/discard workflow.

## Compatibility

- Missing or unknown values in modes.json safely fall back to inherit.
- Built-in mode migrations preserve the stored punctuation policy.
- Revise remains an independent edit action and continues to use global output-format settings.

## Verification

- Focused formatter, mode storage, recognition session, and settings draft tests passed.
- Full swift test: 717 passed, 2 environment-gated tests skipped, 0 failures.
- Type4Me Dev 2.1.0 build 63 was signed, deployed, and passed manual testing, including per-mode strategies.