### PR TITLE
fix(openrouter): support disabling reasoning

### DIFF
--- a/Type4Me/LLM/DoubaoChatClient.swift
+++ b/Type4Me/LLM/DoubaoChatClient.swift
@@ -52,14 +52,7 @@ actor DoubaoChatClient: LLMClient {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = 30
 
-        // tf_disableThinking: true (default) = disable thinking to save tokens;
-        // false = let the model use its default thinking behavior.
-        let disableThinking: Bool = {
-            guard let obj = UserDefaults.standard.object(forKey: "tf_disableThinking") else {
-                return true  // default: thinking disabled
-            }
-            return obj as? Bool ?? true
-        }()
+        let disableThinking = LLMThinkingPreference.isDisabled(for: provider)
         let disableField = disableThinking ? provider.thinkingDisableField(for: config.model) : nil
         let body = ChatRequest(
             model: config.model,
@@ -67,6 +60,7 @@ actor DoubaoChatClient: LLMClient {
             stream: true,
             thinking: disableField == .thinking ? ThinkingConfig(type: "disabled") : nil,
             enable_thinking: disableField == .enableThinking ? false : nil,
+            reasoning: disableField == .reasoning ? ReasoningConfig(effort: "none") : nil,
             reasoning_effort: disableField == .reasoningEffort ? "none" : nil,
             think: disableField == .think ? false : nil,
             reasoning_split: provider.needsReasoningSplit ? true : nil
@@ -101,12 +95,7 @@ actor DoubaoChatClient: LLMClient {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = 30
 
-        let disableThinking: Bool = {
-            guard let obj = UserDefaults.standard.object(forKey: "tf_disableThinking") else {
-                return true
-            }
-            return obj as? Bool ?? true
-        }()
+        let disableThinking = LLMThinkingPreference.isDisabled(for: provider)
         let disableField = disableThinking ? provider.thinkingDisableField : nil
         let body = ChatRequest(
             model: config.model,
@@ -114,6 +103,7 @@ actor DoubaoChatClient: LLMClient {
             stream: true,
             thinking: disableField == .thinking ? ThinkingConfig(type: "disabled") : nil,
             enable_thinking: disableField == .enableThinking ? false : nil,
+            reasoning: disableField == .reasoning ? ReasoningConfig(effort: "none") : nil,
             reasoning_effort: disableField == .reasoningEffort ? "none" : nil,
             think: disableField == .think ? false : nil,
             reasoning_split: provider.needsReasoningSplit ? true : nil
@@ -213,12 +203,17 @@ struct ThinkingConfig: Encodable, Sendable {
     let type: String
 }
 
+struct ReasoningConfig: Encodable, Sendable {
+    let effort: String
+}
+
 struct ChatRequest: Encodable, Sendable {
     let model: String
     let messages: [ChatMessage]
     let stream: Bool
     let thinking: ThinkingConfig?
     let enable_thinking: Bool?
+    let reasoning: ReasoningConfig?
     let reasoning_effort: String?
     let think: Bool?
     let reasoning_split: Bool?

--- a/Type4Me/LLM/LLMProvider.swift
+++ b/Type4Me/LLM/LLMProvider.swift
@@ -199,6 +199,9 @@ enum LLMProvider: String, CaseIterable, Codable, Sendable {
         case .zhipu:
             // thinking: { type: "disabled" } (GLM-5.x / GLM-4.7)
             return .thinking
+        case .openrouter:
+            // reasoning: { effort: "none" }
+            return .reasoning
         case .ollama:
             // think: false
             return .think
@@ -206,7 +209,6 @@ enum LLMProvider: String, CaseIterable, Codable, Sendable {
             // OpenAI: defaults to none already for GPT-5.2+, risky for o3
             // Gemini: OpenAI-compat layer doesn't reliably support it
             // MiniMax: API doesn't support disabling reasoning (use needsReasoningSplit instead)
-            // OpenRouter: proxy, can't generically handle
             return nil
         }
     }
@@ -228,8 +230,41 @@ enum ThinkingDisableField: Equatable {
     case enableThinking
     /// `reasoning_effort: "none"` — providers that still expose OpenAI-style effort control
     case reasoningEffort
+    /// `reasoning: { effort: "none" }` — OpenRouter's unified reasoning control
+    case reasoning
     /// `think: false` — Ollama
     case think
+}
+
+// MARK: - Thinking Preference
+
+enum LLMThinkingPreference {
+    private static let sharedKey = "tf_disableThinking"
+    private static let openRouterKey = "tf_disableThinking_openrouter"
+
+    /// OpenRouter fronts models with different reasoning requirements, including
+    /// models where reasoning is mandatory. Keep its default provider-controlled
+    /// until the user explicitly opts out, while preserving the existing default
+    /// for direct providers.
+    static func isDisabled(
+        for provider: LLMProvider,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        let key = provider == .openrouter ? openRouterKey : sharedKey
+        guard let value = defaults.object(forKey: key) as? Bool else {
+            return provider != .openrouter
+        }
+        return value
+    }
+
+    static func setDisabled(
+        _ disabled: Bool,
+        for provider: LLMProvider,
+        defaults: UserDefaults = .standard
+    ) {
+        let key = provider == .openrouter ? openRouterKey : sharedKey
+        defaults.set(disabled, forKey: key)
+    }
 }
 
 // MARK: - Provider Config Protocol

--- a/Type4Me/UI/Settings/LLMSettingsCard.swift
+++ b/Type4Me/UI/Settings/LLMSettingsCard.swift
@@ -18,9 +18,7 @@ struct LLMSettingsCard: View, SettingsCardHelpers {
     @State private var testTask: Task<Void, Never>?
     /// Tracks which credential fields are in "custom input" mode (value not in preset options).
     @State private var customModeFields: Set<String> = []
-    @State private var disableThinking: Bool = UserDefaults.standard.object(forKey: "tf_disableThinking") == nil
-        ? true
-        : UserDefaults.standard.bool(forKey: "tf_disableThinking")
+    @State private var disableThinking = LLMThinkingPreference.isDisabled(for: .doubao)
     @State private var fetchedModelOptions: [FieldOption] = []
     @State private var isFetchingModels = false
 
@@ -152,7 +150,7 @@ struct LLMSettingsCard: View, SettingsCardHelpers {
             set: { newValue in
                 guard thinkingToggleAvailable else { return }
                 disableThinking = newValue
-                UserDefaults.standard.set(disableThinking, forKey: "tf_disableThinking")
+                LLMThinkingPreference.setDisabled(disableThinking, for: selectedLLMProvider)
             }
         )
     }
@@ -170,6 +168,8 @@ struct LLMSettingsCard: View, SettingsCardHelpers {
             return L("发送 enable_thinking: false", "Sends enable_thinking: false")
         case .reasoningEffort:
             return L("发送 reasoning_effort: none", "Sends reasoning_effort: none")
+        case .reasoning:
+            return L("发送 reasoning.effort: none", "Sends reasoning.effort: none")
         case .think:
             return L("发送 think: false", "Sends think: false")
         case nil where selectedLLMProvider.needsReasoningSplit:
@@ -419,6 +419,7 @@ struct LLMSettingsCard: View, SettingsCardHelpers {
     private func loadLLMCredentialsForProvider(_ provider: LLMProvider) {
         testTask?.cancel()
         editedFields = []
+        disableThinking = LLMThinkingPreference.isDisabled(for: provider)
         if let values = KeychainService.loadLLMCredentials(for: provider) {
             llmCredentialValues = values
             savedLLMValues = values

--- a/Type4MeTests/DoubaoChatClientTests.swift
+++ b/Type4MeTests/DoubaoChatClientTests.swift
@@ -9,4 +9,26 @@ final class DoubaoChatClientTests: XCTestCase {
 
         XCTAssertEqual(finalPrompt, "请修正以下文本：200毫秒")
     }
+
+    func testOpenRouterDisableThinkingUsesUnifiedReasoningParameter() throws {
+        let request = ChatRequest(
+            model: "deepseek/deepseek-v4-flash-0731",
+            messages: [ChatMessage(role: "user", content: "test")],
+            stream: true,
+            thinking: nil,
+            enable_thinking: nil,
+            reasoning: ReasoningConfig(effort: "none"),
+            reasoning_effort: nil,
+            think: nil,
+            reasoning_split: nil
+        )
+
+        let data = try JSONEncoder().encode(request)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let reasoning = try XCTUnwrap(json["reasoning"] as? [String: String])
+
+        XCTAssertEqual(reasoning["effort"], "none")
+        XCTAssertNil(json["thinking"])
+        XCTAssertNil(json["reasoning_effort"])
+    }
 }

--- a/Type4MeTests/LLMProviderModelOptionsTests.swift
+++ b/Type4MeTests/LLMProviderModelOptionsTests.swift
@@ -62,6 +62,21 @@ final class LLMProviderModelOptionsTests: XCTestCase {
         XCTAssertEqual(LLMProvider.kimi.thinkingDisableField(for: "kimi-k2.6"), .thinking)
         XCTAssertEqual(LLMProvider.deepseek.thinkingDisableField(for: "deepseek-v4-flash"), .thinking)
         XCTAssertEqual(LLMProvider.zhipu.thinkingDisableField(for: "glm-5.2"), .thinking)
+        XCTAssertEqual(LLMProvider.openrouter.thinkingDisableField(for: "deepseek/deepseek-v4-flash-0731"), .reasoning)
+    }
+
+    func testOpenRouterThinkingPreferenceDefaultsToModelBehavior() throws {
+        let suiteName = "LLMThinkingPreferenceTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: "tf_disableThinking")
+
+        XCTAssertTrue(LLMThinkingPreference.isDisabled(for: .deepseek, defaults: defaults))
+        XCTAssertFalse(LLMThinkingPreference.isDisabled(for: .openrouter, defaults: defaults))
+
+        LLMThinkingPreference.setDisabled(true, for: .openrouter, defaults: defaults)
+        XCTAssertTrue(LLMThinkingPreference.isDisabled(for: .openrouter, defaults: defaults))
     }
 }
 


### PR DESCRIPTION
## Summary

- expose the existing thinking-mode selector for OpenRouter
- send OpenRouter’s unified `reasoning: { "effort": "none" }` when thinking is disabled
- omit the reasoning field when Model Default is selected
- keep a separate OpenRouter preference that defaults to model behavior, avoiding failures for models with mandatory reasoning
- add coverage for provider routing, preference defaults, and the encoded request body

## Why

OpenRouter normalizes reasoning controls through the `reasoning` object. Type4Me currently treats OpenRouter as unsupported, so models that enable reasoning by default can spend several seconds producing hidden reasoning before any content is available. The settings UI therefore cannot trade reasoning quality for lower dictation latency.

Reference: https://openrouter.ai/docs/guides/best-practices/reasoning-tokens

## Verification

- `swift build -c release` ✅
- targeted tests were added; the local Command Line Tools-only environment cannot import XCTest, which also prevents the existing test suite from running