### PR TITLE
fix: preserve spacing in CJK numbered lists

### DIFF
--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -2143,12 +2143,23 @@ extension String {
     /// "hello world" is untouched.
     var removingCJKLatinSpaces: String {
         let cjk = "[\\u3400-\\u4DBF\\u4E00-\\u9FFF\\uF900-\\uFAFF]"
+
+        func restoringOrderedListSpacing(in text: String) -> String {
+            // Punctuation cleanup treats the dot in a list marker as ordinary
+            // punctuation. Restore the syntactic space in "3. 中文".
+            text.replacingOccurrences(
+                of: "(?m)^([ \\t]*[0-9]+\\.)(?=\(cjk))",
+                with: "$1 ",
+                options: .regularExpression
+            )
+        }
+
         let preserveCJKLatinSpacing = UserDefaults.standard.object(forKey: "tf_preserveCJKLatinSpacing") as? Bool ?? true
         guard preserveCJKLatinSpacing else {
             var s = self
             s = s.replacingOccurrences(of: "(?<=\(cjk)) +(?=\\S)", with: "", options: .regularExpression)
             s = s.replacingOccurrences(of: "(?<=\\S) +(?=\(cjk))", with: "", options: .regularExpression)
-            return s
+            return restoringOrderedListSpacing(in: s)
         }
         // A neighbour that should hug the CJK character with no space: anything
         // that is neither whitespace nor an ASCII letter/digit (i.e. another CJK
@@ -2162,7 +2173,7 @@ extension String {
         // Space before CJK, after a non-letter/digit: "， 你" → "，你"
         // ("Max 你" / "3 个" keep their space because 'x' / '3' are letter/digit.)
         s = s.replacingOccurrences(of: "(?<=\(glue)) +(?=\(cjk))", with: "", options: .regularExpression)
-        return s
+        return restoringOrderedListSpacing(in: s)
     }
 
     /// Strip trailing punctuation based on user preference (tf_stripTrailingPunctuation).

--- a/Type4MeTests/RecognitionSessionTests.swift
+++ b/Type4MeTests/RecognitionSessionTests.swift
@@ -125,4 +125,22 @@ final class RecognitionSessionTests: XCTestCase {
         )
         XCTAssertEqual("第 3 个".removingCJKLatinSpaces, "第3个")
     }
+
+    func testRemovingCJKLatinSpaces_preservesOrderedListSpacingBeforeCJK() {
+        let input = """
+        3. 智谱
+        10. 中文标题
+        """
+
+        for preservePanguSpacing in [true, false] {
+            UserDefaults.standard.set(preservePanguSpacing, forKey: "tf_preserveCJKLatinSpacing")
+            XCTAssertEqual(input.removingCJKLatinSpaces, input)
+        }
+    }
+
+    func testRemovingCJKLatinSpaces_doesNotTreatDecimalAsOrderedList() {
+        UserDefaults.standard.set(true, forKey: "tf_preserveCJKLatinSpacing")
+
+        XCTAssertEqual("3.14 版本".removingCJKLatinSpaces, "3.14 版本")
+    }
 }


### PR DESCRIPTION
## Summary

- preserve the syntactic space in line-leading numbered lists before CJK text
- apply the fix whether Pangu spacing preservation is enabled or disabled
- keep decimal text such as `3.14 版本` unchanged
- add regression coverage for single- and double-digit list markers

## Root cause

`removingCJKLatinSpaces` runs after LLM processing. Its punctuation cleanup treats the dot in a numbered-list marker as ordinary punctuation, so a correct LLM result such as:

```text
1. DeepSeek 直连
2. OpenRouter
3. 智谱
```

is changed immediately before injection to `3.智谱`. Items starting with Latin text happen to keep the space, which makes mixed CJK/Latin lists inconsistent.

The fix restores one space only for line-leading `<digits>.` markers followed by CJK text. The line anchor and CJK lookahead avoid changing decimal numbers.

## Verification

- `swift build -c release` ✅
- standalone checks for CJK list markers, both spacing preferences, decimals, and existing punctuation cleanup ✅
- regression tests added to `RecognitionSessionTests`; the local Command Line Tools-only environment cannot import XCTest, so the XCTest suite could not run locally