### PR TITLE
fix(history): prevent SQLite descriptor leaks

### DIFF
--- a/Type4Me/Database/HistoryStore.swift
+++ b/Type4Me/Database/HistoryStore.swift
@@ -7,6 +7,8 @@ extension Notification.Name {
 }
 actor HistoryStore {
 
+    static let shared = HistoryStore()
+
     private var db: OpaquePointer?
 
     init(path: String? = nil) {
@@ -126,6 +128,15 @@ actor HistoryStore {
 
             // Index for ORDER BY created_at DESC pagination
             sqlite3_exec(db, "CREATE INDEX IF NOT EXISTS idx_history_created_at ON recognition_history(created_at DESC);", nil, nil, nil)
+        } else if let db {
+            sqlite3_close_v2(db)
+            self.db = nil
+        }
+    }
+
+    deinit {
+        if let db {
+            sqlite3_close_v2(db)
         }
     }
 

--- a/Type4Me/Services/CorrectionLearning.swift
+++ b/Type4Me/Services/CorrectionLearning.swift
@@ -631,7 +631,7 @@ final class PostInjectionLearningCoordinator: NSObject {
     private let timing: UserEditObservationTiming
 
     init(
-        historyStore: HistoryStore = HistoryStore(),
+        historyStore: HistoryStore = .shared,
         timing: UserEditObservationTiming = .production
     ) {
         self.historyStore = historyStore

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -149,7 +149,7 @@ actor RecognitionSession {
 
     private let audioEngine = AudioCaptureEngine()
     private let injectionEngine = TextInjectionEngine()
-    let historyStore = HistoryStore()
+    let historyStore = HistoryStore.shared
     private var asrClient: (any SpeechRecognizer)?
     private var llmClientCache = LLMClientCache()
     private(set) var recordingPurpose: RecordingPurpose = .input(.direct)

--- a/Type4Me/UI/Settings/HistoryTab.swift
+++ b/Type4Me/UI/Settings/HistoryTab.swift
@@ -297,7 +297,7 @@ struct HistoryTab: View {
 
     let isActive: Bool
 
-    private let historyStore = HistoryStore()
+    private let historyStore = HistoryStore.shared
 
     @State private var records: [HistoryRecord] = []
     @State private var sections: [DateSection] = []

--- a/Type4Me/UI/Settings/HomeDashboardView.swift
+++ b/Type4Me/UI/Settings/HomeDashboardView.swift
@@ -11,7 +11,7 @@ struct HomeDashboardView: View {
     @State private var hoveredMetric: Metric?
     @State private var isModesButtonHovered = false
 
-    private let historyStore = HistoryStore()
+    private let historyStore = HistoryStore.shared
     private let assumedTypingSpeed = 40.0
 
     /// Drive the list from the same live, observable source the menu bar reads

--- a/Type4Me/UI/Settings/SmartCorrectionSheet.swift
+++ b/Type4Me/UI/Settings/SmartCorrectionSheet.swift
@@ -38,7 +38,7 @@ struct SmartCorrectionSheet: View {
     @State private var hotwordSuggestions: [HotwordSuggestion] = []
     @State private var hotwordReason: String = ""
 
-    private let historyStore = HistoryStore()
+    private let historyStore = HistoryStore.shared
     private let generator = ASRVariantGenerator()
 
     // MARK: - Computed

--- a/Type4MeTests/HistoryStoreTests.swift
+++ b/Type4MeTests/HistoryStoreTests.swift
@@ -1,5 +1,6 @@
-import XCTest
+import Darwin
 import SQLite3
+import XCTest
 @testable import Type4Me
 
 final class HistoryStoreTests: XCTestCase {
@@ -14,7 +15,21 @@ final class HistoryStoreTests: XCTestCase {
     }
 
     override func tearDown() async throws {
+        store = nil
         try? FileManager.default.removeItem(atPath: testPath)
+    }
+
+    func testTemporaryStoresCloseDatabaseDescriptorOnDeinit() {
+        let baseline = openDescriptorCount(for: testPath)
+
+        for _ in 0..<20 {
+            autoreleasepool {
+                let temporaryStore = HistoryStore(path: testPath)
+                withExtendedLifetime(temporaryStore) {}
+            }
+        }
+
+        XCTAssertEqual(openDescriptorCount(for: testPath), baseline)
     }
 
     func testInsertAndFetchAll() async {
@@ -370,5 +385,43 @@ final class HistoryStoreTests: XCTestCase {
         let fetched = await store.fetchAll()
         XCTAssertEqual(fetched.count, 1)
         XCTAssertEqual(fetched.first?.rawText, "shrink test")
+    }
+
+    private func openDescriptorCount(for path: String) -> Int {
+        let resolvedPath = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
+        let pid = getpid()
+        let descriptorInfoSize = MemoryLayout<proc_fdinfo>.stride
+        let requiredBytes = Int(proc_pidinfo(pid, PROC_PIDLISTFDS, 0, nil, 0))
+        guard requiredBytes > 0 else { return 0 }
+
+        var descriptors = [proc_fdinfo](
+            repeating: proc_fdinfo(),
+            count: requiredBytes / descriptorInfoSize
+        )
+        let usedBytes = descriptors.withUnsafeMutableBytes {
+            proc_pidinfo(pid, PROC_PIDLISTFDS, 0, $0.baseAddress, Int32($0.count))
+        }
+        guard usedBytes > 0 else { return 0 }
+
+        let pathInfoSize = Int32(MemoryLayout<vnode_fdinfowithpath>.stride)
+        return descriptors.prefix(Int(usedBytes) / descriptorInfoSize).reduce(into: 0) { count, descriptor in
+            var pathInfo = vnode_fdinfowithpath()
+            guard proc_pidfdinfo(
+                pid,
+                descriptor.proc_fd,
+                PROC_PIDFDVNODEPATHINFO,
+                &pathInfo,
+                pathInfoSize
+            ) == pathInfoSize else { return }
+
+            let descriptorPath = withUnsafePointer(to: &pathInfo.pvip.vip_path) { pointer in
+                pointer.withMemoryRebound(to: CChar.self, capacity: Int(MAXPATHLEN)) {
+                    String(cString: $0)
+                }
+            }
+            if descriptorPath == resolvedPath {
+                count += 1
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- reuse one `HistoryStore` actor across recognition, history, and smart-correction flows
- close the SQLite connection when a temporary store is released or `sqlite3_open` fails
- add a regression test that checks repeated temporary stores do not grow the database descriptor count

## Problem

`HistoryTab`, `SmartCorrectionSheet`, and `RecognitionSession` each created their own `HistoryStore`. SwiftUI can recreate the settings views repeatedly, while `HistoryStore` never closed its SQLite handle. In a long-running Type4Me session this resulted in 140 open descriptors for the same `history.db`, close to the process soft limit.

## Verification

- `swift build -c release` ✅
- `git diff --check` ✅
- `swift test --filter HistoryStoreTests` could not run with the selected Command Line Tools because that local toolchain has no `XCTest` module; the production target compiled successfully and the regression test is included for CI/Xcode.