### PR TITLE
fix: 避免上下文捕获阻塞录音启动

### DIFF
--- a/Type4Me/LLM/PromptContext.swift
+++ b/Type4Me/LLM/PromptContext.swift
@@ -6,21 +6,73 @@ import os
 /// Captured at recording start so `{selected}` reflects the user's selection
 /// before any text injection occurs.
 struct PromptContext: Sendable {
+    struct CaptureRequirements: OptionSet, Sendable {
+        let rawValue: UInt8
+
+        static let selected = CaptureRequirements(rawValue: 1 << 0)
+        static let clipboard = CaptureRequirements(rawValue: 1 << 1)
+
+        var logDescription: String {
+            var names: [String] = []
+            if contains(.selected) { names.append("selected") }
+            if contains(.clipboard) { names.append("clipboard") }
+            return names.isEmpty ? "none" : names.joined(separator: ",")
+        }
+    }
+
     let selectedText: String
     let clipboardText: String
 
-    /// Capture the current selected text (via Accessibility) and clipboard content.
-    /// Clipboard is read on MainActor (AppKit requirement).
-    /// AX calls run on a detached task with a short timeout.
-    static func capture() async -> PromptContext {
-        let clipboard = await MainActor.run {
-            NSPasteboard.general.string(forType: .string) ?? ""
+    static let empty = PromptContext(selectedText: "", clipboardText: "")
+
+    /// Return only the context fields referenced by a prompt. Some modes use
+    /// selection outside their prompt template and can request it explicitly.
+    static func captureRequirements(
+        for prompt: String,
+        requiresSelection: Bool = false
+    ) -> CaptureRequirements {
+        var requirements: CaptureRequirements = []
+        if requiresSelection || prompt.contains("{selected}") {
+            requirements.insert(.selected)
         }
-        let axSelectedText = await readSelectedTextAsync(timeoutMs: 500)
-        let selected = shouldUseTemporaryCopy(axSelectedText: axSelectedText)
-            ? await readSelectedTextByTemporaryCopy(timeoutMs: 250)
-            : (axSelectedText ?? "")
+        if prompt.contains("{clipboard}") {
+            requirements.insert(.clipboard)
+        }
+        return requirements
+    }
+
+    /// Capture only the requested fields. Clipboard is read before the
+    /// selected-text fallback because that fallback temporarily replaces it.
+    /// AX calls run on a detached task with a short timeout.
+    static func capture(
+        requirements: CaptureRequirements = [.selected, .clipboard]
+    ) async -> PromptContext {
+        guard !requirements.isEmpty else { return .empty }
+
+        let clipboard: String
+        if requirements.contains(.clipboard) {
+            clipboard = await MainActor.run {
+                NSPasteboard.general.string(forType: .string) ?? ""
+            }
+        } else {
+            clipboard = ""
+        }
+
+        var selected = ""
+        if requirements.contains(.selected) {
+            let axSelectedText = await readSelectedTextAsync(timeoutMs: 500)
+            selected = shouldUseTemporaryCopy(axSelectedText: axSelectedText)
+                ? await readSelectedTextByTemporaryCopy(timeoutMs: 250)
+                : (axSelectedText ?? "")
+        }
         return PromptContext(selectedText: selected, clipboardText: clipboard)
+    }
+
+    func merging(_ other: PromptContext) -> PromptContext {
+        PromptContext(
+            selectedText: other.selectedText.isEmpty ? selectedText : other.selectedText,
+            clipboardText: other.clipboardText.isEmpty ? clipboardText : other.clipboardText
+        )
     }
 
     /// An empty string is a successful AX result meaning the focused control has

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -363,7 +363,128 @@ actor RecognitionSession {
 
     // MARK: - Prompt context (selected text + clipboard captured at recording start)
 
-    private var promptContext: PromptContext = PromptContext(selectedText: "", clipboardText: "")
+    private struct PendingPromptContextCapture: Sendable {
+        let id: UUID
+        let generation: Int
+        let requirements: PromptContext.CaptureRequirements
+        let task: Task<PromptContext, Never>
+    }
+
+    private var promptContext: PromptContext = .empty
+    private var capturedPromptContextRequirements: PromptContext.CaptureRequirements = []
+    private var pendingPromptContextCapture: PendingPromptContextCapture?
+    /// A serialization barrier that prevents temporary Command+C clipboard
+    /// fallbacks from consecutive sessions from overlapping their restore work.
+    private var lastPromptContextCaptureTask: Task<PromptContext, Never>?
+    private var lastPromptContextCaptureID: UUID?
+
+    private func resetPromptContextCapture(
+        for purpose: RecordingPurpose,
+        generation: Int
+    ) {
+        promptContext = .empty
+        capturedPromptContextRequirements = []
+        pendingPromptContextCapture = nil
+        guard case .input(let mode) = purpose else { return }
+        schedulePromptContextCaptureIfNeeded(for: mode, generation: generation)
+    }
+
+    private func schedulePromptContextCaptureIfNeeded(
+        for mode: ProcessingMode,
+        generation: Int
+    ) {
+        // Selection Ask consumes the selection outside normal template expansion.
+        // Mac Action passes it to selection-aware actions after the LLM reply.
+        let requiresSelection = mode.executionKind == .selectionAsk
+            || mode.id == ProcessingMode.macActionId
+        let requested = PromptContext.captureRequirements(
+            for: mode.prompt,
+            requiresSelection: requiresSelection
+        )
+        let pendingRequirements = pendingPromptContextCapture?.generation == generation
+            ? pendingPromptContextCapture?.requirements ?? []
+            : []
+        let covered = capturedPromptContextRequirements.union(pendingRequirements)
+        let missing = requested.subtracting(covered)
+
+        guard !missing.isEmpty else {
+            if requested.isEmpty {
+                DebugFileLogger.log(
+                    "prompt context capture skipped mode=\(mode.name) requirements=none"
+                )
+            }
+            return
+        }
+
+        let previousTask = lastPromptContextCaptureTask
+        let previousPending = pendingPromptContextCapture
+        let baseContext = promptContext
+        let id = UUID()
+        let combinedRequirements = covered.union(missing)
+        DebugFileLogger.log(
+            "prompt context capture scheduled mode=\(mode.name) "
+                + "missing=\(missing.logDescription) "
+                + "total=\(combinedRequirements.logDescription)"
+        )
+
+        let task = Task.detached {
+            let previousResult = await previousTask?.value
+            let base: PromptContext
+            if previousPending?.generation == generation, let previousResult {
+                base = previousResult
+            } else {
+                base = baseContext
+            }
+
+            let captureStartedAt = ContinuousClock.now
+            let addition = await PromptContext.capture(requirements: missing)
+            DebugFileLogger.log(
+                "prompt context capture completed requirements=\(missing.logDescription) "
+                    + "duration=\(ContinuousClock.now - captureStartedAt)"
+            )
+            return base.merging(addition)
+        }
+
+        lastPromptContextCaptureTask = task
+        lastPromptContextCaptureID = id
+        pendingPromptContextCapture = PendingPromptContextCapture(
+            id: id,
+            generation: generation,
+            requirements: combinedRequirements,
+            task: task
+        )
+        Task { [weak self] in
+            _ = await task.value
+            await self?.clearPromptContextCaptureBarrier(id: id)
+        }
+    }
+
+    private func clearPromptContextCaptureBarrier(id: UUID) {
+        guard lastPromptContextCaptureID == id else { return }
+        lastPromptContextCaptureTask = nil
+        lastPromptContextCaptureID = nil
+    }
+
+    private func resolvePromptContextIfNeeded(generation: Int) async {
+        while let pending = pendingPromptContextCapture,
+              pending.generation == generation {
+            let context = await pending.task.value
+            guard sessionGeneration == generation else { return }
+
+            // A cross-mode switch may schedule a superset while this task is
+            // suspended. In that case, wait for the replacement task instead.
+            guard pendingPromptContextCapture?.id == pending.id else { continue }
+
+            promptContext = context
+            capturedPromptContextRequirements.formUnion(pending.requirements)
+            pendingPromptContextCapture = nil
+            DebugFileLogger.log(
+                "prompt context capture resolved requirements="
+                    + capturedPromptContextRequirements.logDescription
+            )
+            return
+        }
+    }
 
     private struct IntelliSenseRequestContext: Sendable {
         let settings: IntelliSenseSettings
@@ -473,8 +594,11 @@ actor RecognitionSession {
 
     // MARK: - Start
 
-    func startRecording(mode: ProcessingMode = .direct) async {
-        await startRecording(purpose: .input(mode))
+    func startRecording(
+        mode: ProcessingMode = .direct,
+        requestedAt: ContinuousClock.Instant? = nil
+    ) async {
+        await startRecording(purpose: .input(mode), requestedAt: requestedAt)
     }
 
     func startReviseRecording(_ target: RevisePreparedTarget) async {
@@ -489,7 +613,11 @@ actor RecognitionSession {
         onASREvent?(.reviseCancelled)
     }
 
-    func startRecording(purpose: RecordingPurpose) async {
+    func startRecording(
+        purpose: RecordingPurpose,
+        requestedAt: ContinuousClock.Instant? = nil
+    ) async {
+        let recordingRequestStartedAt = requestedAt ?? ContinuousClock.now
         if state == .finishing || state == .injecting || state == .postProcessing || state == .recovering {
             NSLog("[Session] startRecording: blocked, current session still processing (state=%@)", String(describing: state))
             DebugFileLogger.log("startRecording blocked: still processing state=\(state)")
@@ -595,6 +723,10 @@ actor RecognitionSession {
             pendingSelectionAskRequestContext = nil
         }
 
+        // Capture prompt context beside credential loading and audio startup.
+        // It is resolved only when a prompt or selection-aware action needs it.
+        resetPromptContextCapture(for: purpose, generation: myGeneration)
+
         self.recordingStartTime = nil
         hasEmittedReadyForCurrentSession = false
         injectionAborted = false
@@ -681,19 +813,6 @@ actor RecognitionSession {
             bypassProxy: ProxyBypassMode.current.bypassASR
         )
 
-        // Intelli Sense never reads selection or clipboard context. Other modes
-        // preserve the existing prompt-variable behavior.
-        if currentMode.id == ProcessingMode.intelliSenseId
-            || currentMode.id == ProcessingMode.translationModeId {
-            promptContext = PromptContext(selectedText: "", clipboardText: "")
-        } else {
-            promptContext = await PromptContext.capture()
-        }
-        guard sessionGeneration == myGeneration else {
-            DebugFileLogger.log("startRecording: zombie detected after capture, bailing")
-            return
-        }
-
         // Reset text state and clean up previous pipeline
         currentTranscript = .empty
         await finishAudioChunkPipeline(timeout: .milliseconds(100))
@@ -734,9 +853,15 @@ actor RecognitionSession {
                 "audio input selected uid=\(selectedDeviceUID ?? "system-default") " +
                 "mode=\(preferenceMode) priority=[\(priorityUIDs)]"
             )
+            let audioEngineStartAt = ContinuousClock.now
             try audioEngine.start()
             NSLog("[Session] Audio engine started OK")
-            DebugFileLogger.log("audio engine started OK")
+            let audioReadyAt = ContinuousClock.now
+            DebugFileLogger.log(
+                "audio engine started OK "
+                    + "requestToReady=\(audioReadyAt - recordingRequestStartedAt) "
+                    + "engineStart=\(audioReadyAt - audioEngineStartAt)"
+            )
         } catch {
             NSLog("[Session] Audio engine start FAILED: %@", String(describing: error))
             DebugFileLogger.log("audio engine start failed: \(String(describing: error))")
@@ -914,6 +1039,10 @@ actor RecognitionSession {
             clearTranslationSessionContext()
         }
         currentMode = resolved
+        schedulePromptContextCaptureIfNeeded(
+            for: resolved,
+            generation: sessionGeneration
+        )
     }
 
     // MARK: - Stop
@@ -1021,6 +1150,9 @@ actor RecognitionSession {
         activeProvider: ASRProvider,
         myGeneration: Int
     ) async {
+        await resolvePromptContextIfNeeded(generation: myGeneration)
+        guard sessionGeneration == myGeneration else { return }
+
         let question = questionText.trimmingCharacters(in: .whitespacesAndNewlines)
         let requestContext = pendingSelectionAskRequestContext ?? SelectionAskRequestContext(
             requestID: UUID(),
@@ -2357,6 +2489,14 @@ actor RecognitionSession {
 
     private func fireSpeculativeLLM(text: String) async {
         guard speculativeThrottle.beginDebouncedRequest(for: text) else { return }
+        let contextGeneration = sessionGeneration
+        await resolvePromptContextIfNeeded(generation: contextGeneration)
+        guard !Task.isCancelled,
+              sessionGeneration == contextGeneration,
+              state == .recording else {
+            _ = speculativeThrottle.requestCompleted(input: text)
+            return
+        }
         guard let runtime = await resolveLLMRuntime() else {
             _ = speculativeThrottle.requestCompleted(input: text)
             return
@@ -2458,6 +2598,8 @@ actor RecognitionSession {
     }
 
     private func promptForCurrentMode(text: String? = nil) async -> String {
+        await resolvePromptContextIfNeeded(generation: sessionGeneration)
+
         if currentMode.id == ProcessingMode.translationModeId,
            let context = translationRequestContext,
            context.generation == sessionGeneration {
@@ -3053,6 +3195,9 @@ actor RecognitionSession {
         sessionGeneration &+= 1
         state = .idle
         currentTranscript = .empty
+        promptContext = .empty
+        capturedPromptContextRequirements = []
+        pendingPromptContextCapture = nil
         pendingSelectionAskRequestContext = nil
         hasEmittedReadyForCurrentSession = false
         currentConfig = nil

--- a/Type4Me/Type4MeApp.swift
+++ b/Type4Me/Type4MeApp.swift
@@ -577,6 +577,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         self.askAnythingCoordinator.prepareForExternalNewQuestion()
                     }
                 }
+                let recordingRequestedAt = ContinuousClock.now
                 NSLog("[Type4Me] >>> HOTKEY: Record START (mode: %@)", effectiveMode.name)
                 DebugFileLogger.log("hotkey record start mode=\(effectiveMode.name)")
                 Task { @MainActor in
@@ -590,7 +591,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         NSLog("[Type4Me] >>> HOTKEY: previous session did not reach idle in time")
                         DebugFileLogger.log("hotkey start: awaitIdle timed out")
                     }
-                    await self.session.startRecording(mode: effectiveMode)
+                    await self.session.startRecording(
+                        mode: effectiveMode,
+                        requestedAt: recordingRequestedAt
+                    )
                 }
             }
             let onStop: @Sendable () -> Void = { [weak self] in
@@ -794,6 +798,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let resolvedMode = ASRProviderRegistry.resolvedMode(for: .selectionAsk, provider: selectedProvider)
         let effectiveMode = availableModes.first(where: { $0.id == resolvedMode.id }) ?? resolvedMode
 
+        let recordingRequestedAt = ContinuousClock.now
         DebugFileLogger.log("selectionAsk follow-up start")
         let generation = selectionAskFollowUpStartGate.begin()
         appState.selectModeForRecording(effectiveMode)
@@ -815,7 +820,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 return
             }
             await self.session.setSelectionAskRequestContext(requestContext)
-            await self.session.startRecording(mode: effectiveMode)
+            await self.session.startRecording(
+                mode: effectiveMode,
+                requestedAt: recordingRequestedAt
+            )
         }
         return true
     }

--- a/Type4MeTests/PromptContextTests.swift
+++ b/Type4MeTests/PromptContextTests.swift
@@ -3,6 +3,47 @@ import XCTest
 
 final class PromptContextTests: XCTestCase {
 
+    func testCaptureRequirements_skipsPromptWithoutContextVariables() {
+        let requirements = PromptContext.captureRequirements(
+            for: "Rewrite this text: {text}"
+        )
+
+        XCTAssertTrue(requirements.isEmpty)
+    }
+
+    func testCaptureRequirements_detectsOnlyReferencedVariables() {
+        XCTAssertEqual(
+            PromptContext.captureRequirements(for: "Use {selected}"),
+            [.selected]
+        )
+        XCTAssertEqual(
+            PromptContext.captureRequirements(for: "Use {clipboard}"),
+            [.clipboard]
+        )
+        XCTAssertEqual(
+            PromptContext.captureRequirements(for: "Use {selected} and {clipboard}"),
+            [.selected, .clipboard]
+        )
+    }
+
+    func testCaptureRequirements_canRequireSelectionOutsidePrompt() {
+        let requirements = PromptContext.captureRequirements(
+            for: "Question: {text}",
+            requiresSelection: true
+        )
+
+        XCTAssertEqual(requirements, [.selected])
+    }
+
+    func testMergingContextPreservesPreviouslyCapturedFields() {
+        let selected = PromptContext(selectedText: "selection", clipboardText: "")
+        let clipboard = PromptContext(selectedText: "", clipboardText: "clipboard")
+        let merged = selected.merging(clipboard)
+
+        XCTAssertEqual(merged.selectedText, "selection")
+        XCTAssertEqual(merged.clipboardText, "clipboard")
+    }
+
     func testEmptyAXSelectionDoesNotFallBackToCommandCopy() {
         XCTAssertFalse(PromptContext.shouldUseTemporaryCopy(axSelectedText: ""))
     }


### PR DESCRIPTION
## 问题

v2.0.0 在启动麦克风前会等待 `PromptContext.capture()`。当辅助功能无法直接读取选中文本时，回退流程最长可能等待 750 ms；即使快速模式不使用 `{selected}` 或 `{clipboard}`，也会执行这段捕获。

## 修复

- 只捕获当前 Prompt 实际使用的 `{selected}` / `{clipboard}`；随便问仍固定捕获选中文本。
- 上下文捕获改为后台任务，不再阻塞麦克风启动；在构造 Prompt 前再等待结果。
- 保留跨模式停止，并串行化连续会话的剪贴板回退操作。
- 增加 `requestToReady`、`engineStart` 和上下文捕获耗时日志。

本次没有修改 `AVCaptureSession` 或蓝牙设备生命周期。

## 验证

- 完整测试：341 个 XCTest（1 个既有跳过）和 5 个 Swift Testing 测试通过。
- Release 构建通过。
- 本机实测快速模式、随便问和跨模式停止均正常。
- 修复后热键到录音 ready 约 100–110 ms，其中音频引擎启动约 46–52 ms。

Fixes #232
