### PR TITLE
fix: prevent floating transcript panel layout loop

### DIFF
--- a/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
@@ -64,6 +64,10 @@ final class FloatingBarController {
 
         let barView = FloatingBarView<AppState>(state: state)
         let hosting = NSHostingView(rootView: barView)
+        // The controller owns the panel frame. Content-driven sizing can otherwise
+        // resize the window while SwiftUI is laying it out and trigger an AppKit
+        // update-constraints loop for long transcript previews.
+        hosting.sizingOptions = []
         hosting.layer?.backgroundColor = .clear
         hosting.frame = NSRect(origin: .zero, size: frame.size)
         hosting.autoresizingMask = [.width, .height]

--- a/Type4Me/UI/FloatingBar/FloatingBarView.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarView.swift
@@ -461,19 +461,22 @@ struct FloatingBarView<S: FloatingBarState>: View {
     // MARK: - Transcript Popup View
 
     private var transcriptPopup: some View {
-        Text(state.transcriptionText)
-            .font(.system(size: 14, weight: .medium))
-            .foregroundStyle(.white)
-            .fixedSize(horizontal: false, vertical: true)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(12)
-            .frame(width: TF.barWidth)
-            .background(
-                RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous)
-                    .fill(Color(white: 0.08, opacity: 0.78))
-            )
-            .clipShape(RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous))
-            .shadow(color: Color.black.opacity(0.3), radius: 8, y: -2)
+        ScrollView(.vertical) {
+            Text(state.transcriptionText)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(.white)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+        }
+        .frame(width: TF.barWidth)
+        .frame(maxHeight: TF.transcriptPopupMaxHeight)
+        .background(
+            RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous)
+                .fill(Color(white: 0.08, opacity: 0.78))
+        )
+        .clipShape(RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous))
+        .shadow(color: Color.black.opacity(0.3), radius: 8, y: -2)
     }
 }
 

--- a/Type4MeTests/FloatingBarPanelTests.swift
+++ b/Type4MeTests/FloatingBarPanelTests.swift
@@ -1,0 +1,64 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import Type4Me
+
+@MainActor
+final class FloatingBarPanelTests: XCTestCase {
+    func testHostingViewDoesNotDrivePanelSize() throws {
+        let (_, panel) = try makeControllerAndPanel()
+        defer { panel.orderOut(nil) }
+
+        let hosting = try XCTUnwrap(
+            panel.contentView as? NSHostingView<FloatingBarView<AppState>>
+        )
+
+        XCTAssertEqual(hosting.sizingOptions, [])
+    }
+
+    func testLongPinnedTranscriptKeepsPanelWithinReservedSize() throws {
+        let (state, controller, panel) = try makeStateControllerAndPanel()
+        defer { panel.orderOut(nil) }
+        let expectedSize = panel.frame.size
+
+        state.showRecovery(
+            text: String(repeating: "This is a long transcript segment. ", count: 1_000),
+            message: "Recovering"
+        )
+
+        for _ in 0..<10 {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+            panel.contentView?.layoutSubtreeIfNeeded()
+        }
+
+        let hosting = try XCTUnwrap(
+            panel.contentView as? NSHostingView<FloatingBarView<AppState>>
+        )
+        let fittingSize = hosting.fittingSize
+
+        XCTAssertEqual(panel.frame.width, expectedSize.width, accuracy: 0.5)
+        XCTAssertEqual(panel.frame.height, expectedSize.height, accuracy: 0.5)
+        XCTAssertLessThanOrEqual(fittingSize.height, expectedSize.height)
+        withExtendedLifetime(controller) {}
+    }
+
+    private func makeControllerAndPanel() throws -> (FloatingBarController, FloatingBarPanel) {
+        let state = AppState()
+        let (_, controller, panel) = try makeStateControllerAndPanel(state: state)
+        return (controller, panel)
+    }
+
+    private func makeStateControllerAndPanel(
+        state: AppState = AppState()
+    ) throws -> (AppState, FloatingBarController, FloatingBarPanel) {
+        _ = NSApplication.shared
+        let existingWindows = Set(NSApp.windows.map(ObjectIdentifier.init))
+        let controller = FloatingBarController(state: state)
+        let panel = try XCTUnwrap(
+            NSApp.windows
+                .compactMap { $0 as? FloatingBarPanel }
+                .first { !existingWindows.contains(ObjectIdentifier($0)) }
+        )
+        return (state, controller, panel)
+    }
+}


### PR DESCRIPTION
## Summary

- keep the floating transcript panel frame under `FloatingBarController` ownership
- cap long transcript previews at the reserved popup height and make overflow scrollable
- add regression coverage for content-driven panel resizing

## Root cause

The floating panel installs `NSHostingView` directly as its `contentView` while also managing a fixed frame manually. `NSHostingView` defaults to `.standardBounds`, so long SwiftUI content can update the window's sizing constraints.

The transcript popup also used vertically fixed-size text without applying `TF.transcriptPopupMaxHeight` to the actual view. During a long recording, the popup expanded the v2.0.0 panel from 432x492 to 432x603. SwiftUI then repeatedly resized the window and invalidated safe-area constraints until AppKit raised `NSGenericException` for excessive Update Constraints passes.

## Changes

- set `hosting.sizingOptions = []` for the fixed-size panel
- wrap transcript text in a vertical `ScrollView` capped at `TF.transcriptPopupMaxHeight`
- verify a long pinned transcript cannot change the panel frame or exceed its reserved fitting height

This does not replace or depend on #236, which addresses hover-state flicker and tracking-area stability.

## Validation

- `swift test --filter FloatingBarPanelTests` — 2 tests, 0 failures
- `swift test` — 339 XCTest tests, 1 skipped, 0 failures; 5 Swift Testing tests, 0 failures
- `swift build -c release` — succeeded

Fixes #237
