### PR TITLE
feat(asr): add Cartesia Ink-2 streaming

### DIFF
--- a/Type4Me/ASR/ASRProvider.swift
+++ b/Type4Me/ASR/ASRProvider.swift
@@ -12,6 +12,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
     case google
     case aws
     case deepgram
+    case cartesia
     case assemblyai
     case elevenlabs
     case grok
@@ -40,6 +41,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
         case .google:   return "Google Cloud STT"
         case .aws:      return "AWS Transcribe"
         case .deepgram: return "Deepgram"
+        case .cartesia: return "Cartesia"
         case .assemblyai: return "AssemblyAI"
         case .elevenlabs: return "ElevenLabs"
         case .grok:     return "Grok"

--- a/Type4Me/ASR/ASRProviderRegistry.swift
+++ b/Type4Me/ASR/ASRProviderRegistry.swift
@@ -68,6 +68,11 @@ enum ASRProviderRegistry {
                 createClient: { DeepgramASRClient() },
                 capabilities: .streaming()
             ),
+            .cartesia: ProviderEntry(
+                configType: CartesiaASRConfig.self,
+                createClient: { CartesiaASRClient() },
+                capabilities: .streaming()
+            ),
             .assemblyai: ProviderEntry(
                 configType: AssemblyAIASRConfig.self,
                 createClient: { AssemblyAIASRClient() },

--- a/Type4Me/ASR/CartesiaASRClient.swift
+++ b/Type4Me/ASR/CartesiaASRClient.swift
@@ -1,0 +1,97 @@
+import Foundation
+import os
+
+/// Cartesia Ink-2 manual realtime STT. The app owns voice activity detection,
+/// so recording completion sends Cartesia's required `finalize` command.
+actor CartesiaASRClient: SpeechRecognizer {
+    private let logger = Logger(subsystem: "com.type4me.asr", category: "CartesiaASRClient")
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var receiveTask: Task<Void, Never>?
+    private var eventContinuation: AsyncStream<RecognitionEvent>.Continuation?
+    private var stream: AsyncStream<RecognitionEvent>?
+    private var confirmedSegments: [String] = []
+
+    var events: AsyncStream<RecognitionEvent> {
+        if let stream { return stream }
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        self.stream = stream
+        eventContinuation = continuation
+        return stream
+    }
+
+    func connect(config: any ASRProviderConfig, options: ASRRequestOptions = ASRRequestOptions()) async throws {
+        guard let config = config as? CartesiaASRConfig else {
+            throw CartesiaProtocolError.invalidEndpoint
+        }
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        self.stream = stream
+        eventContinuation = continuation
+        confirmedSegments = []
+
+        let url = try CartesiaProtocol.buildWebSocketURL(config: config, options: options)
+        var request = URLRequest(url: url)
+        request.setValue(config.apiKey, forHTTPHeaderField: "X-API-Key")
+        let task = URLSession(configuration: options.urlSessionConfiguration).webSocketTask(with: request)
+        webSocketTask = task
+        task.resume()
+        startReceiveLoop()
+        logger.info("Cartesia Ink-2 WebSocket started")
+    }
+
+    func sendAudio(_ data: Data) async throws {
+        guard let webSocketTask else { return }
+        try await webSocketTask.send(.data(data))
+    }
+
+    func endAudio() async throws {
+        guard let webSocketTask else { return }
+        try await webSocketTask.send(.string("finalize"))
+    }
+
+    func disconnect() {
+        receiveTask?.cancel()
+        receiveTask = nil
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        webSocketTask = nil
+        eventContinuation?.finish()
+        eventContinuation = nil
+        stream = nil
+        confirmedSegments = []
+    }
+
+    private func startReceiveLoop() {
+        receiveTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                do {
+                    guard let task = await self.webSocketTask else { break }
+                    let message = try await task.receive()
+                    await self.handle(message)
+                } catch {
+                    if !Task.isCancelled {
+                        await self.eventContinuation?.yield(.error(error))
+                        await self.eventContinuation?.yield(.completed)
+                    }
+                    break
+                }
+            }
+        }
+    }
+
+    private func handle(_ message: URLSessionWebSocketTask.Message) {
+        do {
+            let data: Data
+            switch message {
+            case .data(let value): data = value
+            case .string(let value): data = Data(value.utf8)
+            @unknown default: return
+            }
+            guard let update = try CartesiaProtocol.makeTranscriptUpdate(from: data, confirmedSegments: confirmedSegments) else { return }
+            confirmedSegments = update.confirmedSegments
+            eventContinuation?.yield(.transcript(update.transcript))
+            if update.transcript.isFinal { eventContinuation?.yield(.completed) }
+        } catch {
+            eventContinuation?.yield(.error(error))
+        }
+    }
+}

--- a/Type4Me/ASR/CartesiaASRClient.swift
+++ b/Type4Me/ASR/CartesiaASRClient.swift
@@ -10,6 +10,10 @@ actor CartesiaASRClient: SpeechRecognizer {
     private var eventContinuation: AsyncStream<RecognitionEvent>.Continuation?
     private var stream: AsyncStream<RecognitionEvent>?
     private var confirmedSegments: [String] = []
+    /// Cartesia may finalize individual transcript chunks while the microphone
+    /// remains open. Only the explicit `finalize` we send on key release ends
+    /// the app's recording session.
+    private var awaitingFinalization = false
 
     var events: AsyncStream<RecognitionEvent> {
         if let stream { return stream }
@@ -27,6 +31,7 @@ actor CartesiaASRClient: SpeechRecognizer {
         self.stream = stream
         eventContinuation = continuation
         confirmedSegments = []
+        awaitingFinalization = false
 
         let url = try CartesiaProtocol.buildWebSocketURL(config: config, options: options)
         var request = URLRequest(url: url)
@@ -45,6 +50,7 @@ actor CartesiaASRClient: SpeechRecognizer {
 
     func endAudio() async throws {
         guard let webSocketTask else { return }
+        awaitingFinalization = true
         try await webSocketTask.send(.string("finalize"))
     }
 
@@ -57,6 +63,7 @@ actor CartesiaASRClient: SpeechRecognizer {
         eventContinuation = nil
         stream = nil
         confirmedSegments = []
+        awaitingFinalization = false
     }
 
     private func startReceiveLoop() {
@@ -88,8 +95,18 @@ actor CartesiaASRClient: SpeechRecognizer {
             }
             guard let update = try CartesiaProtocol.makeTranscriptUpdate(from: data, confirmedSegments: confirmedSegments) else { return }
             confirmedSegments = update.confirmedSegments
-            eventContinuation?.yield(.transcript(update.transcript))
-            if update.transcript.isFinal { eventContinuation?.yield(.completed) }
+            let completesRecording = awaitingFinalization && update.transcript.isFinal
+            let transcript = RecognitionTranscript(
+                confirmedSegments: update.transcript.confirmedSegments,
+                partialText: update.transcript.partialText,
+                authoritativeText: update.transcript.authoritativeText,
+                isFinal: completesRecording
+            )
+            eventContinuation?.yield(.transcript(transcript))
+            if completesRecording {
+                awaitingFinalization = false
+                eventContinuation?.yield(.completed)
+            }
         } catch {
             eventContinuation?.yield(.error(error))
         }

--- a/Type4Me/ASR/Providers/CartesiaASRConfig.swift
+++ b/Type4Me/ASR/Providers/CartesiaASRConfig.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+struct CartesiaASRConfig: ASRProviderConfig, Sendable {
+    static let provider = ASRProvider.cartesia
+    static let displayName = "Cartesia"
+    static let model = "ink-2"
+    static let language = "en"
+
+    static var credentialFields: [CredentialField] { [
+        CredentialField(key: "apiKey", label: "API Key", placeholder: L("粘贴 API Key", "Paste your API Key"), isSecure: true, isOptional: false, defaultValue: ""),
+    ] }
+
+    let apiKey: String
+
+    init?(credentials: [String: String]) {
+        guard let apiKey = credentials["apiKey"]?.trimmingCharacters(in: .whitespacesAndNewlines), !apiKey.isEmpty else {
+            return nil
+        }
+        self.apiKey = apiKey
+    }
+
+    func toCredentials() -> [String: String] { ["apiKey": apiKey] }
+    var isValid: Bool { !apiKey.isEmpty }
+}

--- a/Type4Me/ASR/Providers/CartesiaASRConfig.swift
+++ b/Type4Me/ASR/Providers/CartesiaASRConfig.swift
@@ -7,7 +7,7 @@ struct CartesiaASRConfig: ASRProviderConfig, Sendable {
     static let language = "en"
 
     static var credentialFields: [CredentialField] { [
-        CredentialField(key: "apiKey", label: "API Key", placeholder: L("粘贴 API Key", "Paste your API Key"), isSecure: true, isOptional: false, defaultValue: ""),
+        CredentialField(key: "apiKey", label: "API Key", placeholder: "sk_car_...", isSecure: true, isOptional: false, defaultValue: ""),
     ] }
 
     let apiKey: String

--- a/Type4Me/Protocol/CartesiaProtocol.swift
+++ b/Type4Me/Protocol/CartesiaProtocol.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+enum CartesiaProtocolError: Error, LocalizedError, Equatable {
+    case invalidEndpoint
+    case serverError(title: String, message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidEndpoint:
+            return L("无法生成 Cartesia WebSocket URL", "Failed to build Cartesia WebSocket URL")
+        case let .serverError(title, message):
+            return "Cartesia \(title): \(message)"
+        }
+    }
+}
+
+struct CartesiaTranscriptUpdate: Sendable, Equatable {
+    let transcript: RecognitionTranscript
+    let confirmedSegments: [String]
+}
+
+enum CartesiaProtocol {
+    static let endpoint = "wss://api.cartesia.ai/stt/websocket"
+    static let apiVersion = "2026-08-14"
+
+    static func buildWebSocketURL(config: CartesiaASRConfig, options: ASRRequestOptions) throws -> URL {
+        guard var components = URLComponents(string: endpoint) else { throw CartesiaProtocolError.invalidEndpoint }
+        var queryItems = [
+            URLQueryItem(name: "model", value: CartesiaASRConfig.model),
+            URLQueryItem(name: "encoding", value: "pcm_s16le"),
+            URLQueryItem(name: "sample_rate", value: "16000"),
+            URLQueryItem(name: "cartesia_version", value: apiVersion),
+            URLQueryItem(name: "language", value: CartesiaASRConfig.language),
+        ]
+        queryItems.append(contentsOf: options.hotwords
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .prefix(100)
+            .map { URLQueryItem(name: "keyterm", value: $0) })
+        components.queryItems = queryItems
+        guard let url = components.url else { throw CartesiaProtocolError.invalidEndpoint }
+        return url
+    }
+
+    static func makeTranscriptUpdate(from data: Data, confirmedSegments: [String]) throws -> CartesiaTranscriptUpdate? {
+        let response = try JSONDecoder().decode(Response.self, from: data)
+        if response.type == "error" {
+            throw CartesiaProtocolError.serverError(title: response.title ?? "Error", message: response.message ?? "Unknown server error")
+        }
+        guard response.type == "transcript" else { return nil }
+        let text = response.text ?? ""
+        var confirmed = confirmedSegments
+        let partial: String
+        if response.isFinal == true {
+            if !text.isEmpty { confirmed.append(text) }
+            partial = ""
+        } else {
+            partial = text
+        }
+        let transcript = RecognitionTranscript(
+            confirmedSegments: confirmed,
+            partialText: partial,
+            authoritativeText: (confirmed + (partial.isEmpty ? [] : [partial])).joined(),
+            isFinal: response.isFinal ?? false
+        )
+        return CartesiaTranscriptUpdate(transcript: transcript, confirmedSegments: confirmed)
+    }
+
+    private struct Response: Decodable {
+        let type: String
+        let isFinal: Bool?
+        let text: String?
+        let title: String?
+        let message: String?
+        enum CodingKeys: String, CodingKey { case type; case isFinal = "is_final"; case text; case title; case message }
+    }
+}

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -201,6 +201,9 @@ actor RecognitionSession {
         if provider == .sherpa {
             return "\(providerName) · \(ModelManager.selectedStreamingModel.displayName)"
         }
+        if provider == .cartesia {
+            return "\(providerName) · \(CartesiaASRConfig.model)"
+        }
 
         guard let credentials = KeychainService.loadASRConfig(for: provider)?.toCredentials() else {
             return providerName

--- a/Type4Me/UI/Settings/ASRSettingsCard.swift
+++ b/Type4Me/UI/Settings/ASRSettingsCard.swift
@@ -113,6 +113,11 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
                 (L("可用模型", "Models"), L("查看", "view"), URL(string: "https://developers.deepgram.com/docs/models-languages-overview/")!),
                 (L("API Key", "API Key"), L("获取", "get"), URL(string: "https://developers.deepgram.com/docs/create-additional-api-keys")!),
             ]
+        case .cartesia:
+            return [
+                (L("文档", "Docs"), L("查看", "view"), URL(string: "https://docs.cartesia.ai/use-the-api/stt/compare-endpoints")!),
+                ("API Key", L("获取", "get"), URL(string: "https://play.cartesia.ai/keys")!),
+            ]
         case .assemblyai:
             return [
                 (L("可用模型", "Models"), L("查看", "view"), URL(string: "https://www.assemblyai.com/docs/getting-started/models")!),

--- a/Type4MeTests/CartesiaProtocolTests.swift
+++ b/Type4MeTests/CartesiaProtocolTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import Type4Me
+
+final class CartesiaProtocolTests: XCTestCase {
+    func testConfigDefaultsToInk2English() throws {
+        let config = try XCTUnwrap(CartesiaASRConfig(credentials: ["apiKey": "key"]))
+        XCTAssertEqual(CartesiaASRConfig.model, "ink-2")
+        XCTAssertEqual(CartesiaASRConfig.language, "en")
+        XCTAssertTrue(config.isValid)
+        XCTAssertTrue(ASRProviderRegistry.configType(for: .cartesia) == CartesiaASRConfig.self)
+        XCTAssertTrue(ASRProviderRegistry.entry(for: .cartesia)?.isAvailable == true)
+    }
+
+    func testWebSocketURLUsesDocumentedInk2ParametersAndKeyterms() throws {
+        let config = try XCTUnwrap(CartesiaASRConfig(credentials: ["apiKey": "key"]))
+        let url = try CartesiaProtocol.buildWebSocketURL(
+            config: config,
+            options: ASRRequestOptions(hotwords: ["Type4Me", "Ink 2"])
+        )
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertEqual(url.host, "api.cartesia.ai")
+        XCTAssertEqual(items.first(where: { $0.name == "model" })?.value, "ink-2")
+        XCTAssertEqual(items.first(where: { $0.name == "encoding" })?.value, "pcm_s16le")
+        XCTAssertEqual(items.first(where: { $0.name == "sample_rate" })?.value, "16000")
+        XCTAssertEqual(items.first(where: { $0.name == "cartesia_version" })?.value, CartesiaProtocol.apiVersion)
+        XCTAssertEqual(items.filter { $0.name == "keyterm" }.compactMap(\.value), ["Type4Me", "Ink 2"])
+    }
+
+    func testTranscriptDeltasAreConcatenatedOnlyWhenFinal() throws {
+        let partial = try CartesiaProtocol.makeTranscriptUpdate(
+            from: Data(#"{"type":"transcript","is_final":false,"text":"Hello"}"#.utf8),
+            confirmedSegments: []
+        )
+        XCTAssertEqual(partial?.transcript.partialText, "Hello")
+        XCTAssertTrue(partial?.confirmedSegments.isEmpty == true)
+
+        let final = try CartesiaProtocol.makeTranscriptUpdate(
+            from: Data(#"{"type":"transcript","is_final":true,"text":"Hello world"}"#.utf8),
+            confirmedSegments: []
+        )
+        XCTAssertEqual(final?.transcript.authoritativeText, "Hello world")
+        XCTAssertTrue(final?.transcript.isFinal == true)
+    }
+}


### PR DESCRIPTION
## Summary
- add Cartesia as a realtime ASR provider using the English-only Ink-2 model
- stream 16 kHz PCM to Cartesia’s manual WebSocket endpoint and finalize on record-key release
- add Cartesia setup UI, keyterm support, history metadata, and focused protocol tests
- prevent server-finalized interim chunks from ending an active recording

## Validation
- `swift test --filter CartesiaProtocolTests`
- manually verified in local test build

## Screenshot
<img width="908" height="232" alt="Type4Me_Settings" src="https://github.com/user-attachments/assets/eb822b4d-9fd1-41c3-ac60-34f59e162e69" />


<img width="475" height="146" alt="image" src="https://github.com/user-attachments/assets/a30b7399-ca2e-4883-a9aa-2ed80b300409" />
