### PR TITLE
fix(input): isolate standalone modifier hotkeys and preserve side-specific keys (#243)

### DIFF
--- a/Type4Me/Input/HotkeyManager.swift
+++ b/Type4Me/Input/HotkeyManager.swift
@@ -24,6 +24,7 @@ struct ModeBinding: Sendable {
     let style: HotkeyStyle
     let onStart: @Sendable () -> Void
     let onStop: @Sendable () -> Void
+    let onAbort: @Sendable () -> Void
     var onBusyConflict: (@Sendable () -> Void)? = nil
 
     init(
@@ -34,6 +35,7 @@ struct ModeBinding: Sendable {
         style: HotkeyStyle,
         onStart: @escaping @Sendable () -> Void,
         onStop: @escaping @Sendable () -> Void,
+        onAbort: (@Sendable () -> Void)? = nil,
         onBusyConflict: (@Sendable () -> Void)? = nil
     ) {
         self.bindingId = bindingId
@@ -43,6 +45,7 @@ struct ModeBinding: Sendable {
         self.style = style
         self.onStart = onStart
         self.onStop = onStop
+        self.onAbort = onAbort ?? { @Sendable in }
         self.onBusyConflict = onBusyConflict
     }
 
@@ -54,6 +57,7 @@ struct ModeBinding: Sendable {
         style: HotkeyStyle,
         onStart: @escaping @Sendable () -> Void,
         onStop: @escaping @Sendable () -> Void,
+        onAbort: (@Sendable () -> Void)? = nil,
         onBusyConflict: (@Sendable () -> Void)? = nil
     ) {
         self.init(
@@ -64,6 +68,7 @@ struct ModeBinding: Sendable {
             style: style,
             onStart: onStart,
             onStop: onStop,
+            onAbort: onAbort,
             onBusyConflict: onBusyConflict
         )
     }
@@ -121,6 +126,89 @@ struct ModeBinding: Sendable {
 
     /// Check if a keyCode represents a media key.
     static func isMediaKeyCode(_ keyCode: Int) -> Bool { keyCode >= mediaKeyCodeBase }
+
+    // MARK: - Device-Specific Modifier Masks
+    //
+    // macOS IOKit / NSEvent device-dependent modifier flags in CGEvent.flags.rawValue
+    static let deviceLeftControlMask: UInt64   = 0x00000001
+    static let deviceLeftShiftMask: UInt64     = 0x00000002
+    static let deviceRightShiftMask: UInt64    = 0x00000004
+    static let deviceLeftCommandMask: UInt64   = 0x00000008
+    static let deviceRightCommandMask: UInt64  = 0x00000010
+    static let deviceLeftOptionMask: UInt64    = 0x00000020
+    static let deviceRightOptionMask: UInt64   = 0x00000040
+    static let deviceRightControlMask: UInt64  = 0x00002000
+    static let allDeviceModifierMasks: UInt64  = 0x0000207F
+
+    static func deviceModifierMask(for keyCode: Int) -> UInt64? {
+        switch keyCode {
+        case 54: return deviceRightCommandMask
+        case 55: return deviceLeftCommandMask
+        case 56: return deviceLeftShiftMask
+        case 60: return deviceRightShiftMask
+        case 58: return deviceLeftOptionMask
+        case 61: return deviceRightOptionMask
+        case 59: return deviceLeftControlMask
+        case 62: return deviceRightControlMask
+        default: return nil
+        }
+    }
+
+    static func isModifierPressed(keyCode: Int, flags: CGEventFlags) -> Bool {
+        let raw = flags.rawValue
+        switch keyCode {
+        case 54:
+            if raw & deviceRightCommandMask != 0 { return true }
+            if raw & deviceLeftCommandMask != 0 { return false }
+            return flags.contains(.maskCommand)
+        case 55:
+            if raw & deviceLeftCommandMask != 0 { return true }
+            if raw & deviceRightCommandMask != 0 { return false }
+            return flags.contains(.maskCommand)
+        case 56:
+            if raw & deviceLeftShiftMask != 0 { return true }
+            if raw & deviceRightShiftMask != 0 { return false }
+            return flags.contains(.maskShift)
+        case 60:
+            if raw & deviceRightShiftMask != 0 { return true }
+            if raw & deviceLeftShiftMask != 0 { return false }
+            return flags.contains(.maskShift)
+        case 58:
+            if raw & deviceLeftOptionMask != 0 { return true }
+            if raw & deviceRightOptionMask != 0 { return false }
+            return flags.contains(.maskAlternate)
+        case 61:
+            if raw & deviceRightOptionMask != 0 { return true }
+            if raw & deviceLeftOptionMask != 0 { return false }
+            return flags.contains(.maskAlternate)
+        case 59:
+            if raw & deviceLeftControlMask != 0 { return true }
+            if raw & deviceRightControlMask != 0 { return false }
+            return flags.contains(.maskControl)
+        case 62:
+            if raw & deviceRightControlMask != 0 { return true }
+            if raw & deviceLeftControlMask != 0 { return false }
+            return flags.contains(.maskControl)
+        case 63:
+            return flags.contains(.maskSecondaryFn)
+        default:
+            return false
+        }
+    }
+
+    static func modifierKeyCodes(forRawFlags rawFlags: UInt64, standardFlags: CGEventFlags) -> Set<Int> {
+        var keys = Set<Int>()
+        if rawFlags & deviceLeftCommandMask != 0 { keys.insert(55) }
+        if rawFlags & deviceRightCommandMask != 0 { keys.insert(54) }
+        if rawFlags & deviceLeftShiftMask != 0 { keys.insert(56) }
+        if rawFlags & deviceRightShiftMask != 0 { keys.insert(60) }
+        if rawFlags & deviceLeftOptionMask != 0 { keys.insert(58) }
+        if rawFlags & deviceRightOptionMask != 0 { keys.insert(61) }
+        if rawFlags & deviceLeftControlMask != 0 { keys.insert(59) }
+        if rawFlags & deviceRightControlMask != 0 { keys.insert(62) }
+        if standardFlags.contains(.maskSecondaryFn) { keys.insert(63) }
+        return keys
+    }
 
     static func isModifierKeyCode(_ keyCode: Int) -> Bool {
         modifierKeyCodes.contains(keyCode)
@@ -222,6 +310,16 @@ struct ModeBinding: Sendable {
     }
 }
 
+extension CGEventFlags {
+    func isSubset(of other: CGEventFlags) -> Bool {
+        self.intersection(other) == self
+    }
+
+    func isStrictSubset(of other: CGEventFlags) -> Bool {
+        self != other && self.isSubset(of: other)
+    }
+}
+
 final class HotkeyManager: NSObject {
 
     // MARK: - Configuration
@@ -248,19 +346,26 @@ final class HotkeyManager: NSObject {
     private var activeRecordingModeId: UUID?
     private var activeRecordingOwner: HotkeyOwner?
     var onBusyConflict: (() -> Void)?
-    private struct PendingModifierTrigger {
-        let binding: ModeBinding
-        let token: UUID
+
+    private enum ModifierGestureState: Equatable {
+        case idle
+        case tracking
+        case candidate(bindingId: UUID, expected: CGEventFlags, token: UUID?)
+        case activeHold(bindingId: UUID, expected: CGEventFlags)
+        case settling
+        case disqualified
     }
-    private var pendingModifierTriggers: [UUID: PendingModifierTrigger] = [:]
-    /// The modifier-only binding whose full flag combo is currently exactly held.
-    /// Modifier combos are matched by their complete set of flags (order-independent),
-    /// so we track the single exactly-active combo rather than per-key edge state.
-    private var activeModifierComboBindingId: UUID?
+
+    private var gestureState: ModifierGestureState = .idle
+    private var candidateToken: UUID?
+    private var candidateTimer: Timer?
+
     /// Normalized modifier flags observed on the previous flagsChanged event, used to
     /// distinguish building a combo up (a real press) from releasing a larger combo
     /// down through a smaller one (a transient we must not treat as a press).
     private var previousModifierFlags: CGEventFlags = []
+    /// Track currently-held physical modifier key codes (e.g. 54 for Right Cmd vs 55 for Left Cmd).
+    private var heldModifierKeyCodes: Set<Int> = []
 
     /// Maximum hold duration before auto-stop (seconds).
     private let maxHoldDuration: TimeInterval = 120
@@ -297,16 +402,16 @@ final class HotkeyManager: NSObject {
         for key in holdState.keys { holdState[key] = false }
         holdSafetyTimers.values.forEach { $0.invalidate() }
         holdSafetyTimers = [:]
-        cancelPendingModifierTriggers()
-        activeModifierComboBindingId = nil
+        cancelCandidateTimer()
+        gestureState = .idle
         previousModifierFlags = []
+        heldModifierKeyCodes.removeAll()
     }
 
     /// Called when recording is finished by a different mode's hotkey.
     /// The application decides whether the ending mode should replace the starting mode.
     var onCrossModeFinish: ((UUID) -> Void)?
 
-    /// Called when ESC is pressed during active recording or processing (abort).
     /// Called when ESC is pressed during active recording or processing (abort).
     /// Returns true if the abort was handled (ESC should be swallowed),
     /// false if the app is not actually in an active session (ESC should pass through).
@@ -331,9 +436,10 @@ final class HotkeyManager: NSObject {
         clearActiveRecordingState()
         holdSafetyTimers.values.forEach { $0.invalidate() }
         holdSafetyTimers = [:]
-        cancelPendingModifierTriggers()
-        activeModifierComboBindingId = nil
+        cancelCandidateTimer()
+        gestureState = .idle
         previousModifierFlags = []
+        heldModifierKeyCodes.removeAll()
         updateMediaKeySession()
     }
 
@@ -409,7 +515,10 @@ final class HotkeyManager: NSObject {
         clearActiveRecordingState()
         holdSafetyTimers.values.forEach { $0.invalidate() }
         holdSafetyTimers = [:]
-        cancelPendingModifierTriggers()
+        cancelCandidateTimer()
+        gestureState = .idle
+        previousModifierFlags = []
+        heldModifierKeyCodes.removeAll()
     }
 
     // MARK: - Health check
@@ -540,7 +649,10 @@ final class HotkeyManager: NSObject {
         // MARK: Keyboard events
         let keyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
         if type == .keyDown {
-            cancelPendingModifierTriggers()
+            let isRepeat = event.getIntegerValueField(.keyboardEventAutorepeat) != 0
+            if !isModifierKeyCode(keyCode) {
+                reduceRegularKeyDownBeforeDispatch(keyCode: keyCode, isRepeat: isRepeat)
+            }
         }
 
         // Modifier-only combos (fn, Ctrl+Shift, fn+Shift, …) are matched by their full
@@ -554,7 +666,11 @@ final class HotkeyManager: NSObject {
                     "hotkey flagsChanged keyCode=\(keyCode) rawFlags=\(normalizedModifierFlags(event.flags).rawValue) previousFlags=\(previousModifierFlags.rawValue)"
                 )
             }
-            let matchedCombo = evaluateModifierBindings(currentFlags: event.flags)
+            let matchedCombo = evaluateModifierBindings(
+                currentFlags: event.flags,
+                rawFlags: event.flags.rawValue,
+                keyCode: keyCode
+            )
             return matchedCombo ? nil : Unmanaged.passUnretained(event)
         }
 
@@ -756,6 +872,40 @@ final class HotkeyManager: NSObject {
         return bindings.first { $0.bindingId == id }
     }
 
+    // MARK: - Reducer
+
+    internal func reduceRegularKeyDownBeforeDispatch(keyCode: CGKeyCode, isRepeat: Bool) {
+        guard !isRepeat else { return }
+        guard !isModifierKeyCode(keyCode) else { return }
+
+        cancelCandidateTimer()
+
+        switch gestureState {
+        case .idle:
+            break
+        case .candidate:
+            gestureState = .disqualified
+        case .activeHold(let bindingId, _):
+            gestureState = .disqualified
+            if let binding = bindings.first(where: { $0.bindingId == bindingId }) {
+                abortActiveHold(binding: binding)
+            } else if let active = activeRecordingBinding() {
+                abortActiveHold(binding: active)
+            } else {
+                clearActiveRecordingState()
+            }
+        case .tracking, .settling:
+            gestureState = .disqualified
+        case .disqualified:
+            break
+        }
+    }
+
+    private func abortActiveHold(binding: ModeBinding) {
+        clearActiveRecordingState()
+        binding.onAbort()
+    }
+
     // MARK: - Test SPI (internal)
     //
     // Exposes a thin driver + read-only views of the state machine so unit tests can
@@ -771,8 +921,17 @@ final class HotkeyManager: NSObject {
     /// Drive the modifier-combo evaluator with synthetic flags. This covers the
     /// prefix-delay path used by modifier-only bindings such as fn and fn+Shift.
     @discardableResult
-    internal func simulateModifierFlags(_ flags: CGEventFlags) -> Bool {
-        evaluateModifierBindings(currentFlags: flags)
+    internal func simulateModifierFlags(
+        _ flags: CGEventFlags,
+        rawFlags: UInt64? = nil,
+        keyCode: CGKeyCode? = nil
+    ) -> Bool {
+        evaluateModifierBindings(currentFlags: flags, rawFlags: rawFlags, keyCode: keyCode)
+    }
+
+    /// Drive the regular-key pre-dispatch reducer with a synthetic regular key-down.
+    internal func simulateRegularKeyDown(keyCode: CGKeyCode, isRepeat: Bool = false) {
+        reduceRegularKeyDownBeforeDispatch(keyCode: keyCode, isRepeat: isRepeat)
     }
 
     /// Stop the active recording (same path as ESC / safety timer / reset).
@@ -795,141 +954,290 @@ final class HotkeyManager: NSObject {
         holdSafetyTimers[bindingId] != nil
     }
 
+    /// True if a candidate classification timer is currently scheduled.
+    internal func hasPendingCandidateTimer() -> Bool {
+        candidateTimer != nil
+    }
+
+    /// Read-only snapshot of current modifier gesture state for tests.
+    internal var currentModifierGestureStateDescription: String {
+        switch gestureState {
+        case .idle: return "idle"
+        case .tracking: return "tracking"
+        case .candidate(let id, _, let token): return "candidate(\(id), token: \(String(describing: token)))"
+        case .activeHold(let id, _): return "activeHold(\(id))"
+        case .settling: return "settling"
+        case .disqualified: return "disqualified"
+        }
+    }
+
     // MARK: - Modifier Combo Evaluation
 
     /// Order-independent evaluation of modifier-only combos (e.g. `fn`, `Ctrl+Shift`,
     /// `fn+Shift`). A combo is active when the full set of currently-held modifier flags
     /// exactly equals the combo's flags, regardless of the order the keys were pressed.
-    /// At most one combo matches at a time. Prefix combos (e.g. `fn` when `fn+Shift`
-    /// also exists) are deferred so the longer combo wins when both are being formed.
+    /// At most one combo matches at a time.
     /// - Returns: `true` when the current flags exactly match a registered combo, so the
     ///   caller can swallow the event and suppress the modifier's own system behavior.
     @discardableResult
-    private func evaluateModifierBindings(currentFlags: CGEventFlags) -> Bool {
+    private func evaluateModifierBindings(
+        currentFlags: CGEventFlags,
+        rawFlags: UInt64? = nil,
+        keyCode: CGKeyCode? = nil
+    ) -> Bool {
         let current = normalizedModifierFlags(currentFlags)
         let previous = previousModifierFlags
         previousModifierFlags = current
+
+        updateHeldModifierKeyCodes(currentFlags: current, rawFlags: rawFlags, keyCode: keyCode)
 
         let matched = bindings.first { b in
             guard isModifierKeyCode(b.keyCode), !b.isMouseButton, !b.isMediaKey,
                   let expected = ModeBinding.fullModifierFlags(
                       keyCode: Int(b.keyCode), modifiers: b.modifiers.rawValue)
             else { return false }
-            return expected == current
+            guard expected == current else { return false }
+            return heldModifierKeyCodes.contains(Int(b.keyCode))
         }
         let shouldSwallow = matched != nil
 
-        guard matched?.bindingId != activeModifierComboBindingId else { return shouldSwallow }
+        if current.isEmpty {
+            cancelCandidateTimer()
 
-        // Release the previously-active combo.
-        if let activeId = activeModifierComboBindingId,
-           let activeBinding = bindings.first(where: { $0.bindingId == activeId }) {
-            activeModifierComboBindingId = nil
-            let activeExpected = ModeBinding.fullModifierFlags(
-                keyCode: Int(activeBinding.keyCode), modifiers: activeBinding.modifiers.rawValue) ?? []
-            let buildingIntoLargerCombo = activeExpected != current && activeExpected.isSubset(of: current)
-            if buildingIntoLargerCombo, pendingModifierTriggers[activeId] != nil {
-                // We're extending a deferred prefix (e.g. fn → fn+Shift) into the longer
-                // combo. Drop the pending prefix trigger silently; do NOT fire it as a tap.
-                cancelPendingModifierTriggers()
-            } else if !consumePendingModifierRelease(for: activeBinding) {
-                handleBindingEvent(binding: activeBinding, pressed: false)
+            switch gestureState {
+            case .idle:
+                return false
+            case .tracking, .settling, .disqualified:
+                gestureState = .idle
+                return false
+            case .candidate(let candidateId, let expected, _):
+                gestureState = .idle
+                if previous == expected {
+                    if let candidateBinding = bindings.first(where: { $0.bindingId == candidateId }),
+                       candidateBinding.style == .toggle {
+                        handleTogglePress(binding: candidateBinding)
+                    }
+                }
+                return false
+            case .activeHold(let bindingId, let expected):
+                gestureState = .idle
+                if previous == expected {
+                    if let activeBinding = bindings.first(where: { $0.bindingId == bindingId }) {
+                        handleHoldRelease(binding: activeBinding)
+                    } else {
+                        stopActiveRecording()
+                    }
+                } else {
+                    stopActiveRecording()
+                }
+                return false
             }
         }
 
-        // Press the newly-active combo (if any).
-        guard let matched, !current.isEmpty,
-              let expected = ModeBinding.fullModifierFlags(
-                  keyCode: Int(matched.keyCode), modifiers: matched.modifiers.rawValue)
-        else { return shouldSwallow }
+        if gestureState == .disqualified {
+            return false
+        }
 
-        // Arriving here by releasing a *larger* combo down through this one (previous
-        // flags were a strict superset) is a release transient, not a deliberate press:
-        // don't trigger, and don't mark active so the following release is a clean no-op.
-        if expected != previous && expected.isSubset(of: previous) { return shouldSwallow }
+        if gestureState == .settling {
+            return false
+        }
 
-        activeModifierComboBindingId = matched.bindingId
-        if shouldDeferModifierTrigger(for: matched) {
-            schedulePendingModifierTrigger(for: matched)
+        let isBuilding = !previous.isEmpty && current != previous && !current.isStrictSubset(of: previous)
+
+        switch gestureState {
+        case .idle:
+            if let matched,
+               let expected = ModeBinding.fullModifierFlags(keyCode: Int(matched.keyCode), modifiers: matched.modifiers.rawValue) {
+                armCandidate(binding: matched, expected: expected)
+                return true
+            } else {
+                gestureState = .tracking
+                return false
+            }
+
+        case .tracking:
+            if isBuilding,
+               let matched,
+               let expected = ModeBinding.fullModifierFlags(keyCode: Int(matched.keyCode), modifiers: matched.modifiers.rawValue) {
+                armCandidate(binding: matched, expected: expected)
+                return true
+            }
+            return false
+
+        case .candidate(let candidateId, let expected, _):
+            let candidateBinding = bindings.first(where: { $0.bindingId == candidateId })
+
+            // Clean-release predicate:
+            // previous == expected && current != expected && current.isStrictSubset(of: expected)
+            if previous == expected && current != expected && current.isStrictSubset(of: expected) {
+                cancelCandidateTimer()
+                gestureState = current.isEmpty ? .idle : .settling
+
+                if let candidateBinding, candidateBinding.style == .toggle {
+                    handleTogglePress(binding: candidateBinding)
+                }
+                return false
+            }
+
+            if isBuilding {
+                if let matched,
+                   let newExpected = ModeBinding.fullModifierFlags(keyCode: Int(matched.keyCode), modifiers: matched.modifiers.rawValue),
+                   expected.isStrictSubset(of: newExpected) {
+                    cancelCandidateTimer()
+                    armCandidate(binding: matched, expected: newExpected)
+                    return true
+                } else if expected.isStrictSubset(of: current) {
+                    cancelCandidateTimer()
+                    gestureState = .tracking
+                    return false
+                }
+            }
+
+            if current.isStrictSubset(of: previous) {
+                cancelCandidateTimer()
+                gestureState = current.isEmpty ? .idle : .settling
+                return false
+            }
+
+            return shouldSwallow
+
+        case .activeHold(let bindingId, let expected):
+            let activeBinding = bindings.first(where: { $0.bindingId == bindingId })
+
+            // Clean-release predicate:
+            if previous == expected && current != expected && current.isStrictSubset(of: expected) {
+                gestureState = current.isEmpty ? .idle : .settling
+                if let activeBinding {
+                    handleHoldRelease(binding: activeBinding)
+                } else {
+                    stopActiveRecording()
+                }
+                return false
+            }
+
+            if isBuilding {
+                if let activeBinding {
+                    handleHoldRelease(binding: activeBinding)
+                } else {
+                    stopActiveRecording()
+                }
+
+                if let matched,
+                   let newExpected = ModeBinding.fullModifierFlags(keyCode: Int(matched.keyCode), modifiers: matched.modifiers.rawValue) {
+                    armCandidate(binding: matched, expected: newExpected)
+                    return true
+                } else {
+                    gestureState = .tracking
+                    return false
+                }
+            }
+
+            if current.isStrictSubset(of: previous) {
+                if let activeBinding {
+                    handleHoldRelease(binding: activeBinding)
+                } else {
+                    stopActiveRecording()
+                }
+                gestureState = current.isEmpty ? .idle : .settling
+                return false
+            }
+
+            return shouldSwallow
+
+        case .settling, .disqualified:
+            return false
+        }
+    }
+
+    private func armCandidate(binding: ModeBinding, expected: CGEventFlags) {
+        cancelCandidateTimer()
+        if binding.style == .hold {
+            let token = UUID()
+            gestureState = .candidate(bindingId: binding.bindingId, expected: expected, token: token)
+            candidateToken = token
+            let delay = modifierPrefixTriggerDelay
+            candidateTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+                self?.fireCandidateTimer(bindingId: binding.bindingId, token: token)
+            }
         } else {
-            cancelPendingModifierTriggers()
-            handleBindingEvent(binding: matched, pressed: true)
-        }
-        return shouldSwallow
-    }
-
-    // MARK: - Modifier Prefix Conflicts
-
-    private func shouldDeferModifierTrigger(for binding: ModeBinding) -> Bool {
-        guard isModifierKeyCode(binding.keyCode) else { return false }
-
-        return bindings.contains { other in
-            guard other.bindingId != binding.bindingId,
-                  !other.isMouseButton,
-                  !other.isMediaKey
-            else { return false }
-            return ModeBinding.modifierBindingIsPrefix(
-                modifierKeyCode: Int(binding.keyCode),
-                modifierModifiers: binding.modifiers.rawValue,
-                otherKeyCode: Int(other.keyCode),
-                otherModifiers: other.modifiers.rawValue
-            )
+            gestureState = .candidate(bindingId: binding.bindingId, expected: expected, token: nil)
         }
     }
 
-    private func schedulePendingModifierTrigger(for binding: ModeBinding) {
-        cancelPendingModifierTriggers(except: binding.bindingId)
-        let token = UUID()
-        pendingModifierTriggers[binding.bindingId] = PendingModifierTrigger(binding: binding, token: token)
-        DispatchQueue.main.asyncAfter(deadline: .now() + modifierPrefixTriggerDelay) { [weak self] in
-            self?.firePendingModifierTrigger(bindingId: binding.bindingId, token: token)
-        }
-    }
-
-    private func firePendingModifierTrigger(bindingId: UUID, token: UUID) {
-        guard let pending = pendingModifierTriggers[bindingId],
-              pending.token == token,
-              isExactModifierComboActive(for: pending.binding)
+    private func fireCandidateTimer(bindingId: UUID, token: UUID) {
+        guard case .candidate(let currentBindingId, let expected, let currentToken) = gestureState,
+              currentBindingId == bindingId,
+              currentToken == token,
+              let binding = bindings.first(where: { $0.bindingId == bindingId }),
+              binding.style == .hold
         else { return }
-        pendingModifierTriggers.removeValue(forKey: bindingId)
-        handleBindingEvent(binding: pending.binding, pressed: true)
+
+        guard previousModifierFlags == expected else { return }
+        guard heldModifierKeyCodes.contains(Int(binding.keyCode)) else { return }
+
+        cancelCandidateTimer()
+        gestureState = .activeHold(bindingId: bindingId, expected: expected)
+        holdState[bindingId] = true
+        startSafetyTimer(for: binding)
+        startRecording(with: binding)
     }
 
-    private func consumePendingModifierRelease(for binding: ModeBinding) -> Bool {
-        guard let pending = pendingModifierTriggers.removeValue(forKey: binding.bindingId) else { return false }
-
-        // A hold binding released before its prefix delay elapsed was never
-        // physically active. Starting and stopping it back-to-back is both
-        // useless and racy: onStart schedules the recording asynchronously,
-        // so onStop can run first and observe an idle UI, leaving the later
-        // recording start unstopped. A quick release should therefore cancel
-        // the pending hold entirely. Toggle bindings still need a synthesized
-        // press/release so a quick tap retains toggle semantics.
-        guard pending.binding.style == .toggle else { return true }
-        handleBindingEvent(binding: pending.binding, pressed: true)
-        handleBindingEvent(binding: pending.binding, pressed: false)
-        return true
+    private func cancelCandidateTimer() {
+        candidateToken = nil
+        candidateTimer?.invalidate()
+        candidateTimer = nil
     }
 
-    private func cancelPendingModifierTriggers(except bindingId: UUID? = nil) {
-        let ids = pendingModifierTriggers.keys.filter { $0 != bindingId }
-        for id in ids {
-            pendingModifierTriggers.removeValue(forKey: id)
+    private func updateHeldModifierKeyCodes(
+        currentFlags: CGEventFlags,
+        rawFlags: UInt64?,
+        keyCode: CGKeyCode?
+    ) {
+        if let rawFlags, rawFlags & ModeBinding.allDeviceModifierMasks != 0 {
+            heldModifierKeyCodes = ModeBinding.modifierKeyCodes(forRawFlags: rawFlags, standardFlags: currentFlags)
+            return
         }
-    }
 
-    private func isExactModifierComboActive(for binding: ModeBinding) -> Bool {
-        guard let expected = ModeBinding.fullModifierFlags(
-            keyCode: Int(binding.keyCode),
-            modifiers: binding.modifiers.rawValue
-        ) else { return false }
+        if currentFlags.isEmpty {
+            heldModifierKeyCodes.removeAll()
+            return
+        }
 
-        // `CGEventSource.flagsState` does not reliably report `.maskSecondaryFn`
-        // while Fn is held. The event tap has already observed the authoritative
-        // flagsChanged state, and updates `previousModifierFlags` before scheduling
-        // the prefix delay. Use that state so a deferred Fn hold can actually fire;
-        // a release event clears it before the pending trigger gets a chance to run.
-        return previousModifierFlags == expected
+        if let keyCode, isModifierKeyCode(keyCode) {
+            let kc = Int(keyCode)
+            if ModeBinding.isModifierPressed(keyCode: kc, flags: currentFlags) {
+                heldModifierKeyCodes.insert(kc)
+                if currentFlags.contains(.maskSecondaryFn) {
+                    heldModifierKeyCodes.insert(63)
+                }
+            } else {
+                heldModifierKeyCodes.remove(kc)
+                if let ownFlag = ModeBinding.modifierEventFlag(for: kc), !currentFlags.contains(ownFlag) {
+                    switch ownFlag {
+                    case .maskCommand: heldModifierKeyCodes.subtract([54, 55])
+                    case .maskShift: heldModifierKeyCodes.subtract([56, 60])
+                    case .maskAlternate: heldModifierKeyCodes.subtract([58, 61])
+                    case .maskControl: heldModifierKeyCodes.subtract([59, 62])
+                    case .maskSecondaryFn: heldModifierKeyCodes.remove(63)
+                    default: break
+                    }
+                }
+            }
+            return
+        }
+
+        if currentFlags.contains(.maskSecondaryFn) {
+            heldModifierKeyCodes.insert(63)
+        } else {
+            heldModifierKeyCodes.remove(63)
+        }
+        for binding in bindings where isModifierKeyCode(binding.keyCode) {
+            if let expected = ModeBinding.fullModifierFlags(
+                keyCode: Int(binding.keyCode), modifiers: binding.modifiers.rawValue),
+               expected == currentFlags {
+                heldModifierKeyCodes.insert(Int(binding.keyCode))
+            }
+        }
     }
 
     // MARK: - Safety Timer
@@ -989,12 +1297,20 @@ final class HotkeyManager: NSObject {
 
             if !stillDown {
                 NSLog("[HotkeyManager] Recovering stuck hold for binding %@", id.uuidString)
+                let wasDisqualified = gestureState == .disqualified
                 holdState[id] = false
                 cancelSafetyTimer(for: id)
-                if activeRecordingBindingId == id {
-                    stopActiveRecording()
+                if wasDisqualified {
+                    if activeRecordingBindingId == id {
+                        clearActiveRecordingState()
+                    }
+                    binding.onAbort()
                 } else {
-                    binding.onStop()
+                    if activeRecordingBindingId == id {
+                        stopActiveRecording()
+                    } else {
+                        binding.onStop()
+                    }
                 }
             }
         }
@@ -1021,14 +1337,7 @@ final class HotkeyManager: NSObject {
     }
 
     private func isModifierPressed(keyCode: CGKeyCode, flags: CGEventFlags) -> Bool {
-        switch keyCode {
-        case 54, 55: return flags.contains(.maskCommand)
-        case 56, 60: return flags.contains(.maskShift)
-        case 58, 61: return flags.contains(.maskAlternate)
-        case 59, 62: return flags.contains(.maskControl)
-        case 63: return flags.contains(.maskSecondaryFn)
-        default: return false
-        }
+        ModeBinding.isModifierPressed(keyCode: Int(keyCode), flags: flags)
     }
 
     // MARK: - Media Session (prevent Apple Music auto-launch)

--- a/Type4Me/Services/ReviseCoordinator.swift
+++ b/Type4Me/Services/ReviseCoordinator.swift
@@ -305,6 +305,11 @@ actor ReviseCoordinator {
         }
     }
 
+    func cancelActiveTransaction() {
+        guard transaction?.phase != .committing else { return }
+        transaction = nil
+    }
+
     // MARK: - Commit
 
     func commit(

--- a/Type4Me/Session/SoundFeedback.swift
+++ b/Type4Me/Session/SoundFeedback.swift
@@ -148,6 +148,15 @@ enum SoundFeedback {
         playSound(errorSpec.label, volume: errorSpec.volume)
     }
 
+    /// Synchronously enqueues stopping all cached players on the sound queue.
+    static func cancelActiveFeedback() {
+        soundQueue.async {
+            for player in cachedPlayers.values {
+                player.stop()
+            }
+        }
+    }
+
     static func previewStartSound(_ style: StartSoundStyle) {
         switch style {
         case .off: return

--- a/Type4Me/Type4MeApp.swift
+++ b/Type4Me/Type4MeApp.swift
@@ -88,6 +88,23 @@ struct SelectionAskFollowUpStartGate {
     }
 }
 
+struct RecordingStartGate {
+    private(set) var generation = 0
+
+    mutating func begin() -> Int {
+        generation &+= 1
+        return generation
+    }
+
+    mutating func invalidate() {
+        generation &+= 1
+    }
+
+    func allowsStart(token: Int) -> Bool {
+        token == generation
+    }
+}
+
 // MARK: - App Delegate
 
 @MainActor
@@ -112,6 +129,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let hotkeyManager = HotkeyManager()
     private let session = RecognitionSession()
     private var selectionAskFollowUpStartGate = SelectionAskFollowUpStartGate()
+    private var recordingStartGate = RecordingStartGate()
     private var recognitionEventTask: Task<Void, Never>?
     private var recognitionEventContinuation: AsyncStream<RecognitionEvent>.Continuation?
 
@@ -577,10 +595,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         self.askAnythingCoordinator.prepareForExternalNewQuestion()
                     }
                 }
+                let startToken = MainActor.assumeIsolated { self.recordingStartGate.begin() }
                 let recordingRequestedAt = ContinuousClock.now
                 NSLog("[Type4Me] >>> HOTKEY: Record START (mode: %@)", effectiveMode.name)
                 DebugFileLogger.log("hotkey record start mode=\(effectiveMode.name)")
                 Task { @MainActor in
+                    guard self.recordingStartGate.allowsStart(token: startToken) else { return }
                     self.appState.selectModeForRecording(effectiveMode)
                     self.appState.startRecording()
                 }
@@ -590,6 +610,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     if !ready {
                         NSLog("[Type4Me] >>> HOTKEY: previous session did not reach idle in time")
                         DebugFileLogger.log("hotkey start: awaitIdle timed out")
+                    }
+                    let canStart = await MainActor.run {
+                        self.recordingStartGate.allowsStart(token: startToken)
+                    }
+                    guard canStart else {
+                        NSLog("[Type4Me] >>> HOTKEY: start aborted by start gate token invalidation")
+                        DebugFileLogger.log("hotkey start aborted by start gate token invalidation")
+                        return
                     }
                     await self.session.startRecording(
                         mode: effectiveMode,
@@ -623,6 +651,41 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     Task { await self.session.stopRecording() }
                 }
             }
+            let onAbort: @Sendable () -> Void = { [weak self] in
+                guard let self else { return }
+
+                if capturedMode.executionKind == .selectionAsk {
+                    let isAskVisible = MainActor.assumeIsolated { self.selectionAskController?.isVisible == true }
+                    let isFollowUp = MainActor.assumeIsolated { self.selectionAskController?.isRecordingFollowUp == true }
+                    if isAskVisible && isFollowUp {
+                        _ = MainActor.assumeIsolated {
+                            self.selectionAskController?.handleActiveRecordingAction(.cancel)
+                        }
+                        return
+                    }
+
+                    let isCoordinatorFollowUp = MainActor.assumeIsolated { self.askAnythingCoordinator.isRecordingFollowUp }
+                    if isCoordinatorFollowUp {
+                        _ = MainActor.assumeIsolated {
+                            self.askAnythingCoordinator.cancelActiveFollowUp()
+                        }
+                        return
+                    }
+                }
+
+                NSLog("[Type4Me] >>> HOTKEY: Record ABORT (full discard)")
+                DebugFileLogger.log("hotkey record abort: full discard")
+
+                MainActor.assumeIsolated {
+                    self.recordingStartGate.invalidate()
+                    self.selectionAskFollowUpStartGate.invalidate()
+                    self.appState.cancel()
+                }
+                SoundFeedback.cancelActiveFeedback()
+                Task {
+                    await self.session.cancelRecording()
+                }
+            }
 
             // Fan out: one ModeBinding per hotkey binding, all sharing this mode's callbacks.
             return mode.hotkeyBindings.map { hk in
@@ -633,7 +696,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     modifiers: CGEventFlags(rawValue: hk.modifiers ?? 0),
                     style: hk.style,
                     onStart: onStart,
-                    onStop: onStop
+                    onStop: onStop,
+                    onAbort: onAbort
                 )
             }
         }
@@ -643,8 +707,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
            let hk = reviseSettings.hotkey {
             let reviseOnStart: @Sendable () -> Void = { [weak self] in
                 guard let self else { return }
+                let startToken = MainActor.assumeIsolated { self.recordingStartGate.begin() }
                 Task {
                     let prepResult = await ReviseCoordinator.shared.prepareForRecording()
+                    let canStart = await MainActor.run {
+                        self.recordingStartGate.allowsStart(token: startToken)
+                    }
+                    guard canStart else {
+                        if case .success(let prepared) = prepResult {
+                            await ReviseCoordinator.shared.cancel(transactionID: prepared.transactionID)
+                        }
+                        return
+                    }
                     switch prepResult {
                     case .success(let prepared):
                         await MainActor.run {
@@ -670,6 +744,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     Task { await self.session.stopRecording() }
                 }
             }
+            let reviseOnAbort: @Sendable () -> Void = { [weak self] in
+                guard let self else { return }
+                NSLog("[Type4Me] >>> HOTKEY: Revise ABORT (full discard)")
+                DebugFileLogger.log("hotkey revise abort: full discard")
+
+                MainActor.assumeIsolated {
+                    self.recordingStartGate.invalidate()
+                    self.appState.cancel()
+                }
+                SoundFeedback.cancelActiveFeedback()
+                Task {
+                    await ReviseCoordinator.shared.cancelActiveTransaction()
+                    await self.session.cancelRecording()
+                }
+            }
             let reviseBinding = ModeBinding(
                 bindingId: hk.id,
                 owner: .globalAction(.revise),
@@ -678,6 +767,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 style: hk.style,
                 onStart: reviseOnStart,
                 onStop: reviseOnStop,
+                onAbort: reviseOnAbort,
                 onBusyConflict: { [weak self] in
                     Task { @MainActor [weak self] in
                         SoundFeedback.playError()

--- a/Type4Me/UI/Settings/HotkeyRecorderView.swift
+++ b/Type4Me/UI/Settings/HotkeyRecorderView.swift
@@ -212,14 +212,7 @@ struct HotkeyRecorderView: View {
     }
 
     private func isModifierPressed(keyCode: Int, flags: NSEvent.ModifierFlags) -> Bool {
-        switch keyCode {
-        case 54, 55: return flags.contains(.command)
-        case 56, 60: return flags.contains(.shift)
-        case 58, 61: return flags.contains(.option)
-        case 59, 62: return flags.contains(.control)
-        case 63: return flags.contains(.function)
-        default: return false
-        }
+        ModeBinding.isModifierPressed(keyCode: keyCode, flags: CGEventFlags(rawValue: UInt64(flags.rawValue)))
     }
 
     // MARK: - Modifier Combo Helpers

--- a/Type4Me/UI/Settings/ModesSettingsTab.swift
+++ b/Type4Me/UI/Settings/ModesSettingsTab.swift
@@ -1542,9 +1542,7 @@ private struct HotkeyRecordingSheet: View {
     }
 
     private func isModifierPressed(keyCode: Int, flags: NSEvent.ModifierFlags) -> Bool {
-        if keyCode == 63 { return flags.contains(.function) }
-        guard let flag = modifierFlag(for: keyCode) else { return false }
-        return flags.contains(flag)
+        ModeBinding.isModifierPressed(keyCode: keyCode, flags: CGEventFlags(rawValue: UInt64(flags.rawValue)))
     }
 }
 

--- a/Type4MeTests/HotkeyConflictTests.swift
+++ b/Type4MeTests/HotkeyConflictTests.swift
@@ -263,4 +263,84 @@ final class HotkeyConflictTests: XCTestCase {
         XCTAssertEqual(other.hotkeyBindings.count, 1)
         XCTAssertEqual(other.hotkeyBindings.first?.keyCode, 21)
     }
+
+    func testLeftAndRightCommandAreNotEquivalentHotkeys() {
+        XCTAssertFalse(
+            ModeBinding.hotkeysAreEquivalent(
+                keyCode: 55,
+                modifiers: 0,
+                otherKeyCode: 54,
+                otherModifiers: 0
+            )
+        )
+    }
+
+    func testLeftAndRightOptionAreNotEquivalentHotkeys() {
+        XCTAssertFalse(
+            ModeBinding.hotkeysAreEquivalent(
+                keyCode: 58,
+                modifiers: 0,
+                otherKeyCode: 61,
+                otherModifiers: 0
+            )
+        )
+    }
+
+    func testLeftAndRightShiftAreNotEquivalentHotkeys() {
+        XCTAssertFalse(
+            ModeBinding.hotkeysAreEquivalent(
+                keyCode: 56,
+                modifiers: 0,
+                otherKeyCode: 60,
+                otherModifiers: 0
+            )
+        )
+    }
+
+    func testLeftAndRightControlAreNotEquivalentHotkeys() {
+        XCTAssertFalse(
+            ModeBinding.hotkeysAreEquivalent(
+                keyCode: 59,
+                modifiers: 0,
+                otherKeyCode: 62,
+                otherModifiers: 0
+            )
+        )
+    }
+
+    func testModifierKeyCodesExtractionFromDeviceMasks() {
+        let leftCmdRaw = ModeBinding.deviceLeftCommandMask | CGEventFlags.maskCommand.rawValue
+        let rightCmdRaw = ModeBinding.deviceRightCommandMask | CGEventFlags.maskCommand.rawValue
+        let bothCmdRaw = ModeBinding.deviceLeftCommandMask | ModeBinding.deviceRightCommandMask | CGEventFlags.maskCommand.rawValue
+
+        XCTAssertEqual(
+            ModeBinding.modifierKeyCodes(forRawFlags: leftCmdRaw, standardFlags: [.maskCommand]),
+            [55]
+        )
+        XCTAssertEqual(
+            ModeBinding.modifierKeyCodes(forRawFlags: rightCmdRaw, standardFlags: [.maskCommand]),
+            [54]
+        )
+        XCTAssertEqual(
+            ModeBinding.modifierKeyCodes(forRawFlags: bothCmdRaw, standardFlags: [.maskCommand]),
+            [55, 54]
+        )
+
+        let comboRaw = ModeBinding.deviceLeftShiftMask | CGEventFlags.maskShift.rawValue | CGEventFlags.maskSecondaryFn.rawValue
+        XCTAssertEqual(
+            ModeBinding.modifierKeyCodes(forRawFlags: comboRaw, standardFlags: [.maskShift, .maskSecondaryFn]),
+            [56, 63]
+        )
+    }
+
+    func testIsModifierPressedDistinguishesLeftAndRightSides() {
+        let leftCmdFlags = CGEventFlags(rawValue: ModeBinding.deviceLeftCommandMask | CGEventFlags.maskCommand.rawValue)
+        let rightCmdFlags = CGEventFlags(rawValue: ModeBinding.deviceRightCommandMask | CGEventFlags.maskCommand.rawValue)
+
+        XCTAssertTrue(ModeBinding.isModifierPressed(keyCode: 55, flags: leftCmdFlags))
+        XCTAssertFalse(ModeBinding.isModifierPressed(keyCode: 54, flags: leftCmdFlags))
+
+        XCTAssertTrue(ModeBinding.isModifierPressed(keyCode: 54, flags: rightCmdFlags))
+        XCTAssertFalse(ModeBinding.isModifierPressed(keyCode: 55, flags: rightCmdFlags))
+    }
 }

--- a/Type4MeTests/HotkeyStateMachineTests.swift
+++ b/Type4MeTests/HotkeyStateMachineTests.swift
@@ -1,11 +1,12 @@
 import XCTest
 @testable import Type4Me
 
-/// Thread-safe counters for capturing ModeBinding onStart/onStop invocation counts.
+/// Thread-safe counters for capturing ModeBinding onStart/onStop/onAbort invocation counts.
 final class BindingCounters: @unchecked Sendable {
     private let lock = NSLock()
     private var _startCount = 0
     private var _stopCount = 0
+    private var _abortCount = 0
 
     func recordStart() {
         lock.lock(); _startCount += 1; lock.unlock()
@@ -13,21 +14,25 @@ final class BindingCounters: @unchecked Sendable {
     func recordStop() {
         lock.lock(); _stopCount += 1; lock.unlock()
     }
+    func recordAbort() {
+        lock.lock(); _abortCount += 1; lock.unlock()
+    }
 
     var startCount: Int { lock.lock(); defer { lock.unlock() }; return _startCount }
     var stopCount: Int { lock.lock(); defer { lock.unlock() }; return _stopCount }
+    var abortCount: Int { lock.lock(); defer { lock.unlock() }; return _abortCount }
+
+    func reset() {
+        lock.lock()
+        _startCount = 0
+        _stopCount = 0
+        _abortCount = 0
+        lock.unlock()
+    }
 }
 
-/// State-machine regression tests for the multi-hotkey P0 "ghost hold" fix.
-///
-/// Before the fix, stopping a hold-initiated recording via any path other than the
-/// binding's own release left `holdState[bindingId] == true` and a running 120s safety
-/// timer. When the timer eventually fired, `handleHoldSafetyTimer` saw the stale
-/// hold state, passed its guard, and invoked `onStop` a second time on a session that
-/// was no longer recording — a "ghost stop". These tests exercise the three stop
-/// paths (same-mode second binding, cross-mode toggle, cross-mode hold) plus the
-/// direct stop path and assert no residual hold state, no pending safety timer, and
-/// exactly one `onStop` per binding.
+/// State-machine regression tests for multi-hotkey ghost hold prevention and
+/// standalone modifier hotkey state machine lifecycle (Issue #243 / MSOR-7).
 final class HotkeyStateMachineTests: XCTestCase {
 
     // MARK: - Fixtures
@@ -48,33 +53,45 @@ final class HotkeyStateMachineTests: XCTestCase {
         )
     }
 
-    private func makeHoldBinding(modeId: UUID, counters: BindingCounters) -> ModeBinding {
+    private func makeHoldBinding(
+        modeId: UUID = UUID(),
+        keyCode: CGKeyCode = 42,
+        modifiers: CGEventFlags = [],
+        counters: BindingCounters
+    ) -> ModeBinding {
         ModeBinding(
             bindingId: UUID(),
             modeId: modeId,
-            keyCode: 42,                       // arbitrary non-modifier keyCode
-            modifiers: [],
+            keyCode: keyCode,
+            modifiers: modifiers,
             style: .hold,
             onStart: { counters.recordStart() },
-            onStop: { counters.recordStop() }
+            onStop: { counters.recordStop() },
+            onAbort: { counters.recordAbort() }
         )
     }
 
-    private func makeToggleBinding(modeId: UUID, counters: BindingCounters) -> ModeBinding {
+    private func makeToggleBinding(
+        modeId: UUID = UUID(),
+        keyCode: CGKeyCode = 43,
+        modifiers: CGEventFlags = [],
+        counters: BindingCounters
+    ) -> ModeBinding {
         ModeBinding(
             bindingId: UUID(),
             modeId: modeId,
-            keyCode: 43,
-            modifiers: [],
+            keyCode: keyCode,
+            modifiers: modifiers,
             style: .toggle,
             onStart: { counters.recordStart() },
-            onStop: { counters.recordStop() }
+            onStop: { counters.recordStop() },
+            onAbort: { counters.recordAbort() }
         )
     }
 
     private func makeFnBinding(
         style: ProcessingMode.HotkeyStyle,
-        modeId: UUID,
+        modeId: UUID = UUID(),
         counters: BindingCounters
     ) -> ModeBinding {
         ModeBinding(
@@ -84,11 +101,15 @@ final class HotkeyStateMachineTests: XCTestCase {
             modifiers: [],
             style: style,
             onStart: { counters.recordStart() },
-            onStop: { counters.recordStop() }
+            onStop: { counters.recordStop() },
+            onAbort: { counters.recordAbort() }
         )
     }
 
-    private func makeFnShiftBinding(modeId: UUID, counters: BindingCounters) -> ModeBinding {
+    private func makeFnShiftBinding(
+        modeId: UUID = UUID(),
+        counters: BindingCounters
+    ) -> ModeBinding {
         ModeBinding(
             bindingId: UUID(),
             modeId: modeId,
@@ -96,18 +117,18 @@ final class HotkeyStateMachineTests: XCTestCase {
             modifiers: .maskSecondaryFn,
             style: .toggle,
             onStart: { counters.recordStart() },
-            onStop: { counters.recordStop() }
+            onStop: { counters.recordStop() },
+            onAbort: { counters.recordAbort() }
         )
     }
 
-    // MARK: - Tests
+    // MARK: - Suite 1: Non-Modifier Stop Paths & Ghost Hold Prevention
 
-    /// Direct stop path: hold press → stopActiveRecording. Before the fix this path
-    /// also left `holdState`/timer set; now `clearActiveRecordingState` cleans them.
+    /// Direct stop path: hold press → stopActiveRecording.
     func testStopActiveRecordingClearsHoldStateAndSafetyTimer() {
         let manager = makeManager()
         let counters = BindingCounters()
-        let binding = makeHoldBinding(modeId: UUID(), counters: counters)
+        let binding = makeHoldBinding(counters: counters)
 
         manager.registerBindings([binding])
         manager.simulateBindingEvent(binding, pressed: true)
@@ -126,15 +147,13 @@ final class HotkeyStateMachineTests: XCTestCase {
         XCTAssertEqual(counters.stopCount, 1, "onStop must be called exactly once")
     }
 
-    /// Path 1: hold recording → same-mode second toggle press. The second press just
-    /// stops the recording; it must not start a new one or leave the first binding's
-    /// hold state/timer behind.
+    /// Path 1: hold recording → same-mode second toggle press.
     func testHoldRecording_sameModeSecondTogglePressStopsWithoutGhostHold() {
         let manager = makeManager()
         let counters = BindingCounters()
         let modeId = UUID()
-        let hold = makeHoldBinding(modeId: modeId, counters: counters)
-        let toggle = makeToggleBinding(modeId: modeId, counters: counters)
+        let hold = makeHoldBinding(modeId: modeId, keyCode: 42, counters: counters)
+        let toggle = makeToggleBinding(modeId: modeId, keyCode: 43, counters: counters)
 
         manager.registerBindings([hold, toggle])
         manager.simulateBindingEvent(hold, pressed: true)
@@ -155,70 +174,42 @@ final class HotkeyStateMachineTests: XCTestCase {
         XCTAssertEqual(counters.stopCount, 1, "onStop must fire exactly once for the hold recording")
     }
 
-    /// Path 2: hold recording (mode A) → cross-mode toggle press (mode B). The toggle
-    /// hands off to the new mode via `onCrossModeFinish`; it must also clear the former
-    /// hold binding's state and timer so the safety timer can't ghost-stop it later.
-    func testHoldRecording_crossModeToggleClearsFormerHold() {
+    /// Path 2: hold recording (mode A) → cross-mode toggle press (mode B).
+    func testHoldRecording_crossModeToggleFinishesOnceAndClearsState() {
         let manager = makeManager()
         let counters = BindingCounters()
         let modeA = UUID()
         let modeB = UUID()
-        let hold = makeHoldBinding(modeId: modeA, counters: counters)
-        let toggle = makeToggleBinding(modeId: modeB, counters: counters)
+        let holdA = makeHoldBinding(modeId: modeA, keyCode: 42, counters: counters)
+        let toggleB = makeToggleBinding(modeId: modeB, keyCode: 43, counters: counters)
 
         var crossModeFinishes: [UUID] = []
         manager.onCrossModeFinish = { crossModeFinishes.append($0) }
 
-        manager.registerBindings([hold, toggle])
-        manager.simulateBindingEvent(hold, pressed: true)
+        manager.registerBindings([holdA, toggleB])
+        manager.simulateBindingEvent(holdA, pressed: true)
 
-        XCTAssertTrue(manager.isHoldActive(for: hold.bindingId))
-        XCTAssertTrue(manager.hasPendingSafetyTimer(for: hold.bindingId))
+        XCTAssertTrue(manager.isHoldActive(for: holdA.bindingId))
+        XCTAssertTrue(manager.hasPendingSafetyTimer(for: holdA.bindingId))
 
-        manager.simulateBindingEvent(toggle, pressed: true)
-
-        XCTAssertFalse(manager.isHoldActive(for: hold.bindingId),
-                       "cross-mode stop must clear the former hold binding's holdState")
-        XCTAssertFalse(manager.hasPendingSafetyTimer(for: hold.bindingId),
-                       "cross-mode stop must cancel the former hold binding's safety timer")
-        XCTAssertEqual(crossModeFinishes, [modeB],
-                       "onCrossModeFinish must fire exactly once with the new mode's id")
-        XCTAssertEqual(counters.stopCount, 0,
-                       "cross-mode finish must be coordinated by the application, not the former binding")
-    }
-
-    func testToggleRecording_crossModeToggleFinishesOnceAndClearsState() {
-        let manager = makeManager()
-        let counters = BindingCounters()
-        let modeA = UUID()
-        let modeB = UUID()
-        let toggleA = makeToggleBinding(modeId: modeA, counters: counters)
-        let toggleB = makeToggleBinding(modeId: modeB, counters: counters)
-
-        var crossModeFinishes: [UUID] = []
-        manager.onCrossModeFinish = { crossModeFinishes.append($0) }
-
-        manager.registerBindings([toggleA, toggleB])
-        manager.simulateBindingEvent(toggleA, pressed: true)
         manager.simulateBindingEvent(toggleB, pressed: true)
 
-        XCTAssertEqual(crossModeFinishes, [modeB])
-        XCTAssertFalse(manager.isActiveRecordingBinding(toggleA.bindingId))
+        XCTAssertFalse(manager.isHoldActive(for: holdA.bindingId))
+        XCTAssertFalse(manager.hasPendingSafetyTimer(for: holdA.bindingId))
+        XCTAssertFalse(manager.isActiveRecordingBinding(holdA.bindingId))
         XCTAssertFalse(manager.isActiveRecordingBinding(toggleB.bindingId))
-        XCTAssertEqual(counters.startCount, 1)
+        XCTAssertEqual(crossModeFinishes, [modeB])
         XCTAssertEqual(counters.stopCount, 0)
     }
 
-    /// Path 3: hold recording (mode A) → cross-mode hold press (mode B). Same expected
-    /// cleanup as path 2; the new mode's hold does not begin recording because the
-    /// cross-mode branch hands off to `onCrossModeFinish`.
+    /// Path 3: hold recording (mode A) → cross-mode hold press (mode B).
     func testHoldRecording_crossModeHoldClearsFormerHold() {
         let manager = makeManager()
         let counters = BindingCounters()
         let modeA = UUID()
         let modeB = UUID()
-        let holdA = makeHoldBinding(modeId: modeA, counters: counters)
-        let holdB = makeHoldBinding(modeId: modeB, counters: counters)
+        let holdA = makeHoldBinding(modeId: modeA, keyCode: 42, counters: counters)
+        let holdB = makeHoldBinding(modeId: modeB, keyCode: 43, counters: counters)
 
         var crossModeFinishes: [UUID] = []
         manager.onCrossModeFinish = { crossModeFinishes.append($0) }
@@ -231,22 +222,18 @@ final class HotkeyStateMachineTests: XCTestCase {
 
         manager.simulateBindingEvent(holdB, pressed: true)
 
-        XCTAssertFalse(manager.isHoldActive(for: holdA.bindingId),
-                       "cross-mode hold must clear the former hold binding's holdState")
-        XCTAssertFalse(manager.hasPendingSafetyTimer(for: holdA.bindingId),
-                       "cross-mode hold must cancel the former hold binding's safety timer")
-        XCTAssertFalse(manager.isHoldActive(for: holdB.bindingId),
-                       "cross-mode hold must not begin a new hold recording (it hands off to onCrossModeFinish)")
+        XCTAssertFalse(manager.isHoldActive(for: holdA.bindingId))
+        XCTAssertFalse(manager.hasPendingSafetyTimer(for: holdA.bindingId))
+        XCTAssertFalse(manager.isHoldActive(for: holdB.bindingId))
         XCTAssertEqual(crossModeFinishes, [modeB])
         XCTAssertEqual(counters.stopCount, 0)
     }
 
-    /// Regression: a normal hold release still clears state and fires onStop exactly once.
-    /// Ensures the unified `clearActiveRecordingState` cleanup didn't break the happy path.
+    /// Normal hold release clears state and fires onStop exactly once.
     func testHoldReleaseClearsStateAndStopsOnce() {
         let manager = makeManager()
         let counters = BindingCounters()
-        let binding = makeHoldBinding(modeId: UUID(), counters: counters)
+        let binding = makeHoldBinding(counters: counters)
 
         manager.registerBindings([binding])
         manager.simulateBindingEvent(binding, pressed: true)
@@ -262,85 +249,7 @@ final class HotkeyStateMachineTests: XCTestCase {
         XCTAssertEqual(counters.stopCount, 1, "onStop must be called exactly once on release")
     }
 
-    /// Regression: fn is deferred when fn+Shift is also bound. A quick fn tap
-    /// releases before that delay and must not enqueue an asynchronous recording
-    /// start after its stop has already been ignored by the idle UI.
-    func testQuickFnReleaseBeforePrefixDelayDoesNotStartHoldBinding() {
-        let manager = makeManager()
-        let counters = BindingCounters()
-        let fnHold = makeFnBinding(style: .hold, modeId: UUID(), counters: counters)
-        let fnShift = makeFnShiftBinding(modeId: UUID(), counters: counters)
-        manager.registerBindings([fnHold, fnShift])
-
-        manager.simulateModifierFlags(.maskSecondaryFn)
-        manager.simulateModifierFlags([])
-
-        XCTAssertEqual(counters.startCount, 0)
-        XCTAssertEqual(counters.stopCount, 0)
-        XCTAssertFalse(manager.isHoldActive(for: fnHold.bindingId))
-        XCTAssertFalse(manager.isActiveRecordingBinding(fnHold.bindingId))
-        XCTAssertFalse(manager.hasPendingSafetyTimer(for: fnHold.bindingId))
-    }
-
-    /// Toggle bindings intentionally treat the same quick prefix tap as a press,
-    /// so the hold-only fix must not remove their established behavior.
-    func testQuickFnReleaseBeforePrefixDelayStillStartsToggleBinding() {
-        let manager = makeManager()
-        let counters = BindingCounters()
-        let fnToggle = makeFnBinding(style: .toggle, modeId: UUID(), counters: counters)
-        let fnShift = makeFnShiftBinding(modeId: UUID(), counters: counters)
-        manager.registerBindings([fnToggle, fnShift])
-
-        manager.simulateModifierFlags(.maskSecondaryFn)
-        manager.simulateModifierFlags([])
-
-        XCTAssertEqual(counters.startCount, 1)
-        XCTAssertEqual(counters.stopCount, 0)
-        XCTAssertTrue(manager.isActiveRecordingBinding(fnToggle.bindingId))
-    }
-
-    /// Regression: Fn's state is not reliably present in
-    /// `CGEventSource.flagsState(.combinedSessionState)`. A hold that remains down
-    /// beyond the prefix delay must use the event tap's observed flags and start.
-    func testHeldFnPastPrefixDelayStartsAndReleaseStopsHoldBinding() {
-        let defaults = UserDefaults.standard
-        let key = HotkeyManager.modifierPrefixTriggerDelayKey
-        let priorValue = defaults.object(forKey: key)
-        defaults.set(0.02, forKey: key)
-        defer {
-            if let priorValue {
-                defaults.set(priorValue, forKey: key)
-            } else {
-                defaults.removeObject(forKey: key)
-            }
-        }
-
-        let manager = makeManager()
-        let counters = BindingCounters()
-        let fnHold = makeFnBinding(style: .hold, modeId: UUID(), counters: counters)
-        let fnShift = makeFnShiftBinding(modeId: UUID(), counters: counters)
-        manager.registerBindings([fnHold, fnShift])
-
-        manager.simulateModifierFlags(.maskSecondaryFn)
-
-        let delayElapsed = expectation(description: "modifier prefix delay elapsed")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) {
-            delayElapsed.fulfill()
-        }
-        wait(for: [delayElapsed], timeout: 0.5)
-
-        XCTAssertEqual(counters.startCount, 1)
-        XCTAssertEqual(counters.stopCount, 0)
-        XCTAssertTrue(manager.isHoldActive(for: fnHold.bindingId))
-        XCTAssertTrue(manager.isActiveRecordingBinding(fnHold.bindingId))
-
-        manager.simulateModifierFlags([])
-
-        XCTAssertEqual(counters.stopCount, 1)
-        XCTAssertFalse(manager.isHoldActive(for: fnHold.bindingId))
-        XCTAssertFalse(manager.isActiveRecordingBinding(fnHold.bindingId))
-    }
-
+    /// Cross mode stop while in revise recording.
     func testCrossModeStopWhileInReviseRecording() {
         let manager = makeManager()
         let reviseCounters = BindingCounters()
@@ -349,11 +258,12 @@ final class HotkeyStateMachineTests: XCTestCase {
         let reviseBinding = ModeBinding(
             bindingId: UUID(),
             owner: .globalAction(.revise),
-            keyCode: 15, // R
+            keyCode: 15,
             modifiers: [.maskSecondaryFn],
             style: .toggle,
             onStart: { reviseCounters.recordStart() },
-            onStop: { reviseCounters.recordStop() }
+            onStop: { reviseCounters.recordStop() },
+            onAbort: { reviseCounters.recordAbort() }
         )
 
         let modeBinding = ModeBinding(
@@ -363,19 +273,20 @@ final class HotkeyStateMachineTests: XCTestCase {
             modifiers: [],
             style: .toggle,
             onStart: { modeCounters.recordStart() },
-            onStop: { modeCounters.recordStop() }
+            onStop: { modeCounters.recordStop() },
+            onAbort: { modeCounters.recordAbort() }
         )
 
         manager.registerBindings([reviseBinding, modeBinding])
 
-        // 1. Enter Revise via toggle press
+        // Enter Revise via regular binding press
         manager.simulateBindingEvent(reviseBinding, pressed: true)
         manager.simulateBindingEvent(reviseBinding, pressed: false)
         XCTAssertEqual(reviseCounters.startCount, 1)
         XCTAssertEqual(reviseCounters.stopCount, 0)
         XCTAssertTrue(manager.isActiveRecordingBinding(reviseBinding.bindingId))
 
-        // 2. Press standard mode hotkey -> should exit/finish revise recording
+        // Press standard mode hotkey -> exits revise recording
         manager.simulateBindingEvent(modeBinding, pressed: true)
         manager.simulateBindingEvent(modeBinding, pressed: false)
 
@@ -383,53 +294,847 @@ final class HotkeyStateMachineTests: XCTestCase {
         XCTAssertFalse(manager.isActiveRecordingBinding(reviseBinding.bindingId))
     }
 
-    func testFnHoldStopsReviseRecordingAfterModifierPrefixDelay() {
+    // MARK: - Suite 2: Standalone Modifier Hotkey State Machine (Issue #243 / MSOR-7 Scenarios 1-13)
+
+    /// Scenario 1: Toggle Left Command + 'M' Key Contamination.
+    /// Cmd down -> candidate -> 'M' down -> disqualified -> Cmd up -> no callbacks; clean tap afterwards commits.
+    func testScenario1_ToggleLeftCommand_MChordDisqualifiesAndDoesNotTriggerOnRelease() {
+        let manager = makeManager()
+        let counters = BindingCounters()
+        let leftCmdBinding = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 55, // Left Command
+            modifiers: [],
+            style: .toggle,
+            onStart: { counters.recordStart() },
+            onStop: { counters.recordStop() },
+            onAbort: { counters.recordAbort() }
+        )
+        manager.registerBindings([leftCmdBinding])
+
+        let leftCmdRaw = ModeBinding.deviceLeftCommandMask | CGEventFlags.maskCommand.rawValue
+
+        // 1. Press Left Command down -> candidate armed
+        let swallowedCmd = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 55)
+        XCTAssertTrue(swallowedCmd)
+        XCTAssertEqual(counters.startCount, 0, "Toggle candidate must not start on key down")
+        XCTAssertEqual(counters.stopCount, 0)
+        XCTAssertEqual(counters.abortCount, 0)
+
+        // 2. Press regular non-modifier key 'M' (keyCode 46) -> disqualifies modifier gesture
+        manager.simulateRegularKeyDown(keyCode: 46)
+        XCTAssertEqual(counters.startCount, 0)
+        XCTAssertEqual(counters.stopCount, 0)
+        XCTAssertEqual(counters.abortCount, 0)
+
+        // 3. Release Left Command -> clean release is suppressed due to disqualification
+        let swallowedRelease = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 55)
+        XCTAssertFalse(swallowedRelease)
+        XCTAssertEqual(counters.startCount, 0, "Disqualified toggle must not commit on release")
+        XCTAssertEqual(counters.stopCount, 0)
+        XCTAssertEqual(counters.abortCount, 0)
+        XCTAssertFalse(manager.isActiveRecordingBinding(leftCmdBinding.bindingId))
+
+        // 4. Subsequent clean Left Command tap (Cmd down -> Cmd up) commits normally
+        _ = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 55)
+        XCTAssertEqual(counters.startCount, 0)
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 55)
+        XCTAssertEqual(counters.startCount, 1, "Clean tap after release must commit")
+        XCTAssertTrue(manager.isActiveRecordingBinding(leftCmdBinding.bindingId))
+    }
+
+    /// Scenario 2: Hold Left Command + 'M' Key Contamination Before 250ms Delay.
+    /// Cancels candidate timer without any callbacks.
+    func testScenario2_HoldLeftCommand_MChordBeforeClassificationDelayCancelsTimerWithoutCallbacks() {
+        let defaults = UserDefaults.standard
+        let key = HotkeyManager.modifierPrefixTriggerDelayKey
+        let priorValue = defaults.object(forKey: key)
+        defaults.set(0.05, forKey: key)
+        defer {
+            if let priorValue { defaults.set(priorValue, forKey: key) } else { defaults.removeObject(forKey: key) }
+        }
+
+        let manager = makeManager()
+        let counters = BindingCounters()
+        let leftCmdHold = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 55, // Left Command
+            modifiers: [],
+            style: .hold,
+            onStart: { counters.recordStart() },
+            onStop: { counters.recordStop() },
+            onAbort: { counters.recordAbort() }
+        )
+        manager.registerBindings([leftCmdHold])
+
+        let leftCmdRaw = ModeBinding.deviceLeftCommandMask | CGEventFlags.maskCommand.rawValue
+
+        // 1. Press Left Command down -> candidate armed, timer running
+        _ = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 55)
+        XCTAssertTrue(manager.hasPendingCandidateTimer())
+        XCTAssertEqual(counters.startCount, 0)
+
+        // 2. Press 'M' down before delay expires -> cancels timer and sets disqualified
+        manager.simulateRegularKeyDown(keyCode: 46)
+        XCTAssertFalse(manager.hasPendingCandidateTimer())
+        XCTAssertEqual(counters.startCount, 0)
+        XCTAssertEqual(counters.stopCount, 0)
+        XCTAssertEqual(counters.abortCount, 0)
+
+        // 3. Wait past stale timer deadline
+        let delayExp = expectation(description: "stale timer deadline")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { delayExp.fulfill() }
+        wait(for: [delayExp], timeout: 0.5)
+
+        XCTAssertEqual(counters.startCount, 0, "Cancelled timer must never fire")
+        XCTAssertEqual(counters.abortCount, 0)
+
+        // 4. Release Left Command
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 55)
+        XCTAssertEqual(counters.stopCount, 0)
+    }
+
+    /// Scenario 3: Hold Left Command + 'M' Key Contamination After Activation (Active Hold Abort).
+    /// Invokes onAbort without normal stop, clearing recording and safety timer.
+    func testScenario3_HoldLeftCommand_MChordAfterActivationInvokesAbortWithoutStopFeedback() {
         let defaults = UserDefaults.standard
         let key = HotkeyManager.modifierPrefixTriggerDelayKey
         let priorValue = defaults.object(forKey: key)
         defaults.set(0.02, forKey: key)
         defer {
-            if let priorValue {
-                defaults.set(priorValue, forKey: key)
-            } else {
-                defaults.removeObject(forKey: key)
-            }
+            if let priorValue { defaults.set(priorValue, forKey: key) } else { defaults.removeObject(forKey: key) }
         }
 
         let manager = makeManager()
-        let reviseCounters = BindingCounters()
-        let fnCounters = BindingCounters()
-        let fnShiftCounters = BindingCounters()
-        let reviseBinding = ModeBinding(
+        let counters = BindingCounters()
+        let leftCmdHold = ModeBinding(
             bindingId: UUID(),
-            owner: .globalAction(.revise),
-            keyCode: 15,
+            modeId: UUID(),
+            keyCode: 55, // Left Command
+            modifiers: [],
+            style: .hold,
+            onStart: { counters.recordStart() },
+            onStop: { counters.recordStop() },
+            onAbort: { counters.recordAbort() }
+        )
+        manager.registerBindings([leftCmdHold])
+
+        let leftCmdRaw = ModeBinding.deviceLeftCommandMask | CGEventFlags.maskCommand.rawValue
+
+        // 1. Press Left Command down -> wait for activation
+        _ = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 55)
+        let delayExp = expectation(description: "hold delay elapsed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { delayExp.fulfill() }
+        wait(for: [delayExp], timeout: 0.5)
+
+        XCTAssertEqual(counters.startCount, 1, "Hold should become active after delay")
+        XCTAssertTrue(manager.isHoldActive(for: leftCmdHold.bindingId))
+        XCTAssertTrue(manager.isActiveRecordingBinding(leftCmdHold.bindingId))
+        XCTAssertTrue(manager.hasPendingSafetyTimer(for: leftCmdHold.bindingId))
+
+        // 2. Press 'M' down while active -> triggers abort
+        manager.simulateRegularKeyDown(keyCode: 46)
+        XCTAssertEqual(counters.abortCount, 1, "Chord contamination on active hold must invoke onAbort")
+        XCTAssertEqual(counters.stopCount, 0, "Must not invoke normal onStop on abort")
+        XCTAssertFalse(manager.isHoldActive(for: leftCmdHold.bindingId))
+        XCTAssertFalse(manager.isActiveRecordingBinding(leftCmdHold.bindingId))
+        XCTAssertFalse(manager.hasPendingSafetyTimer(for: leftCmdHold.bindingId))
+
+        // 3. Release Left Command -> clean release does not trigger duplicate stop
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 55)
+        XCTAssertEqual(counters.stopCount, 0, "Release after abort must not fire onStop")
+        XCTAssertEqual(counters.abortCount, 1)
+    }
+
+    /// Scenario 4: Clean Left / Right Toggle Taps Commit on Exact Combo Reduction.
+    func testScenario4_CleanLeftAndRightToggleTapsCommitOnExactComboReduction() {
+        let manager = makeManager()
+        let leftCounters = BindingCounters()
+        let rightCounters = BindingCounters()
+
+        let leftCmdBinding = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 55, // Left Command
+            modifiers: [],
+            style: .toggle,
+            onStart: { leftCounters.recordStart() },
+            onStop: { leftCounters.recordStop() },
+            onAbort: { leftCounters.recordAbort() }
+        )
+        let rightCmdBinding = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 54, // Right Command
+            modifiers: [],
+            style: .toggle,
+            onStart: { rightCounters.recordStart() },
+            onStop: { rightCounters.recordStop() },
+            onAbort: { rightCounters.recordAbort() }
+        )
+        manager.registerBindings([leftCmdBinding, rightCmdBinding])
+
+        let leftCmdRaw = ModeBinding.deviceLeftCommandMask | CGEventFlags.maskCommand.rawValue
+        let rightCmdRaw = ModeBinding.deviceRightCommandMask | CGEventFlags.maskCommand.rawValue
+
+        // 1. Left Command tap (toggle on)
+        _ = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 55)
+        XCTAssertEqual(leftCounters.startCount, 0)
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 55)
+        XCTAssertEqual(leftCounters.startCount, 1)
+        XCTAssertTrue(manager.isActiveRecordingBinding(leftCmdBinding.bindingId))
+
+        // 2. Left Command tap (toggle off)
+        _ = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 55)
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 55)
+        XCTAssertEqual(leftCounters.stopCount, 1)
+        XCTAssertFalse(manager.isActiveRecordingBinding(leftCmdBinding.bindingId))
+
+        // 3. Right Command tap (toggle on)
+        _ = manager.simulateModifierFlags(.maskCommand, rawFlags: rightCmdRaw, keyCode: 54)
+        XCTAssertEqual(rightCounters.startCount, 0)
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 54)
+        XCTAssertEqual(rightCounters.startCount, 1)
+        XCTAssertTrue(manager.isActiveRecordingBinding(rightCmdBinding.bindingId))
+
+        // 4. Right Command tap (toggle off)
+        _ = manager.simulateModifierFlags(.maskCommand, rawFlags: rightCmdRaw, keyCode: 54)
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 54)
+        XCTAssertEqual(rightCounters.stopCount, 1)
+        XCTAssertFalse(manager.isActiveRecordingBinding(rightCmdBinding.bindingId))
+    }
+
+    /// Scenario 5: Clean Hold Past Delay Starts and Stops Normally on Reduction.
+    func testScenario5_CleanHoldPastDelayStartsAndStopsNormallyOnReduction() {
+        let defaults = UserDefaults.standard
+        let key = HotkeyManager.modifierPrefixTriggerDelayKey
+        let priorValue = defaults.object(forKey: key)
+        defaults.set(0.02, forKey: key)
+        defer {
+            if let priorValue { defaults.set(priorValue, forKey: key) } else { defaults.removeObject(forKey: key) }
+        }
+
+        let manager = makeManager()
+        let counters = BindingCounters()
+        let leftCmdHold = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 55, // Left Command
+            modifiers: [],
+            style: .hold,
+            onStart: { counters.recordStart() },
+            onStop: { counters.recordStop() },
+            onAbort: { counters.recordAbort() }
+        )
+        manager.registerBindings([leftCmdHold])
+
+        let leftCmdRaw = ModeBinding.deviceLeftCommandMask | CGEventFlags.maskCommand.rawValue
+
+        // 1. Hold Left Command down past delay
+        _ = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 55)
+        let delayExp = expectation(description: "hold delay elapsed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { delayExp.fulfill() }
+        wait(for: [delayExp], timeout: 0.5)
+
+        XCTAssertEqual(counters.startCount, 1)
+        XCTAssertTrue(manager.isHoldActive(for: leftCmdHold.bindingId))
+
+        // 2. Release Left Command -> clean stop
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 55)
+        XCTAssertEqual(counters.stopCount, 1)
+        XCTAssertEqual(counters.abortCount, 0)
+        XCTAssertFalse(manager.isHoldActive(for: leftCmdHold.bindingId))
+    }
+
+    /// Scenario 6: Multi-Modifier Step-Down Release: Toggle `Ctrl + Shift -> Ctrl -> empty`.
+    /// Commits once at first transition and suppresses Ctrl-only prefix.
+    func testScenario6_MultiModifierStepDown_ToggleCtrlShift_CommitsOnceAtFirstTransitionAndSuppressesPrefix() {
+        let manager = makeManager()
+        let ctrlCounters = BindingCounters()
+        let ctrlShiftCounters = BindingCounters()
+
+        let ctrlBinding = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 59, // Left Control
+            modifiers: [],
+            style: .toggle,
+            onStart: { ctrlCounters.recordStart() },
+            onStop: { ctrlCounters.recordStop() },
+            onAbort: { ctrlCounters.recordAbort() }
+        )
+        let ctrlShiftBinding = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 56, // Left Shift
+            modifiers: [.maskControl],
+            style: .toggle,
+            onStart: { ctrlShiftCounters.recordStart() },
+            onStop: { ctrlShiftCounters.recordStop() },
+            onAbort: { ctrlShiftCounters.recordAbort() }
+        )
+        manager.registerBindings([ctrlBinding, ctrlShiftBinding])
+
+        let ctrlRaw = ModeBinding.deviceLeftControlMask | CGEventFlags.maskControl.rawValue
+        let comboRaw = ModeBinding.deviceLeftControlMask | ModeBinding.deviceLeftShiftMask | CGEventFlags.maskControl.rawValue | CGEventFlags.maskShift.rawValue
+
+        // 1. Press Control down -> Ctrl candidate
+        _ = manager.simulateModifierFlags(.maskControl, rawFlags: ctrlRaw, keyCode: 59)
+        XCTAssertEqual(ctrlCounters.startCount, 0)
+
+        // 2. Press Shift down -> builds to Ctrl+Shift candidate
+        _ = manager.simulateModifierFlags([.maskControl, .maskShift], rawFlags: comboRaw, keyCode: 56)
+        XCTAssertEqual(ctrlShiftCounters.startCount, 0)
+        XCTAssertEqual(ctrlCounters.startCount, 0)
+
+        // 3. Release Shift (step-down to Ctrl) -> commits Ctrl+Shift toggle, enters settling
+        _ = manager.simulateModifierFlags(.maskControl, rawFlags: ctrlRaw, keyCode: 56)
+        XCTAssertEqual(ctrlShiftCounters.startCount, 1, "Ctrl+Shift toggle must commit on first step-down reduction")
+        XCTAssertEqual(ctrlCounters.startCount, 0, "Ctrl binding must be suppressed during settling")
+
+        // 4. Release Control (step-down to empty) -> resets to idle
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 59)
+        XCTAssertEqual(ctrlCounters.startCount, 0, "Releasing remaining modifier must not trigger Ctrl binding")
+        XCTAssertEqual(ctrlShiftCounters.startCount, 1)
+    }
+
+    /// Scenario 7: Multi-Modifier Step-Down Release: Hold `Ctrl + Shift -> Ctrl -> empty`.
+    /// Stops once at first transition and leaves no ghost hold state.
+    func testScenario7_MultiModifierStepDown_HoldCtrlShift_StopsOnceAtFirstTransitionAndLeavesNoGhostState() {
+        let defaults = UserDefaults.standard
+        let key = HotkeyManager.modifierPrefixTriggerDelayKey
+        let priorValue = defaults.object(forKey: key)
+        defaults.set(0.02, forKey: key)
+        defer {
+            if let priorValue { defaults.set(priorValue, forKey: key) } else { defaults.removeObject(forKey: key) }
+        }
+
+        let manager = makeManager()
+        let ctrlCounters = BindingCounters()
+        let ctrlShiftCounters = BindingCounters()
+
+        let ctrlHold = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 59, // Left Control
+            modifiers: [],
+            style: .hold,
+            onStart: { ctrlCounters.recordStart() },
+            onStop: { ctrlCounters.recordStop() },
+            onAbort: { ctrlCounters.recordAbort() }
+        )
+        let ctrlShiftHold = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 56, // Left Shift
+            modifiers: [.maskControl],
+            style: .hold,
+            onStart: { ctrlShiftCounters.recordStart() },
+            onStop: { ctrlShiftCounters.recordStop() },
+            onAbort: { ctrlShiftCounters.recordAbort() }
+        )
+        manager.registerBindings([ctrlHold, ctrlShiftHold])
+
+        let ctrlRaw = ModeBinding.deviceLeftControlMask | CGEventFlags.maskControl.rawValue
+        let comboRaw = ModeBinding.deviceLeftControlMask | ModeBinding.deviceLeftShiftMask | CGEventFlags.maskControl.rawValue | CGEventFlags.maskShift.rawValue
+
+        // 1. Press Control then Shift down -> combo candidate
+        _ = manager.simulateModifierFlags(.maskControl, rawFlags: ctrlRaw, keyCode: 59)
+        _ = manager.simulateModifierFlags([.maskControl, .maskShift], rawFlags: comboRaw, keyCode: 56)
+
+        // Wait for classification delay to start Ctrl+Shift hold
+        let delayExp = expectation(description: "combo hold delay elapsed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { delayExp.fulfill() }
+        wait(for: [delayExp], timeout: 0.5)
+
+        XCTAssertEqual(ctrlShiftCounters.startCount, 1)
+        XCTAssertEqual(ctrlCounters.startCount, 0)
+        XCTAssertTrue(manager.isHoldActive(for: ctrlShiftHold.bindingId))
+
+        // 2. Release Shift (step-down to Ctrl) -> clean stop for Ctrl+Shift hold, enters settling
+        _ = manager.simulateModifierFlags(.maskControl, rawFlags: ctrlRaw, keyCode: 56)
+        XCTAssertEqual(ctrlShiftCounters.stopCount, 1)
+        XCTAssertEqual(ctrlShiftCounters.abortCount, 0)
+        XCTAssertFalse(manager.isHoldActive(for: ctrlShiftHold.bindingId))
+        XCTAssertFalse(manager.hasPendingSafetyTimer(for: ctrlShiftHold.bindingId))
+        XCTAssertEqual(ctrlCounters.startCount, 0)
+
+        // 3. Release Control (step-down to empty) -> resets settling to idle
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 59)
+        XCTAssertEqual(ctrlCounters.startCount, 0)
+        XCTAssertEqual(ctrlCounters.stopCount, 0)
+        XCTAssertFalse(manager.isHoldActive(for: ctrlHold.bindingId))
+        XCTAssertFalse(manager.hasPendingSafetyTimer(for: ctrlHold.bindingId))
+    }
+
+    /// Scenario 8: Larger combo reached in either modifier order produces the same candidate.
+    func testScenario8_LargerComboFormedInEitherOrderProducesSameCandidate() {
+        let manager = makeManager()
+        let counters = BindingCounters()
+        let fnLeftShiftBinding = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 56, // Left Shift
             modifiers: [.maskSecondaryFn],
             style: .toggle,
-            onStart: { reviseCounters.recordStart() },
-            onStop: { reviseCounters.recordStop() }
+            onStart: { counters.recordStart() },
+            onStop: { counters.recordStop() },
+            onAbort: { counters.recordAbort() }
         )
-        let fnHold = makeFnBinding(style: .hold, modeId: UUID(), counters: fnCounters)
-        let fnShift = makeFnShiftBinding(modeId: UUID(), counters: fnShiftCounters)
-        manager.registerBindings([reviseBinding, fnHold, fnShift])
+        manager.registerBindings([fnLeftShiftBinding])
 
-        manager.simulateBindingEvent(reviseBinding, pressed: true)
-        manager.simulateBindingEvent(reviseBinding, pressed: false)
-        XCTAssertTrue(manager.isActiveRecordingBinding(reviseBinding.bindingId))
+        let fnFlags: CGEventFlags = [.maskSecondaryFn]
+        let fnRaw: UInt64 = CGEventFlags.maskSecondaryFn.rawValue
+        let leftShiftFlags: CGEventFlags = [.maskShift]
+        let leftShiftRaw: UInt64 = ModeBinding.deviceLeftShiftMask | CGEventFlags.maskShift.rawValue
+        let comboFlags: CGEventFlags = [.maskSecondaryFn, .maskShift]
+        let comboRaw: UInt64 = ModeBinding.deviceLeftShiftMask | CGEventFlags.maskShift.rawValue | CGEventFlags.maskSecondaryFn.rawValue
 
-        manager.simulateModifierFlags(.maskSecondaryFn)
-        let delayElapsed = expectation(description: "modifier prefix delay elapsed")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) {
-            delayElapsed.fulfill()
+        // Order 1: Fn down (63), then Left Shift down (56) -> combo candidate -> clean release to []
+        _ = manager.simulateModifierFlags(fnFlags, rawFlags: fnRaw, keyCode: 63)
+        _ = manager.simulateModifierFlags(comboFlags, rawFlags: comboRaw, keyCode: 56)
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 56)
+        XCTAssertEqual(counters.startCount, 1)
+
+        manager.resetActiveState()
+        counters.reset()
+
+        // Order 2: Left Shift down (56), then Fn down (63) -> combo candidate -> clean release to []
+        _ = manager.simulateModifierFlags(leftShiftFlags, rawFlags: leftShiftRaw, keyCode: 56)
+        _ = manager.simulateModifierFlags(comboFlags, rawFlags: comboRaw, keyCode: 63)
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 63)
+        XCTAssertEqual(counters.startCount, 1)
+    }
+
+    /// Scenario 9: Releasing a larger unowned combo through a registered smaller combo never arms it.
+    func testScenario9_ReleasingLargerUnownedComboThroughRegisteredSmallerComboNeverArmsIt() {
+        let manager = makeManager()
+        let ctrlCounters = BindingCounters()
+
+        let ctrlBinding = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 59, // Left Control
+            modifiers: [],
+            style: .toggle,
+            onStart: { ctrlCounters.recordStart() },
+            onStop: { ctrlCounters.recordStop() },
+            onAbort: { ctrlCounters.recordAbort() }
+        )
+        manager.registerBindings([ctrlBinding])
+
+        let ctrlRaw = ModeBinding.deviceLeftControlMask | CGEventFlags.maskControl.rawValue
+        let comboRaw = ModeBinding.deviceLeftControlMask | ModeBinding.deviceLeftShiftMask | CGEventFlags.maskControl.rawValue | CGEventFlags.maskShift.rawValue
+
+        // 1. Press unowned combo Ctrl + Shift directly
+        _ = manager.simulateModifierFlags([.maskControl, .maskShift], rawFlags: comboRaw, keyCode: 56)
+        XCTAssertEqual(ctrlCounters.startCount, 0)
+
+        // 2. Release Shift (Ctrl + Shift -> Ctrl) -> step-down transient
+        _ = manager.simulateModifierFlags(.maskControl, rawFlags: ctrlRaw, keyCode: 56)
+        XCTAssertEqual(ctrlCounters.startCount, 0, "Step-down from unowned combo must not arm Ctrl binding")
+
+        // 3. Release Control (Ctrl -> empty)
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 59)
+        XCTAssertEqual(ctrlCounters.startCount, 0)
+    }
+
+    /// Scenario 10: Regular key-up and later modifier changes do not re-arm a disqualified gesture;
+    /// complete release followed by a new press does.
+    func testScenario10_DisqualifiedStatePersistsUntilAllModifiersReleased() {
+        let manager = makeManager()
+        let counters = BindingCounters()
+        let leftCmdBinding = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 55, // Left Command
+            modifiers: [],
+            style: .toggle,
+            onStart: { counters.recordStart() },
+            onStop: { counters.recordStop() },
+            onAbort: { counters.recordAbort() }
+        )
+        manager.registerBindings([leftCmdBinding])
+
+        let leftCmdRaw = ModeBinding.deviceLeftCommandMask | CGEventFlags.maskCommand.rawValue
+        let cmdShiftRaw = ModeBinding.deviceLeftCommandMask | ModeBinding.deviceLeftShiftMask | CGEventFlags.maskCommand.rawValue | CGEventFlags.maskShift.rawValue
+
+        // 1. Cmd down -> 'M' down -> disqualified
+        _ = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 55)
+        manager.simulateRegularKeyDown(keyCode: 46)
+
+        // 2. Press Shift down while disqualified (Cmd + Shift) -> still disqualified
+        _ = manager.simulateModifierFlags([.maskCommand, .maskShift], rawFlags: cmdShiftRaw, keyCode: 56)
+        XCTAssertEqual(counters.startCount, 0)
+
+        // 3. Release Shift (back to Cmd) -> still disqualified
+        _ = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 56)
+        XCTAssertEqual(counters.startCount, 0)
+
+        // 4. Release Cmd (flags become empty) -> resets to idle
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 55)
+        XCTAssertEqual(counters.startCount, 0)
+
+        // 5. New clean tap now commits
+        _ = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 55)
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 55)
+        XCTAssertEqual(counters.startCount, 1)
+    }
+
+    /// Scenario 11: Toggle candidates have no classification timer; waiting beyond delay causes no callback.
+    func testScenario11_ToggleCandidateHasNoClassificationTimer() {
+        let manager = makeManager()
+        let counters = BindingCounters()
+        let leftCmdBinding = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 55, // Left Command
+            modifiers: [],
+            style: .toggle,
+            onStart: { counters.recordStart() },
+            onStop: { counters.recordStop() },
+            onAbort: { counters.recordAbort() }
+        )
+        manager.registerBindings([leftCmdBinding])
+
+        let leftCmdRaw = ModeBinding.deviceLeftCommandMask | CGEventFlags.maskCommand.rawValue
+
+        // 1. Press Cmd down
+        _ = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 55)
+        XCTAssertFalse(manager.hasPendingCandidateTimer(), "Toggle candidate must not schedule a classification timer")
+
+        // 2. Wait 0.05s
+        let waitExp = expectation(description: "wait while holding toggle")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { waitExp.fulfill() }
+        wait(for: [waitExp], timeout: 0.5)
+
+        XCTAssertEqual(counters.startCount, 0, "Toggle candidate must not commit while modifier is held")
+
+        // 3. Release Cmd -> clean release commit
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 55)
+        XCTAssertEqual(counters.startCount, 1)
+    }
+
+    /// Scenario 12: Raw-device-mask and key-code-fallback inputs both preserve side matching.
+    func testScenario12_RawDeviceMaskAndKeyCodeFallbackBothPreserveSideMatching() {
+        let manager = makeManager()
+        let leftCounters = BindingCounters()
+        let rightCounters = BindingCounters()
+
+        let leftCmdBinding = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 55, // Left Command
+            modifiers: [],
+            style: .toggle,
+            onStart: { leftCounters.recordStart() },
+            onStop: { leftCounters.recordStop() },
+            onAbort: { leftCounters.recordAbort() }
+        )
+        let rightCmdBinding = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 54, // Right Command
+            modifiers: [],
+            style: .toggle,
+            onStart: { rightCounters.recordStart() },
+            onStop: { rightCounters.recordStop() },
+            onAbort: { rightCounters.recordAbort() }
+        )
+        manager.registerBindings([leftCmdBinding, rightCmdBinding])
+
+        // Path A: Raw flags mask
+        let leftRaw = ModeBinding.deviceLeftCommandMask | CGEventFlags.maskCommand.rawValue
+        _ = manager.simulateModifierFlags(.maskCommand, rawFlags: leftRaw, keyCode: 55)
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 55)
+        XCTAssertEqual(leftCounters.startCount, 1)
+        XCTAssertEqual(rightCounters.startCount, 0)
+
+        manager.resetActiveState()
+
+        // Path B: Key-code fallback (rawFlags = 0)
+        _ = manager.simulateModifierFlags(.maskCommand, rawFlags: 0, keyCode: 54)
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 54)
+        XCTAssertEqual(rightCounters.startCount, 1)
+        XCTAssertEqual(leftCounters.startCount, 1)
+    }
+
+    /// Scenario 13: Edge Case Resets, Autorepeat, and Disqualified Stuck Hold Recovery.
+    func testScenario13_EdgeCaseResetsAutorepeatAndStuckHoldRecovery() {
+        let defaults = UserDefaults.standard
+        let key = HotkeyManager.modifierPrefixTriggerDelayKey
+        let priorValue = defaults.object(forKey: key)
+        defaults.set(0.02, forKey: key)
+        defer {
+            if let priorValue { defaults.set(priorValue, forKey: key) } else { defaults.removeObject(forKey: key) }
         }
-        wait(for: [delayElapsed], timeout: 0.5)
 
-        XCTAssertEqual(reviseCounters.stopCount, 1)
-        XCTAssertEqual(fnCounters.startCount, 0)
-        XCTAssertFalse(manager.isActiveRecordingBinding(reviseBinding.bindingId))
+        let manager = makeManager()
+        let counters = BindingCounters()
+        let leftCmdHold = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 55, // Left Command
+            modifiers: [],
+            style: .hold,
+            onStart: { counters.recordStart() },
+            onStop: { counters.recordStop() },
+            onAbort: { counters.recordAbort() }
+        )
+        manager.registerBindings([leftCmdHold])
 
-        manager.simulateModifierFlags([])
-        XCTAssertEqual(reviseCounters.stopCount, 1)
-        XCTAssertEqual(fnCounters.stopCount, 0)
+        let leftCmdRaw = ModeBinding.deviceLeftCommandMask | CGEventFlags.maskCommand.rawValue
+
+        // Autorepeat regular key ignored by reducer
+        _ = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 55)
+        manager.simulateRegularKeyDown(keyCode: 46, isRepeat: true)
+        XCTAssertTrue(manager.hasPendingCandidateTimer(), "Autorepeat regular key must not disqualify")
+
+        // Wait for hold to activate
+        let delayExp = expectation(description: "hold delay elapsed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { delayExp.fulfill() }
+        wait(for: [delayExp], timeout: 0.5)
+        XCTAssertEqual(counters.startCount, 1)
+
+        // Disqualify with non-repeat regular key
+        manager.simulateRegularKeyDown(keyCode: 46, isRepeat: false)
+        XCTAssertEqual(counters.abortCount, 1)
+
+        // Reset active state
+        manager.resetActiveState()
+        XCTAssertFalse(manager.isHoldActive(for: leftCmdHold.bindingId))
+        XCTAssertFalse(manager.hasPendingCandidateTimer())
+        XCTAssertFalse(manager.hasPendingSafetyTimer(for: leftCmdHold.bindingId))
+    }
+
+    // MARK: - Suite 3: App/Session Abort & SoundFeedback Cancellation Tests
+
+    func testSoundFeedbackCancelActiveFeedbackDoesNotCrash() {
+        SoundFeedback.cancelActiveFeedback()
+    }
+
+    func testReviseCoordinatorCancelActiveTransaction() async {
+        await ReviseCoordinator.shared.cancelActiveTransaction()
+    }
+
+    @MainActor
+    func testAppStateCancelSetsBarPhaseToHidden() {
+        let appState = AppState()
+        appState.startRecording()
+        XCTAssertEqual(appState.barPhase, .preparing)
+
+        appState.cancel()
+        XCTAssertEqual(appState.barPhase, .hidden)
+    }
+
+    /// Scenario 14: Redundant flagsChanged and Caps Lock during active hold preserves hold state.
+    func testScenario14_RedundantFlagsChangedAndCapsLockDuringActiveHoldPreservesHold() {
+        let defaults = UserDefaults.standard
+        let key = HotkeyManager.modifierPrefixTriggerDelayKey
+        let priorValue = defaults.object(forKey: key)
+        defaults.set(0.02, forKey: key)
+        defer {
+            if let priorValue { defaults.set(priorValue, forKey: key) } else { defaults.removeObject(forKey: key) }
+        }
+
+        let manager = makeManager()
+        let counters = BindingCounters()
+        let leftCmdHold = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 55, // Left Command
+            modifiers: [],
+            style: .hold,
+            onStart: { counters.recordStart() },
+            onStop: { counters.recordStop() },
+            onAbort: { counters.recordAbort() }
+        )
+        manager.registerBindings([leftCmdHold])
+
+        let leftCmdRaw = ModeBinding.deviceLeftCommandMask | CGEventFlags.maskCommand.rawValue
+
+        // 1. Press Left Command
+        let swallowedPress = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 55)
+        XCTAssertTrue(swallowedPress)
+
+        // 2. Wait for hold classification timer to fire and activate hold
+        let delayExp = expectation(description: "hold delay elapsed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { delayExp.fulfill() }
+        wait(for: [delayExp], timeout: 0.5)
+        XCTAssertEqual(counters.startCount, 1)
+        XCTAssertEqual(counters.stopCount, 0)
+        XCTAssertTrue(manager.isHoldActive(for: leftCmdHold.bindingId))
+
+        // 3. Send Caps Lock flagsChanged event (flags include maskAlphaShift)
+        let capsFlags: CGEventFlags = [.maskCommand, .maskAlphaShift]
+        let swallowedCaps = manager.simulateModifierFlags(capsFlags, rawFlags: leftCmdRaw, keyCode: 57)
+        XCTAssertTrue(swallowedCaps)
+        XCTAssertTrue(manager.isHoldActive(for: leftCmdHold.bindingId), "Hold must remain active across Caps Lock event")
+        XCTAssertEqual(counters.stopCount, 0, "No premature stop callback should occur on Caps Lock")
+        XCTAssertEqual(counters.startCount, 1)
+
+        // 4. Send redundant same-key flagsChanged event
+        let swallowedRedundant = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 55)
+        XCTAssertTrue(swallowedRedundant)
+        XCTAssertTrue(manager.isHoldActive(for: leftCmdHold.bindingId), "Hold must remain active across redundant flagsChanged")
+        XCTAssertEqual(counters.stopCount, 0)
+
+        // 5. Clean release of Left Command stops the hold cleanly
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 55)
+        XCTAssertEqual(counters.stopCount, 1)
+        XCTAssertFalse(manager.isHoldActive(for: leftCmdHold.bindingId))
+    }
+
+    /// Scenario 15: Redundant flagsChanged and Caps Lock during toggle candidate preserves candidate.
+    func testScenario15_RedundantFlagsChangedAndCapsLockDuringToggleCandidatePreservesCandidate() {
+        let manager = makeManager()
+        let counters = BindingCounters()
+        let leftCmdToggle = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 55, // Left Command
+            modifiers: [],
+            style: .toggle,
+            onStart: { counters.recordStart() },
+            onStop: { counters.recordStop() },
+            onAbort: { counters.recordAbort() }
+        )
+        manager.registerBindings([leftCmdToggle])
+
+        let leftCmdRaw = ModeBinding.deviceLeftCommandMask | CGEventFlags.maskCommand.rawValue
+
+        // 1. Press Left Command (arms toggle candidate)
+        let swallowedPress = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 55)
+        XCTAssertTrue(swallowedPress)
+        XCTAssertEqual(counters.startCount, 0)
+
+        // 2. Send Caps Lock flagsChanged event
+        let capsFlags: CGEventFlags = [.maskCommand, .maskAlphaShift]
+        let swallowedCaps = manager.simulateModifierFlags(capsFlags, rawFlags: leftCmdRaw, keyCode: 57)
+        XCTAssertTrue(swallowedCaps)
+        XCTAssertEqual(counters.startCount, 0, "Toggle should not commit prematurely on Caps Lock")
+
+        // 3. Send redundant same-key flagsChanged event
+        let swallowedRedundant = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 55)
+        XCTAssertTrue(swallowedRedundant)
+        XCTAssertEqual(counters.startCount, 0)
+
+        // 4. Release Left Command cleanly -> toggle commits
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 55)
+        XCTAssertEqual(counters.startCount, 1, "Toggle must commit on clean release")
+        XCTAssertEqual(counters.stopCount, 0)
+        XCTAssertEqual(counters.abortCount, 0)
+    }
+
+    /// Scenario 16: Redundant flagsChanged during hold candidate classification allows normal activation.
+    func testScenario16_RedundantFlagsChangedDuringHoldCandidateAllowsTimerActivation() {
+        let defaults = UserDefaults.standard
+        let key = HotkeyManager.modifierPrefixTriggerDelayKey
+        let priorValue = defaults.object(forKey: key)
+        defaults.set(0.05, forKey: key)
+        defer {
+            if let priorValue { defaults.set(priorValue, forKey: key) } else { defaults.removeObject(forKey: key) }
+        }
+
+        let manager = makeManager()
+        let counters = BindingCounters()
+        let leftCmdHold = ModeBinding(
+            bindingId: UUID(),
+            modeId: UUID(),
+            keyCode: 55, // Left Command
+            modifiers: [],
+            style: .hold,
+            onStart: { counters.recordStart() },
+            onStop: { counters.recordStop() },
+            onAbort: { counters.recordAbort() }
+        )
+        manager.registerBindings([leftCmdHold])
+
+        let leftCmdRaw = ModeBinding.deviceLeftCommandMask | CGEventFlags.maskCommand.rawValue
+
+        // 1. Press Left Command (arms hold candidate)
+        _ = manager.simulateModifierFlags(.maskCommand, rawFlags: leftCmdRaw, keyCode: 55)
+        XCTAssertTrue(manager.hasPendingCandidateTimer())
+
+        // 2. Send Caps Lock flagsChanged event before timer expiration
+        let capsFlags: CGEventFlags = [.maskCommand, .maskAlphaShift]
+        _ = manager.simulateModifierFlags(capsFlags, rawFlags: leftCmdRaw, keyCode: 57)
+
+        // 3. Wait for timer delay to expire
+        let delayExp = expectation(description: "classification delay elapsed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { delayExp.fulfill() }
+        wait(for: [delayExp], timeout: 0.5)
+
+        // 4. Verify candidate successfully activated hold
+        XCTAssertEqual(counters.startCount, 1)
+        XCTAssertTrue(manager.isHoldActive(for: leftCmdHold.bindingId))
+
+        // 5. Release
+        _ = manager.simulateModifierFlags([], rawFlags: 0, keyCode: 55)
+        XCTAssertEqual(counters.stopCount, 1)
+    }
+
+    /// Test AppDelegate onAbort bridge: start gate race invalidation and session cancel discard chain end-to-end.
+    @MainActor
+    func testAppDelegateOnAbortBridgeEndToEnd() async {
+        // 1. Start gate unit validation
+        var startGate = RecordingStartGate()
+        let startToken = startGate.begin()
+        XCTAssertTrue(startGate.allowsStart(token: startToken))
+
+        // Invalidate via abort
+        startGate.invalidate()
+        XCTAssertFalse(startGate.allowsStart(token: startToken), "Invalidated start token must block queued recording start")
+
+        // 2. Full session cancellation discard chain
+        let appState = AppState()
+        let session = RecognitionSession()
+
+        var receivedEvents: [RecognitionEvent] = []
+        let (recognitionEvents, recognitionEventContinuation) = AsyncStream<RecognitionEvent>.makeStream()
+        await session.setOnASREvent { event in
+            recognitionEventContinuation.yield(event)
+        }
+
+        let eventCollectorTask = Task { @MainActor in
+            for await event in recognitionEvents {
+                receivedEvents.append(event)
+            }
+        }
+
+        // Put app state into preparing/recording
+        appState.startRecording()
+        XCTAssertEqual(appState.barPhase, .preparing)
+        await session.setState(.recording)
+        let recordingState = await session.state
+        XCTAssertEqual(recordingState, .recording)
+
+        // Execute composed AppDelegate onAbort bridge
+        startGate.invalidate()
+        appState.cancel()
+        SoundFeedback.cancelActiveFeedback()
+        await session.cancelRecording()
+
+        // Verify side effects
+        XCTAssertEqual(appState.barPhase, .hidden, "AppState must transition to .hidden without entering .processing")
+        let idleState = await session.state
+        XCTAssertEqual(idleState, .idle, "RecognitionSession must return to .idle")
+
+        // Yield time for any async events
+        recognitionEventContinuation.finish()
+        await eventCollectorTask.value
+
+        // Ensure no completed or finalized events were emitted
+        let completedOrFinalized = receivedEvents.contains { event in
+            switch event {
+            case .completed, .finalized, .processingResult:
+                return true
+            default:
+                return false
+            }
+        }
+        XCTAssertFalse(completedOrFinalized, "Full discard abort must not emit completion or processing events")
     }
 }


### PR DESCRIPTION
## Summary

Resolves #243 where configuring a side-specific modifier (e.g. Right Command) triggers on the opposite key (Left Command), and pressing standard keyboard shortcuts (e.g. `Command + M`) inadvertently triggers the modifier-only hotkey.

### Key Changes

1. **Physical Side Differentiation**:
   - Integrated IOKit device-specific modifier bitmasks (`NX_DEVICELCMDKEYMASK`, `NX_DEVICERCMDKEYMASK`, etc.) with `CGKeyCode` fallback tracking so Left/Right Command, Option, Shift, and Control are strictly differentiated.

2. **Standalone Modifier Gesture State Machine (`HotkeyManager`)**:
   - Implemented `ModifierGestureState` (`.idle`, `.tracking`, `.candidate`, `.activeHold`, `.settling`, `.disqualified`).
   - Any non-modifier key `keyDown` (e.g. `M`, `C`, `Space`) immediately disqualifies the active modifier gesture before event dispatch, ensuring system shortcuts execute normally without triggering voice input.
   - For **Toggle** mode: Commits strictly on clean modifier release without contamination.
   - For **Hold** mode: Employs a 250ms classification delay; if a regular key is pressed after hold activation, a dedicated `onAbort` path (`AppState.cancel()` → `.hidden`, `RecognitionSession.cancelRecording()`) discards the audio/session completely without entering processing or playing stop feedback.

3. **Multi-Modifier Step-Down & Settling**:
   - Releasing multi-modifier combos (e.g. `Ctrl + Shift → Ctrl → empty`) commits on the first downward transition and enters `settling`, preventing intermediate single-modifier bindings from misfiring.
   - Non-reducing `flagsChanged` events (e.g. Caps Lock `maskAlphaShift` or redundant same-type key events) are preserved as hold/candidate no-ops.

4. **Testing**:
   - Added 27 state-machine test scenarios in `HotkeyStateMachineTests` covering Left/Right differentiation, `Command + M` chord isolation (toggle and hold), late hold aborts, multi-modifier step-down releases, and Caps Lock/redundant events.
   - Full test suite passing (738 tests).
