### PR TITLE
fix: prevent USB output-device refresh crashes

### DIFF
--- a/Type4Me/Session/SoundFeedback.swift
+++ b/Type4Me/Session/SoundFeedback.swift
@@ -356,9 +356,17 @@ enum SoundFeedback {
             guard AudioObjectGetPropertyDataSize(id, &outputAddress, 0, nil, &bufSize) == noErr,
                   bufSize > 0 else { continue }
 
-            let bufferList = UnsafeMutablePointer<AudioBufferList>.allocate(capacity: 1)
-            defer { bufferList.deallocate() }
-            guard AudioObjectGetPropertyData(id, &outputAddress, 0, nil, &bufSize, bufferList) == noErr else { continue }
+            // AudioBufferList is a variable-length structure. A device with more than one
+            // output buffer needs more storage than MemoryLayout<AudioBufferList>.size.
+            let bufferListStorage = UnsafeMutableRawPointer.allocate(
+                byteCount: Int(bufSize),
+                alignment: MemoryLayout<AudioBufferList>.alignment
+            )
+            defer { bufferListStorage.deallocate() }
+            let bufferList = bufferListStorage.assumingMemoryBound(to: AudioBufferList.self)
+            guard AudioObjectGetPropertyData(
+                id, &outputAddress, 0, nil, &bufSize, bufferListStorage
+            ) == noErr else { continue }
 
             let channelCount = (0..<Int(bufferList.pointee.mNumberBuffers)).reduce(0) { total, i in
                 total + Int(UnsafeMutableAudioBufferListPointer(bufferList)[i].mNumberChannels)


### PR DESCRIPTION
## Summary
- Allocate output-device `AudioBufferList` storage using the byte count CoreAudio reports.
- Prevent memory corruption when an output device exposes multiple audio buffers, including affected USB devices.

## Validation
- `swift build -c release`
- `swift test --filter AudioCaptureEngineTests`

Fixes #246