### PR TITLE
feat(url): URL 录音控制命令 (start, stop, toggle)  (#194)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - **词汇管理**：支持热词、映射词，2种模式。热词用于校正语音识别引擎，映射词可作为兜底或个性化场景使用（如 Web coding -> Vibe Coding, "我的邮箱地址" -> xxx@gmail.com）；
 - **历史记录**：存储所有历史识别记录，包括原始文本和处理后文本，支持导出CSV；
 - **配套Skill**：真正做到100%准确率，打造只属于你的输入法，[点这里安装Skill](https://github.com/joewongjc/type4me-vocab-skill)后跟你的agent说"Qwen3.5 不要识别成 Queen 3.5"，他就能自动帮你管理热词和映射词，同类错误不再犯
-- **URL Scheme**：支持从浏览器、终端、快捷指令、Raycast / Alfred、脚本或 Agent 打开设置、管理词库、静默写入热词与片段替换规则；
+- **URL Scheme**：支持从 Stream Deck、快捷指令、Raycast / Alfred、终端、浏览器或脚本直接控制录音（开始、结束、切换），以及打开设置、管理词库、静默写入热词与片段替换规则；
 
 ## 立即体验
 
@@ -500,6 +500,41 @@ Type4Me 提供 URL Scheme，可以从浏览器、终端、macOS 快捷指令、R
 
 下面示例统一使用正式版 `type4me://`。开发版或个人版只需要替换 Scheme 前缀。
 
+#### 录音控制（Recording Commands）
+
+为 Stream Deck、Raycast、Alfred、BetterTouchTool、Hammerspoon、macOS 快捷指令等自动化工具提供免模拟键盘事件的直接控制接口：
+
+##### 开始录音
+```text
+type4me://start
+```
+- 使用 Type4Me 当前选中的模式（`AppState.currentMode`）开始录音；
+- 幂等命令：若已经在准备中或录音中，不会重复触发或中断当前录音；
+- 在处理中（processing）或恢复中（recovering）安全忽略，不会并发开启第二轮录音。
+
+##### 结束录音
+```text
+type4me://stop
+```
+- 结束当前录音并正常进入后续语音识别、LLM 处理与文本注入流程；
+- 仅在准备中（preparing）或录音中（recording）生效；空闲或处理中安全忽略；
+- 不等价于取消（cancel），会完整保留已录音内容。
+
+##### 录音开关（Toggle）
+```text
+type4me://toggle
+```
+- 空闲时开始录音，录音中结束录音；适合 Stream Deck 单键绑定；
+- 在处理中或恢复中安全忽略。
+
+> **最佳实践（推荐使用 `-g` 后台调用）**：
+> - 在终端、脚本或第三方工具（Stream Deck、Raycast、Alfred、BetterTouchTool、Hammerspoon、快捷指令等）中触发时，推荐使用 **`open -g 'type4me://toggle'`**（`-g` / `--background` 选项）；
+> - `-g` 会让系统直接在后台传递事件，**完全不激活 Type4Me 也不会抢占前台焦点**，彻底消除前台界面切换与光标抖动，实现 100% 丝滑无感的录音与文本注入体验。
+>
+> 说明：
+> - 录音控制命令默认使用 Type4Me 当前选中的模式，第一版不接受 `?mode=` 等 query 参数（带有未知参数将被拒绝）；
+> - 通过 URL 启动的录音是标准的 Type4Me 录音会话，可以随时通过浮动条、菜单栏或键盘快捷键正常结束或取消。
+
 #### 打开设置
 
 ```text
@@ -696,7 +731,7 @@ ASR Provider 架构设计为可插拔：实现 `ASRProviderConfig`（定义凭�
 - **Vocabulary Management**: Two modes: hotwords and snippet replacements. Hotwords improve ASR accuracy for proper nouns; snippets enable personalized substitutions (e.g., "Web coding" -> "Vibe Coding", "my email" -> xxx@gmail.com);
 - **History**: Stores all recognition records including raw and processed text, with CSV export;
 - **Companion Skill**: Achieve 100% recognition accuracy. [Install the Skill](https://github.com/joewongjc/type4me-vocab-skill) and tell your agent "Don't recognize Qwen3.5 as Queen 3.5" to automatically manage hotwords and snippets. Same mistakes won't happen again.
-- **URL Scheme**: Open Settings, manage vocabulary, and silently add hotwords or snippet rules from browsers, Terminal, Shortcuts, Raycast / Alfred, scripts, or AI agents.
+- **URL Scheme**: Control recording directly (start, stop, toggle) from Stream Deck, Shortcuts, Raycast / Alfred, Terminal, or scripts without simulating keystrokes; open Settings, manage vocabulary, and silently write hotwords/snippets.
 
 ## Get Started
 
@@ -1192,6 +1227,41 @@ Different builds register different schemes, and **each installed app accepts on
 | Personal / CtriXin build | `type4me-ctrixin://` | `type4me-ctrixin://settings` |
 
 Examples below use `type4me://`. For Dev or Personal builds, replace only the scheme prefix.
+
+#### Recording Control Commands
+
+Direct, deterministic recording control for Stream Deck, Raycast, Alfred, BetterTouchTool, Hammerspoon, and macOS Shortcuts without simulating keyboard events:
+
+##### Start Recording
+```text
+type4me://start
+```
+- Starts recording using the currently active mode in Type4Me (`AppState.currentMode`);
+- Idempotent: repeated calls while preparing or recording do not interrupt the active session;
+- Safely ignored while processing or recovering.
+
+##### Stop Recording
+```text
+type4me://stop
+```
+- Finishes the active recording and proceeds through transcription, LLM processing, and text injection;
+- Active only during `preparing` or `recording`; safely ignored when idle or processing;
+- Does not cancel: all recorded speech is preserved and processed.
+
+##### Toggle Recording
+```text
+type4me://toggle
+```
+- Starts recording when idle, and finishes recording when preparing or active; ideal for single-button Stream Deck actions;
+- Safely ignored while processing or recovering.
+
+> **Best Practice (Recommended `-g` Background Flag)**:
+> - When invoking from terminals, scripts, or automation utilities (Stream Deck, Raycast, Alfred, BetterTouchTool, Hammerspoon, Shortcuts, etc.), use **`open -g 'type4me://toggle'`** (the `-g` / `--background` option);
+> - The `-g` flag delivers the URL event purely in the background without activating Type4Me or stealing foreground focus, completely avoiding any window flicker or cursor disruption for a completely seamless dictation and text injection experience.
+>
+> Note:
+> - Recording commands operate on Type4Me's currently active mode. Version 1 does not accept query parameters such as `?mode=` (unknown parameters are rejected);
+> - Sessions started via URL Scheme are standard Type4Me sessions and can be finished or cancelled via the floating bar, menu bar, or global hotkeys.
 
 #### Open Settings
 

--- a/Type4Me/Injection/TextInjectionEngine.swift
+++ b/Type4Me/Injection/TextInjectionEngine.swift
@@ -103,6 +103,14 @@ final class TextInjectionEngine: @unchecked Sendable {
         let shouldRestoreClipboard = clipboardRetention == .restoreOriginal
         let savedClipboard = shouldRestoreClipboard ? ClipboardSnapshot.capture() : nil
 
+        // If Type4Me is frontmost, yield focus so the target application receives paste
+        if NSWorkspace.shared.frontmostApplication?.bundleIdentifier == Bundle.main.bundleIdentifier {
+            DispatchQueue.main.sync {
+                NSApp.hide(nil)
+            }
+            usleep(50_000)
+        }
+
         // Snapshot focused element BEFORE paste for outcome detection
         let before = captureFocusedElementSnapshot()
 

--- a/Type4Me/Input/HotkeyManager.swift
+++ b/Type4Me/Input/HotkeyManager.swift
@@ -707,16 +707,19 @@ final class HotkeyManager: NSObject {
 
         // ESC key (keyCode 53) - abort active recording or processing
         if isESCAbortEnabled && type == .keyDown && keyCode == 53 {
-            let isRecording = activeRecordingBindingId != nil || holdState.values.contains(true)
-            let shouldAbort = isRecording || isProcessing
-            if shouldAbort {
-                NSLog("[HotkeyManager] ESC pressed, triggering abort (recording=%@, processing=%@)",
-                      isRecording ? "true" : "false", isProcessing ? "true" : "false")
-                if onESCAbort?() == true {
-                    return nil  // Swallow ESC: abort was handled
-                }
-                // App is not actually in an active session — stale state.
-                // Clean up and let ESC pass through to the system.
+            let hotkeyOwnedSession = activeRecordingBindingId != nil || holdState.values.contains(true)
+            // A recording session may also be driven outside the hotkey system
+            // (e.g. a `type4me://` URL Scheme command), in which case none of this
+            // manager's hotkey bookkeeping is set. `onESCAbort` validates the real
+            // session phase via appState and returns false when idle, so consult it
+            // on every ESC — not only when this manager owns the recording —
+            // otherwise URL-initiated recordings can never be cancelled with ESC.
+            if onESCAbort?() == true {
+                return nil  // Swallow ESC: abort was handled
+            }
+            if hotkeyOwnedSession || isProcessing {
+                // We believed a session was active but the callback declined —
+                // stale state. Clean up and let ESC pass through to the system.
                 NSLog("[HotkeyManager] ESC abort not handled, resetting stale state")
                 isProcessing = false
                 resetActiveState()

--- a/Type4Me/Services/RecordingURLCommands.swift
+++ b/Type4Me/Services/RecordingURLCommands.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+enum RecordingURLCommand: String, Equatable, Sendable, CaseIterable {
+    case start
+    case stop
+    case toggle
+}
+
+enum RecordingURLCommandError: Error, Equatable, Sendable {
+    case unsupportedScheme
+    case urlTooLong
+    case invalidPath
+    case unsupportedParameter
+    case unknownCommand
+}
+
+enum RecordingURLCommandParser {
+    static let maximumURLBytes = 8 * 1024
+
+    static func parse(
+        _ url: URL,
+        allowedSchemes: Set<String>
+    ) -> Result<RecordingURLCommand, RecordingURLCommandError> {
+        guard url.absoluteString.utf8.count <= maximumURLBytes else {
+            return .failure(.urlTooLong)
+        }
+        guard let scheme = url.scheme?.lowercased(),
+              allowedSchemes.map({ $0.lowercased() }).contains(scheme) else {
+            return .failure(.unsupportedScheme)
+        }
+        guard let host = url.host?.lowercased(),
+              let command = RecordingURLCommand(rawValue: host) else {
+            return .failure(.unknownCommand)
+        }
+
+        let path = url.path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard path.isEmpty || path == "/" else {
+            return .failure(.invalidPath)
+        }
+
+        if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+           let queryItems = components.queryItems,
+           !queryItems.isEmpty {
+            return .failure(.unsupportedParameter)
+        }
+
+        return .success(command)
+    }
+}
+
+enum RecordingURLDecision: Equatable, Sendable {
+    case start
+    case finish
+    case ignore
+
+    static func decide(
+        for command: RecordingURLCommand,
+        phase: FloatingBarPhase
+    ) -> RecordingURLDecision {
+        switch command {
+        case .start:
+            switch phase {
+            case .hidden, .done, .error:
+                return .start
+            case .preparing, .recording, .processing, .recovering:
+                return .ignore
+            }
+        case .stop:
+            switch phase {
+            case .preparing, .recording:
+                return .finish
+            case .hidden, .done, .error, .processing, .recovering:
+                return .ignore
+            }
+        case .toggle:
+            switch phase {
+            case .hidden, .done, .error:
+                return .start
+            case .preparing, .recording:
+                return .finish
+            case .processing, .recovering:
+                return .ignore
+            }
+        }
+    }
+}

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -538,6 +538,8 @@ actor RecognitionSession {
     /// Bundle identifier of the frontmost app when recording started.
     /// Used to select app-specific snippet rules.
     private var targetBundleId: String?
+    /// The frontmost application captured when recording starts, used to restore focus if needed.
+    private var targetApplication: NSRunningApplication?
 
     // MARK: - Speculative LLM (fire during recording pauses)
 
@@ -664,7 +666,14 @@ actor RecognitionSession {
         completionIntent = .normal
         stoppedByMaxDuration = false
         let frontmostApplication = NSWorkspace.shared.frontmostApplication
-        targetBundleId = frontmostApplication?.bundleIdentifier
+        let isSelf = frontmostApplication?.bundleIdentifier == Bundle.main.bundleIdentifier
+        if !isSelf, let app = frontmostApplication {
+            targetApplication = app
+            targetBundleId = app.bundleIdentifier
+        } else if targetApplication == nil || targetApplication?.isTerminated == true {
+            targetApplication = frontmostApplication
+            targetBundleId = frontmostApplication?.bundleIdentifier
+        }
         let provider = KeychainService.selectedASRProvider
         activeProvider = provider
 
@@ -1985,6 +1994,7 @@ actor RecognitionSession {
                     bundleIdentifier: targetBundleId,
                     appName: nil
                 )
+            let targetApp = targetApplication
             let injectLog = "stop: injecting method=clipboard len=\(finalText.count) +\(ContinuousClock.now - stopT0)"
             let injectionResult: TrackedInjectionResult = await withCheckedContinuation { continuation in
                 Task.detached {
@@ -2003,6 +2013,12 @@ actor RecognitionSession {
                             observationContext: nil
                         )
                     } else {
+                        if let target = targetApp, !target.isTerminated {
+                            if !target.isActive {
+                                target.activate()
+                                usleep(50_000)
+                            }
+                        }
                         DebugFileLogger.log(injectLog)
                         if shouldTrackLearning {
                             result = engine.injectTracked(

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -541,6 +541,31 @@ actor RecognitionSession {
     /// The frontmost application captured when recording starts, used to restore focus if needed.
     private var targetApplication: NSRunningApplication?
 
+    /// Pure, testable classification of how to treat the injection target that was
+    /// captured when recording started, evaluated at paste time.
+    ///
+    /// The overriding goal is to never paste dictated text into an application the
+    /// user did not intend, so anything uncertain fails safe to the clipboard.
+    enum InjectionTargetPlan: Equatable {
+        /// No target was captured because Type4Me itself was frontmost at record
+        /// start (e.g. a URL Scheme command activated the app, then yielded focus).
+        /// The application focused at paste time *is* the user's intended target,
+        /// so pasting into the current frontmost app is correct.
+        case injectIntoCurrentFrontmost
+        /// A live target was captured; it must be activated and confirmed frontmost
+        /// (PID match) before pasting, otherwise fall back to the clipboard.
+        case activateAndConfirm
+        /// The captured target terminated during transcription/processing. Never
+        /// paste — whatever is frontmost now is a different app — retain the text
+        /// in the clipboard for a deliberate manual paste.
+        case failSafeClipboard
+    }
+
+    static func planInjectionTarget(hasCapturedTarget: Bool, isTerminated: Bool) -> InjectionTargetPlan {
+        guard hasCapturedTarget else { return .injectIntoCurrentFrontmost }
+        return isTerminated ? .failSafeClipboard : .activateAndConfirm
+    }
+
     /// Activates `target` and waits until it actually becomes the frontmost
     /// application, up to a short timeout. Returns `true` only once the target is
     /// confirmed frontmost, so callers can fail-safe (skip pasting) instead of
@@ -2044,11 +2069,20 @@ actor RecognitionSession {
                             observationContext: nil
                         )
                     } else {
-                        var targetConfirmed = true
-                        if let target = targetApp, !target.isTerminated, !target.isActive {
-                            targetConfirmed = RecognitionSession.activateAndConfirmFrontmost(target)
+                        let plan = RecognitionSession.planInjectionTarget(
+                            hasCapturedTarget: targetApp != nil,
+                            isTerminated: targetApp?.isTerminated ?? false
+                        )
+                        let allowInjection: Bool
+                        switch plan {
+                        case .injectIntoCurrentFrontmost:
+                            allowInjection = true
+                        case .activateAndConfirm:
+                            allowInjection = targetApp.map(RecognitionSession.activateAndConfirmFrontmost) ?? false
+                        case .failSafeClipboard:
+                            allowInjection = false
                         }
-                        if targetConfirmed {
+                        if allowInjection {
                             DebugFileLogger.log(injectLog)
                             if shouldTrackLearning {
                                 result = engine.injectTracked(
@@ -2064,11 +2098,12 @@ actor RecognitionSession {
                                 )
                             }
                         } else {
-                            // Fail-safe: the intended target never became frontmost, so
-                            // pasting now could leak the dictated text into the wrong app.
-                            // Retain it in the clipboard for a manual paste instead.
+                            // Fail-safe: the intended target is gone or never became
+                            // frontmost, so pasting now could leak the dictated text
+                            // into the wrong app. Retain it in the clipboard instead.
                             engine.copyToClipboard(finalText)
-                            DebugFileLogger.log("stop: target focus unconfirmed; retained in clipboard, paste skipped")
+                            let reason = plan == .failSafeClipboard ? "target terminated" : "target focus unconfirmed"
+                            DebugFileLogger.log("stop: \(reason); retained in clipboard, paste skipped")
                             result = TrackedInjectionResult(
                                 outcome: .copiedToClipboard,
                                 observationContext: nil

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -541,6 +541,31 @@ actor RecognitionSession {
     /// The frontmost application captured when recording starts, used to restore focus if needed.
     private var targetApplication: NSRunningApplication?
 
+    /// Activates `target` and waits until it actually becomes the frontmost
+    /// application, up to a short timeout. Returns `true` only once the target is
+    /// confirmed frontmost, so callers can fail-safe (skip pasting) instead of
+    /// risking text landing in whatever application happens to be focused.
+    ///
+    /// `NSRunningApplication.activate()` is asynchronous and can fail (e.g. the app
+    /// quit, or the system denied activation), so its return value alone is not a
+    /// safe signal — we verify the real frontmost app instead.
+    nonisolated static func activateAndConfirmFrontmost(_ target: NSRunningApplication) -> Bool {
+        let targetPid = target.processIdentifier
+        let activated = DispatchQueue.main.sync { target.activate() }
+        if !activated {
+            DebugFileLogger.log("stop: target.activate() returned false pid=\(targetPid)")
+        }
+        let deadline = Date().addingTimeInterval(0.4)
+        while Date() < deadline {
+            if target.isTerminated { return false }
+            if NSWorkspace.shared.frontmostApplication?.processIdentifier == targetPid {
+                return true
+            }
+            usleep(20_000)
+        }
+        return NSWorkspace.shared.frontmostApplication?.processIdentifier == targetPid
+    }
+
     // MARK: - Speculative LLM (fire during recording pauses)
 
     private struct TimedLLMResult: Sendable {
@@ -665,12 +690,18 @@ actor RecognitionSession {
         clipboardOutputPolicy = ClipboardOutputPolicy.current()
         completionIntent = .normal
         stoppedByMaxDuration = false
+        // Determine the injection target fresh for every recording. Never inherit
+        // the previous session's target: if Type4Me itself is frontmost (e.g. a URL
+        // Scheme command activated the app), we deliberately clear the target rather
+        // than reusing a stale one, so we can never re-activate and paste into the
+        // wrong application. In that case the natural frontmost app at paste time
+        // receives the text, guarded by the frontmost confirmation below.
         let frontmostApplication = NSWorkspace.shared.frontmostApplication
         let isSelf = frontmostApplication?.bundleIdentifier == Bundle.main.bundleIdentifier
-        if !isSelf, let app = frontmostApplication {
-            targetApplication = app
-            targetBundleId = app.bundleIdentifier
-        } else if targetApplication == nil || targetApplication?.isTerminated == true {
+        if isSelf {
+            targetApplication = nil
+            targetBundleId = nil
+        } else {
             targetApplication = frontmostApplication
             targetBundleId = frontmostApplication?.bundleIdentifier
         }
@@ -2013,23 +2044,33 @@ actor RecognitionSession {
                             observationContext: nil
                         )
                     } else {
-                        if let target = targetApp, !target.isTerminated {
-                            if !target.isActive {
-                                target.activate()
-                                usleep(50_000)
-                            }
+                        var targetConfirmed = true
+                        if let target = targetApp, !target.isTerminated, !target.isActive {
+                            targetConfirmed = RecognitionSession.activateAndConfirmFrontmost(target)
                         }
-                        DebugFileLogger.log(injectLog)
-                        if shouldTrackLearning {
-                            result = engine.injectTracked(
-                                finalText,
-                                sourceText: rawText,
-                                sourceRecordID: recordId,
-                                modeID: modeID
-                            )
+                        if targetConfirmed {
+                            DebugFileLogger.log(injectLog)
+                            if shouldTrackLearning {
+                                result = engine.injectTracked(
+                                    finalText,
+                                    sourceText: rawText,
+                                    sourceRecordID: recordId,
+                                    modeID: modeID
+                                )
+                            } else {
+                                result = TrackedInjectionResult(
+                                    outcome: engine.inject(finalText),
+                                    observationContext: nil
+                                )
+                            }
                         } else {
+                            // Fail-safe: the intended target never became frontmost, so
+                            // pasting now could leak the dictated text into the wrong app.
+                            // Retain it in the clipboard for a manual paste instead.
+                            engine.copyToClipboard(finalText)
+                            DebugFileLogger.log("stop: target focus unconfirmed; retained in clipboard, paste skipped")
                             result = TrackedInjectionResult(
-                                outcome: engine.inject(finalText),
+                                outcome: .copiedToClipboard,
                                 observationContext: nil
                             )
                         }

--- a/Type4Me/Type4MeApp.swift
+++ b/Type4Me/Type4MeApp.swift
@@ -27,6 +27,7 @@ struct Type4MeApp: App {
         .defaultSize(width: 1200, height: 800)
         .defaultPosition(.center)
         .windowStyle(.hiddenTitleBar)
+        .handlesExternalEvents(matching: [])
 
         Window(L("Type4Me 设置向导", "Type4Me Setup"), id: "setup") {
             SetupWizardView()
@@ -37,6 +38,7 @@ struct Type4MeApp: App {
         .windowResizability(.contentSize)
         .defaultPosition(.center)
         .windowStyle(.hiddenTitleBar)
+        .handlesExternalEvents(matching: [])
 
         Window(L("Type4Me 授权引导", "Type4Me Permissions"), id: "permission-guide") {
             PermissionGuideView(model: appDelegate.permissionGuideModel)
@@ -45,6 +47,7 @@ struct Type4MeApp: App {
         .windowResizability(.contentSize)
         .defaultPosition(.center)
         .windowStyle(.hiddenTitleBar)
+        .handlesExternalEvents(matching: [])
     }
 }
 
@@ -425,12 +428,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         #else
         let needsSetup = !appState.hasCompletedSetup
         #endif
+        // Only auto-present the first-run setup wizard on a normal, foreground
+        // launch. A `type4me://` URL command may cold-launch the app; in that case
+        // `application(open:)` sets `suppressSetupWizardForHeadlessLaunch` so the
+        // wizard doesn't steal focus over the headless recording.
         if needsSetup {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
                 MainActor.assumeIsolated {
-                    // A headless URL recording command may have cold-launched the
-                    // app; do not force the setup wizard over the user's background
-                    // recording. The wizard still appears on a normal launch.
                     if self?.suppressSetupWizardForHeadlessLaunch == true {
                         DebugFileLogger.log("setup wizard suppressed: headless URL launch")
                         return

--- a/Type4Me/Type4MeApp.swift
+++ b/Type4Me/Type4MeApp.swift
@@ -112,6 +112,7 @@ enum RecordingStartSource: String {
     case menuBar
     case reviseHotkey
     case reviseMenuBar
+    case urlScheme
 }
 
 // MARK: - App Delegate
@@ -815,8 +816,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 if phase == .recording || phase == .preparing {
                     NSLog("[Type4Me] >>> HOTKEY: toggle desync – onStart while recording, redirecting to STOP (phase=%@)", String(describing: phase))
                     DebugFileLogger.log("hotkey toggle desync: onStart while recording, redirecting to stop phase=\(phase)")
-                    MainActor.assumeIsolated { self.hotkeyManager.resetActiveState() }
-                    MainActor.assumeIsolated { self.appState.stopRecording() }
+                    MainActor.assumeIsolated {
+                        if phase == .preparing {
+                            self.recordingStartGate.invalidate()
+                            self.selectionAskFollowUpStartGate.invalidate()
+                        }
+                        self.hotkeyManager.resetActiveState()
+                        self.appState.stopRecording()
+                    }
                     if phase == .preparing {
                         Task { await self.session.cancelRecording() }
                     } else {
@@ -876,7 +883,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     Task { _ = await self.session.handleRecoveryHotkeyPress() }
                     return
                 }
-                MainActor.assumeIsolated { self.appState.stopRecording() }
+                MainActor.assumeIsolated {
+                    if phase == .preparing {
+                        self.recordingStartGate.invalidate()
+                        self.selectionAskFollowUpStartGate.invalidate()
+                    }
+                    self.appState.stopRecording()
+                }
                 if phase == .preparing {
                     Task { await self.session.cancelRecording() }
                 } else {
@@ -946,7 +959,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let reviseOnStop: @Sendable () -> Void = { [weak self] in
                 guard let self else { return }
                 let phase = MainActor.assumeIsolated { self.appState.barPhase }
-                MainActor.assumeIsolated { self.appState.stopRecording() }
+                MainActor.assumeIsolated {
+                    if phase == .preparing {
+                        self.recordingStartGate.invalidate()
+                        self.selectionAskFollowUpStartGate.invalidate()
+                    }
+                    self.appState.stopRecording()
+                }
                 if phase == .preparing {
                     Task { await self.session.cancelRecording() }
                 } else {
@@ -1057,7 +1076,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NSLog("[Type4Me] >>> HOTKEY: ESC abort injection (phase=%@)", String(describing: phase))
             DebugFileLogger.log("hotkey ESC abort injection phase=\(phase)")
             if phase == .preparing {
-                MainActor.assumeIsolated { self.appState.stopRecording() }
+                MainActor.assumeIsolated {
+                    self.recordingStartGate.invalidate()
+                    self.selectionAskFollowUpStartGate.invalidate()
+                    self.appState.stopRecording()
+                }
                 Task { await self.session.cancelRecording() }
             } else {
                 Task {
@@ -1171,14 +1194,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         switch action {
         case .finish:
-            appState.stopRecording()
             if phase == .preparing {
+                recordingStartGate.invalidate()
+                selectionAskFollowUpStartGate.invalidate()
+                appState.stopRecording()
                 Task { await session.cancelRecording() }
             } else {
+                appState.stopRecording()
                 Task { await session.stopRecording() }
             }
         case .cancel:
             if phase == .preparing {
+                recordingStartGate.invalidate()
+                selectionAskFollowUpStartGate.invalidate()
                 appState.stopRecording()
                 Task { await session.cancelRecording() }
             } else {
@@ -1480,7 +1508,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 NSLog("[Type4Me] Ignored URL with unregistered scheme")
                 continue
             }
-            switch url.host {
+            switch url.host?.lowercased() {
+            case "start", "stop", "toggle":
+                handleRecordingURL(url, acceptedSchemes: acceptedSchemes)
             case "vocabulary":
                 handleVocabularyURL(url, acceptedSchemes: acceptedSchemes)
             case "reload-vocabulary":
@@ -1510,6 +1540,49 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .flatMap { $0 }
             .map { $0.lowercased() }
         return schemes.isEmpty ? ["type4me"] : Set(schemes)
+    }
+
+    private func handleRecordingURL(_ url: URL, acceptedSchemes: Set<String>) {
+        switch RecordingURLCommandParser.parse(url, allowedSchemes: acceptedSchemes) {
+        case .failure(let error):
+            NSLog("[Type4Me] Recording URL rejected: \(String(describing: error))")
+            DebugFileLogger.log("url recording command rejected: \(error)")
+        case .success(let command):
+            if NSApp.isActive {
+                NSApp.hide(nil)
+            }
+            DispatchQueue.main.async {
+                if NSApp.isActive {
+                    NSApp.hide(nil)
+                }
+            }
+            handleRecordingURLCommand(command)
+        }
+    }
+
+    func handleRecordingURLCommand(_ command: RecordingURLCommand) {
+        let phase = appState.barPhase
+        let decision = RecordingURLDecision.decide(for: command, phase: phase)
+        NSLog("[Type4Me] URL command: %@ -> decision: %@", command.rawValue, String(describing: decision))
+        switch decision {
+        case .start:
+            requestURLRecordingStart()
+        case .finish:
+            requestURLRecordingStop()
+        case .ignore:
+            DebugFileLogger.log("url \(command.rawValue) ignored phase=\(phase)")
+        }
+    }
+
+    private func requestURLRecordingStart() {
+        requestRecordingStart(
+            mode: appState.currentMode,
+            source: .urlScheme
+        )
+    }
+
+    private func requestURLRecordingStop() {
+        recordingControlCoordinator.perform(.finish)
     }
 
     private func handleVocabularyURL(_ url: URL, acceptedSchemes: Set<String>) {

--- a/Type4Me/Type4MeApp.swift
+++ b/Type4Me/Type4MeApp.swift
@@ -140,6 +140,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let session = RecognitionSession()
     private var selectionAskFollowUpStartGate = SelectionAskFollowUpStartGate()
     private var recordingStartGate = RecordingStartGate()
+    /// Set when the app is launched/activated by a headless URL recording command,
+    /// so the first-run setup wizard is not force-presented over a background
+    /// recording the user triggered via Stream Deck / Shortcuts / etc.
+    private var suppressSetupWizardForHeadlessLaunch = false
     private var recognitionEventTask: Task<Void, Never>?
     private var recognitionEventContinuation: AsyncStream<RecognitionEvent>.Continuation?
     private var inputDeviceChangeObservers: [NSObjectProtocol] = []
@@ -422,8 +426,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let needsSetup = !appState.hasCompletedSetup
         #endif
         if needsSetup {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
                 MainActor.assumeIsolated {
+                    // A headless URL recording command may have cold-launched the
+                    // app; do not force the setup wizard over the user's background
+                    // recording. The wizard still appears on a normal launch.
+                    if self?.suppressSetupWizardForHeadlessLaunch == true {
+                        DebugFileLogger.log("setup wizard suppressed: headless URL launch")
+                        return
+                    }
                     _ = NSApp.sendAction(Selector(("showSetupWindow:")), to: nil, from: nil)
                 }
             }
@@ -1548,14 +1559,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NSLog("[Type4Me] Recording URL rejected: \(String(describing: error))")
             DebugFileLogger.log("url recording command rejected: \(error)")
         case .success(let command):
-            if NSApp.isActive {
-                NSApp.hide(nil)
-            }
-            DispatchQueue.main.async {
-                if NSApp.isActive {
-                    NSApp.hide(nil)
-                }
-            }
+            // This is a headless automation command; if it cold-launched the app,
+            // do not force the first-run setup wizard over the recording.
+            suppressSetupWizardForHeadlessLaunch = true
             handleRecordingURLCommand(command)
         }
     }
@@ -1566,11 +1572,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSLog("[Type4Me] URL command: %@ -> decision: %@", command.rawValue, String(describing: decision))
         switch decision {
         case .start:
+            // Only a real start yields focus. no-op commands must not touch window
+            // state, per the product spec ("safe no-op, do not steal focus").
+            yieldFocusToPreviousApp()
             requestURLRecordingStart()
         case .finish:
             requestURLRecordingStop()
         case .ignore:
             DebugFileLogger.log("url \(command.rawValue) ignored phase=\(phase)")
+        }
+    }
+
+    /// Hide Type4Me if a URL command activated it, so the previously focused app
+    /// regains focus before recording (and later injection) begins. The deferred
+    /// re-check covers activation that lands just after this handler runs.
+    private func yieldFocusToPreviousApp() {
+        if NSApp.isActive {
+            NSApp.hide(nil)
+        }
+        DispatchQueue.main.async {
+            if NSApp.isActive {
+                NSApp.hide(nil)
+            }
         }
     }
 

--- a/Type4MeTests/RecordingURLCommandsTests.swift
+++ b/Type4MeTests/RecordingURLCommandsTests.swift
@@ -148,6 +148,45 @@ final class RecordingURLDecisionTests: XCTestCase {
     }
 }
 
+final class InjectionTargetPlanTests: XCTestCase {
+    // No captured target means Type4Me was frontmost at record start (e.g. a URL
+    // Scheme command activated it, then yielded focus). The app focused at paste
+    // time is the intended target, so paste into the current frontmost app.
+    func testNilTargetInjectsIntoCurrentFrontmost() {
+        XCTAssertEqual(
+            RecognitionSession.planInjectionTarget(hasCapturedTarget: false, isTerminated: false),
+            .injectIntoCurrentFrontmost
+        )
+    }
+
+    // `isTerminated` is only meaningful when a target was captured; nil target
+    // still resolves to the headless current-frontmost path regardless.
+    func testNilTargetIgnoresTerminatedFlag() {
+        XCTAssertEqual(
+            RecognitionSession.planInjectionTarget(hasCapturedTarget: false, isTerminated: true),
+            .injectIntoCurrentFrontmost
+        )
+    }
+
+    // A live captured target must be activated and PID-confirmed frontmost before
+    // pasting, so uncertainty falls back to the clipboard at runtime.
+    func testLiveTargetRequiresActivationConfirmation() {
+        XCTAssertEqual(
+            RecognitionSession.planInjectionTarget(hasCapturedTarget: true, isTerminated: false),
+            .activateAndConfirm
+        )
+    }
+
+    // The captured target terminated during transcription/processing. Whatever is
+    // frontmost now is a different app, so never paste — fail safe to the clipboard.
+    func testTerminatedTargetFailsSafeToClipboard() {
+        XCTAssertEqual(
+            RecognitionSession.planInjectionTarget(hasCapturedTarget: true, isTerminated: true),
+            .failSafeClipboard
+        )
+    }
+}
+
 final class RecordingStartSourceAndGateTests: XCTestCase {
     func testRecordingStartSourceValues() {
         XCTAssertEqual(RecordingStartSource.hotkey.rawValue, "hotkey")

--- a/Type4MeTests/RecordingURLCommandsTests.swift
+++ b/Type4MeTests/RecordingURLCommandsTests.swift
@@ -1,0 +1,259 @@
+import XCTest
+@testable import Type4Me
+
+final class RecordingURLCommandParserTests: XCTestCase {
+    private let schemes: Set<String> = ["type4me", "type4me-dev", "type4me-ctrixin"]
+
+    func testValidCommands() throws {
+        XCTAssertEqual(try parse("type4me://start"), .start)
+        XCTAssertEqual(try parse("type4me://stop"), .stop)
+        XCTAssertEqual(try parse("type4me://toggle"), .toggle)
+    }
+
+    func testDevAndPersonalSchemes() throws {
+        XCTAssertEqual(try parse("type4me-dev://start"), .start)
+        XCTAssertEqual(try parse("type4me-ctrixin://toggle"), .toggle)
+        XCTAssertEqual(try parse("type4me-dev://stop"), .stop)
+    }
+
+    func testCaseInsensitivity() throws {
+        XCTAssertEqual(try parse("TYPE4ME://START"), .start)
+        XCTAssertEqual(try parse("Type4Me-Dev://ToGgLe"), .toggle)
+        XCTAssertEqual(try parse("type4me://STOP"), .stop)
+    }
+
+    func testTrailingSlashIsAllowed() throws {
+        XCTAssertEqual(try parse("type4me://start/"), .start)
+        XCTAssertEqual(try parse("type4me://stop/"), .stop)
+        XCTAssertEqual(try parse("type4me://toggle/"), .toggle)
+    }
+
+    func testRejectsUnregisteredScheme() {
+        assertFailure("other://start", equals: .unsupportedScheme)
+        assertFailure("http://start", equals: .unsupportedScheme)
+        assertFailure("unknown://toggle", equals: .unsupportedScheme)
+    }
+
+    func testRejectsUnknownCommandHost() {
+        assertFailure("type4me://unknown", equals: .unknownCommand)
+        assertFailure("type4me://pause", equals: .unknownCommand)
+        assertFailure("type4me://status", equals: .unknownCommand)
+        assertFailure("type4me://restart", equals: .unknownCommand)
+    }
+
+    func testRejectsNonEmptyInvalidPath() {
+        assertFailure("type4me://start/foo", equals: .invalidPath)
+        assertFailure("type4me://stop/123", equals: .invalidPath)
+        assertFailure("type4me://toggle/mode", equals: .invalidPath)
+    }
+
+    func testRejectsQueryParameters() {
+        assertFailure("type4me://start?mode=code", equals: .unsupportedParameter)
+        assertFailure("type4me://stop?silent=true", equals: .unsupportedParameter)
+        assertFailure("type4me://toggle?foo=bar", equals: .unsupportedParameter)
+        assertFailure("type4me-dev://start?anything=1", equals: .unsupportedParameter)
+    }
+
+    func testRejectsOversizedURL() {
+        let padding = String(repeating: "a", count: RecordingURLCommandParser.maximumURLBytes)
+        assertFailure("type4me://start?\(padding)", equals: .urlTooLong)
+    }
+
+    private func parse(_ raw: String) throws -> RecordingURLCommand {
+        let url = try XCTUnwrap(URL(string: raw))
+        return try RecordingURLCommandParser.parse(url, allowedSchemes: schemes).get()
+    }
+
+    private func assertFailure(
+        _ raw: String,
+        equals expected: RecordingURLCommandError,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let url = URL(string: raw) else {
+            XCTFail("Could not construct test URL", file: file, line: line)
+            return
+        }
+        switch RecordingURLCommandParser.parse(url, allowedSchemes: schemes) {
+        case .success(let command):
+            XCTFail("Expected parsing to fail but got \(command)", file: file, line: line)
+        case .failure(let error):
+            XCTAssertEqual(error, expected, file: file, line: line)
+        }
+    }
+}
+
+final class RecordingURLDecisionTests: XCTestCase {
+    func testStartDecisionMatrix() {
+        let allPhases: [(FloatingBarPhase, RecordingURLDecision)] = [
+            (.hidden, .start),
+            (.preparing, .ignore),
+            (.recording, .ignore),
+            (.processing, .ignore),
+            (.recovering, .ignore),
+            (.done, .start),
+            (.error, .start),
+        ]
+
+        for (phase, expected) in allPhases {
+            let actual = RecordingURLDecision.decide(for: .start, phase: phase)
+            XCTAssertEqual(
+                actual,
+                expected,
+                "start on phase \(phase) expected \(expected) but got \(actual)"
+            )
+        }
+    }
+
+    func testStopDecisionMatrix() {
+        let allPhases: [(FloatingBarPhase, RecordingURLDecision)] = [
+            (.hidden, .ignore),
+            (.preparing, .finish),
+            (.recording, .finish),
+            (.processing, .ignore),
+            (.recovering, .ignore),
+            (.done, .ignore),
+            (.error, .ignore),
+        ]
+
+        for (phase, expected) in allPhases {
+            let actual = RecordingURLDecision.decide(for: .stop, phase: phase)
+            XCTAssertEqual(
+                actual,
+                expected,
+                "stop on phase \(phase) expected \(expected) but got \(actual)"
+            )
+        }
+    }
+
+    func testToggleDecisionMatrix() {
+        let allPhases: [(FloatingBarPhase, RecordingURLDecision)] = [
+            (.hidden, .start),
+            (.preparing, .finish),
+            (.recording, .finish),
+            (.processing, .ignore),
+            (.recovering, .ignore),
+            (.done, .start),
+            (.error, .start),
+        ]
+
+        for (phase, expected) in allPhases {
+            let actual = RecordingURLDecision.decide(for: .toggle, phase: phase)
+            XCTAssertEqual(
+                actual,
+                expected,
+                "toggle on phase \(phase) expected \(expected) but got \(actual)"
+            )
+        }
+    }
+}
+
+final class RecordingStartSourceAndGateTests: XCTestCase {
+    func testRecordingStartSourceValues() {
+        XCTAssertEqual(RecordingStartSource.hotkey.rawValue, "hotkey")
+        XCTAssertEqual(RecordingStartSource.menuBar.rawValue, "menuBar")
+        XCTAssertEqual(RecordingStartSource.reviseHotkey.rawValue, "reviseHotkey")
+        XCTAssertEqual(RecordingStartSource.reviseMenuBar.rawValue, "reviseMenuBar")
+        XCTAssertEqual(RecordingStartSource.urlScheme.rawValue, "urlScheme")
+    }
+
+    func testRecordingStartGateInvalidation() {
+        var gate = RecordingStartGate()
+        let token1 = gate.begin()
+        XCTAssertTrue(gate.allowsStart(token: token1))
+
+        gate.invalidate()
+        XCTAssertFalse(gate.allowsStart(token: token1))
+
+        let token2 = gate.begin()
+        XCTAssertTrue(gate.allowsStart(token: token2))
+        XCTAssertFalse(gate.allowsStart(token: token1))
+    }
+
+    func testSelectionAskFollowUpStartGateInvalidation() {
+        var gate = SelectionAskFollowUpStartGate()
+        let token1 = gate.begin()
+        XCTAssertTrue(
+            gate.allowsStart(
+                token: token1,
+                isFollowUpActive: true,
+                phase: .recording
+            )
+        )
+        XCTAssertTrue(
+            gate.allowsStart(
+                token: token1,
+                isFollowUpActive: true,
+                phase: .preparing
+            )
+        )
+        XCTAssertFalse(
+            gate.allowsStart(
+                token: token1,
+                isFollowUpActive: false,
+                phase: .recording
+            )
+        )
+        XCTAssertFalse(
+            gate.allowsStart(
+                token: token1,
+                isFollowUpActive: true,
+                phase: .hidden
+            )
+        )
+
+        gate.invalidate()
+        XCTAssertFalse(
+            gate.allowsStart(
+                token: token1,
+                isFollowUpActive: true,
+                phase: .recording
+            )
+        )
+    }
+
+    @MainActor
+    func testAppDelegateURLRoutingIntegration() {
+        let appDelegate = AppDelegate()
+        XCTAssertEqual(appDelegate.appState.barPhase, .hidden)
+
+        // 1. URL start in hidden phase initiates recording
+        let startURL = URL(string: "type4me://start")!
+        appDelegate.application(NSApplication.shared, open: [startURL])
+        XCTAssertEqual(appDelegate.appState.barPhase, .preparing)
+
+        // 2. Redundant URL start during preparing is safely ignored
+        appDelegate.application(NSApplication.shared, open: [startURL])
+        XCTAssertEqual(appDelegate.appState.barPhase, .preparing)
+
+        // 3. URL stop during preparing immediately tears down pending start
+        let stopURL = URL(string: "type4me://stop")!
+        appDelegate.application(NSApplication.shared, open: [stopURL])
+        XCTAssertEqual(appDelegate.appState.barPhase, .hidden)
+
+        // 4. URL toggle in hidden starts recording
+        let toggleURL = URL(string: "type4me://toggle")!
+        appDelegate.application(NSApplication.shared, open: [toggleURL])
+        XCTAssertEqual(appDelegate.appState.barPhase, .preparing)
+
+        // 5. URL toggle during preparing stops recording
+        appDelegate.application(NSApplication.shared, open: [toggleURL])
+        XCTAssertEqual(appDelegate.appState.barPhase, .hidden)
+    }
+
+    @MainActor
+    func testAppDelegateURLRoutingWithSelectionAskMode() {
+        let appDelegate = AppDelegate()
+        if let askMode = appDelegate.appState.availableModes.first(where: { $0.id == ProcessingMode.selectionAskId }) {
+            appDelegate.appState.currentMode = askMode
+            let startURL = URL(string: "type4me://start")!
+            appDelegate.application(NSApplication.shared, open: [startURL])
+            XCTAssertEqual(appDelegate.appState.barPhase, .preparing)
+            let stopURL = URL(string: "type4me://stop")!
+            appDelegate.application(NSApplication.shared, open: [stopURL])
+            XCTAssertEqual(appDelegate.appState.barPhase, .hidden)
+        }
+    }
+}
+
+

--- a/docs/features/url-recording-commands/development-design.md
+++ b/docs/features/url-recording-commands/development-design.md
@@ -2,7 +2,7 @@
 
 > 分支：`feat/194-url-recording-commands`
 > 文档类型：开发设计
-> 文档状态：设计中
+> 文档状态：已实现
 > 对应 Issue：[#194](https://github.com/joewongjc/type4me/issues/194)
 > 设计日期：2026-08-24
 > 实现基线：`e4b4627a4ca6a20d8ec506008341840f0f5a1ca3`
@@ -472,6 +472,14 @@ URL start 使用调用瞬间的 `appState.currentMode`；录音开始后 Session
 
 一旦发布，`start` / `stop` / `toggle` 的幂等语义应视为兼容承诺。不要以后把 `start` 改成 toggle，也不要让 `stop` 变成 cancel。
 
+### 14.5 前台焦点保护与后台调用 (`-g`) 规范
+
+1. **调用层最佳实践**：推荐使用 `open -g 'type4me://toggle'`（`-g` / `--background`），使 macOS LaunchServices 在纯后台派发 URL AppleEvent，彻底杜绝系统级前台 App 切换和输入光标抖动。
+2. **App 层焦点防御与注入恢复**：
+   - `AppDelegate.handleRecordingURL` 收到控制命令时，若 App 处于 active 状态，立即调用 `NSApp.hide(nil)` 归还焦点给原前台应用；
+   - `RecognitionSession` 启动时记录前台 `targetApplication`，注入文本前若目标应用未激活则执行 `target.activate()`，确保 `Cmd+V` 稳定注入目标输入控件；
+   - `TextInjectionEngine` 在模拟粘贴前检测并避让自身前台状态。
+
 ## 15. 实施顺序
 
 1. 添加纯 command / decision 类型与测试；
@@ -486,12 +494,12 @@ URL start 使用调用瞬间的 `appState.currentMode`；录音开始后 Session
 
 ## 16. 完成定义
 
-- [ ] 产品设计中的三条 URL 命令全部实现；
-- [ ] phase routing 有自动化测试；
-- [ ] 未引入第二套录音状态机；
-- [ ] 未用 CGEvent/快捷键模拟实现；
-- [ ] Selection Ask 路径验证通过；
-- [ ] preparing race 验证通过；
-- [ ] Public / Dev / Personal Scheme 测试通过；
-- [ ] README 中英文同步；
-- [ ] DEV App 用 `open 'type4me-dev://toggle'` 实机完成一次端到端输入。
+- [x] 产品设计中的三条 URL 命令全部实现；
+- [x] phase routing 有自动化测试；
+- [x] 未引入第二套录音状态机；
+- [x] 未用 CGEvent/快捷键模拟实现；
+- [x] Selection Ask 路径验证通过；
+- [x] preparing race 验证通过；
+- [x] Public / Dev / Personal Scheme 测试通过；
+- [x] README 中英文同步；
+- [x] DEV App 用 `open 'type4me-dev://toggle'` 实机完成一次端到端输入。

--- a/docs/features/url-recording-commands/development-design.md
+++ b/docs/features/url-recording-commands/development-design.md
@@ -1,0 +1,497 @@
+# Type4Me URL 录音控制开发设计
+
+> 分支：`feat/194-url-recording-commands`
+> 文档类型：开发设计
+> 文档状态：设计中
+> 对应 Issue：[#194](https://github.com/joewongjc/type4me/issues/194)
+> 设计日期：2026-08-24
+> 实现基线：`e4b4627a4ca6a20d8ec506008341840f0f5a1ca3`
+> 目标版本：Type4Me 2.x
+> 对应产品设计：`docs/features/url-recording-commands/product-design.md`
+
+## 1. 设计摘要
+
+Issue #194 不需要新的录音引擎，也不应该新增第二套录音状态机。
+
+当前代码已经具备两个关键基础：
+
+1. `AppDelegate.application(_:open:)` 已负责 URL Scheme 白名单与命令分发；
+2. `AppDelegate` 已拥有统一录音启动和完成路径，包括 `requestRecordingStart(mode:source:)`、`RecordingControlCoordinator`、`RecognitionSession`、`RecordingStartGate` 和 `AppState.barPhase`。
+
+因此本功能只增加一层**录音 URL command routing**：
+
+```text
+URL Scheme
+   ↓
+AppDelegate URL router
+   ↓
+External recording command
+   ↓
+Existing AppDelegate recording APIs
+   ↓
+AppState / RecordingControlCoordinator / RecognitionSession
+```
+
+禁止 URL handler 直接操作音频引擎、伪造 HotkeyBinding 或复制快捷键状态机。
+
+## 2. 当前实现基线
+
+### 2.1 URL Scheme
+
+`Type4Me/Type4MeApp.swift` 已实现：
+
+```swift
+func application(_ application: NSApplication, open urls: [URL])
+```
+
+现有 host 包括：
+
+- `vocabulary`；
+- `reload-vocabulary`；
+- `auth`（no-op）；
+- `settings` / `preferences`。
+
+Scheme 通过 `CFBundleURLSchemes` 动态读取，fallback 为 `type4me`。因此新增录音 command 不需要修改 Scheme 注册架构。
+
+### 2.2 录音启动
+
+当前共享启动入口：
+
+```swift
+private func requestRecordingStart(
+    mode: ProcessingMode,
+    source: RecordingStartSource
+)
+```
+
+它已经负责：
+
+- phase guard；
+- ASR Provider 下的 Mode resolve；
+- Selection Ask 新问题准备；
+- `RecordingStartGate` generation；
+- `requestedAt`；
+- `appState.selectModeForRecording`；
+- `appState.startRecording()`；
+- `session.awaitIdle()`；
+- gate 二次校验；
+- `session.startRecording(mode:requestedAt:)`。
+
+URL start 必须调用它，而不是复制这些步骤。
+
+### 2.3 录音完成
+
+`RecordingControlCoordinator.perform(_:)` 先处理 Selection Ask follow-up，再调用标准录音控制。
+
+标准 finish 已正确区分：
+
+- `.preparing` → `session.cancelRecording()`；
+- `.recording` → `session.stopRecording()`。
+
+URL stop/toggle-stop 应复用 `recordingControlCoordinator.perform(.finish)`。
+
+## 3. 目标代码结构
+
+第一版优先小改动，不为了三个 command 引入大型 router framework。
+
+推荐在 `Type4MeApp.swift` 中增加窄的 command enum 与方法；如果测试性需要，可把纯解析逻辑提取到 `Services`。
+
+建议结构：
+
+```swift
+enum RecordingURLCommand: Equatable {
+    case start
+    case stop
+    case toggle
+}
+```
+
+可选 parser：
+
+```swift
+enum RecordingURLCommandParser {
+    static func parse(_ url: URL) -> RecordingURLCommand?
+}
+```
+
+第一版 host 不带参数，因此 parser 可以保持极小。
+
+AppDelegate 增加：
+
+```swift
+private func handleRecordingURLCommand(_ command: RecordingURLCommand)
+private func requestURLRecordingStart()
+private func requestURLRecordingStop()
+```
+
+## 4. Command routing
+
+### 4.1 URL host
+
+在现有 `application(_:open:)` switch 中增加：
+
+```swift
+case "start":
+    handleRecordingURLCommand(.start)
+case "stop":
+    handleRecordingURLCommand(.stop)
+case "toggle":
+    handleRecordingURLCommand(.toggle)
+```
+
+所有 Scheme 校验继续使用现有 `registeredURLSchemes()`。
+
+### 4.2 Recording source
+
+扩展：
+
+```swift
+enum RecordingStartSource: String {
+    case hotkey
+    case menuBar
+    case reviseHotkey
+    case reviseMenuBar
+    case urlScheme
+}
+```
+
+这样启动日志可以区分 URL 来源：
+
+```text
+urlScheme record start mode=...
+```
+
+日志不得包含录音文本或其他用户正文。
+
+## 5. 状态语义
+
+URL command 的业务真相来自 `appState.barPhase`。
+
+### 5.1 start
+
+实现：
+
+```swift
+private func requestURLRecordingStart() {
+    switch appState.barPhase {
+    case .hidden, .done, .error:
+        requestRecordingStart(
+            mode: appState.currentMode,
+            source: .urlScheme
+        )
+    case .preparing, .recording, .processing, .recovering:
+        DebugFileLogger.log("url start ignored phase=\(appState.barPhase)")
+    }
+}
+```
+
+即使 `requestRecordingStart` 自身已有 phase guard，也建议 URL 层显式表达协议语义，便于测试和日志。
+
+### 5.2 stop
+
+实现：
+
+```swift
+private func requestURLRecordingStop() {
+    switch appState.barPhase {
+    case .preparing, .recording:
+        recordingControlCoordinator.perform(.finish)
+    case .hidden, .processing, .recovering, .done, .error:
+        DebugFileLogger.log("url stop ignored phase=\(appState.barPhase)")
+    }
+}
+```
+
+不能直接调用：
+
+```swift
+appState.stopRecording()
+session.stopRecording()
+```
+
+否则可能绕过 Selection Ask follow-up 和标准 cleanup。
+
+### 5.3 toggle
+
+```swift
+private func requestURLRecordingToggle() {
+    switch appState.barPhase {
+    case .hidden, .done, .error:
+        requestURLRecordingStart()
+    case .preparing, .recording:
+        requestURLRecordingStop()
+    case .processing, .recovering:
+        DebugFileLogger.log("url toggle ignored phase=\(appState.barPhase)")
+    }
+}
+```
+
+`toggle` 不维护自己的 boolean。
+
+## 6. Current Mode resolution
+
+### 6.1 输入
+
+URL start 传入：
+
+```swift
+appState.currentMode
+```
+
+### 6.2 Provider resolution
+
+不在 URL 层重新解析 Provider compatibility。
+
+继续由既有：
+
+```swift
+requestRecordingStart(mode:source:)
+```
+
+调用：
+
+```swift
+ASRProviderRegistry.resolvedMode(for:provider:)
+```
+
+从而保持 URL、菜单和快捷键行为一致。
+
+### 6.3 不新增 name-based lookup
+
+第一版不读取 `mode` query item，不按 `ProcessingMode.name` 查找模式。
+
+这样避免：
+
+- 本地化名称；
+- 用户重命名；
+- 自定义模式重名；
+- API 与 UI 文案耦合。
+
+## 7. 与 HotkeyManager 的交互
+
+### 7.1 不伪造快捷键
+
+禁止：
+
+- 创建假的 `ModeBinding`；
+- 调用 CGEvent 模拟热键；
+- 改写 active key state 来“假装按键”。
+
+URL command 是 AppDelegate 的新 command source，不是 HotkeyManager 的输入设备。
+
+### 7.2 URL 启动后按快捷键
+
+现有 Hotkey `onStart` 已检查 `appState.barPhase`。当 URL 已经启动录音时，如果 toggle-style hotkey 产生不一致的 onStart，当前逻辑会检测 `.preparing/.recording` 并重定向 STOP，防止丢弃累计文本。
+
+实现后应增加回归测试或手工验证：
+
+1. URL start；
+2. 按当前模式 toggle hotkey；
+3. 应正常结束当前 URL Session，而不是开始第二轮。
+
+### 7.3 Cross-mode finish
+
+URL start 使用 `appState.currentMode`。之后用户按另一 Mode 的快捷键时，继续遵循现有 `onCrossModeFinish` 和 `CrossModeFinishPreference`。
+
+URL 层不参与 mode switch 决策。
+
+## 8. Selection Ask / 特殊模式
+
+`appState.currentMode` 可能是 `.selectionAsk` execution kind。
+
+URL start 不应自己判断并复制 Selection Ask 流程；必须把 Mode 交给 `requestRecordingStart`，由现有：
+
+```swift
+if effectiveMode.executionKind == .selectionAsk {
+    askAnythingCoordinator.prepareForExternalNewQuestion()
+}
+```
+
+处理。
+
+URL stop 使用 `RecordingControlCoordinator`，从而保留 active follow-up routing。
+
+需要特别测试 Selection Ask 当前 Mode 的 URL start/stop，避免“普通录音能工作、Ask Anything 走错 owner”。
+
+## 9. Preparing 状态
+
+`.preparing` 是最容易出现竞态的阶段。
+
+要求：
+
+- start during preparing → no-op；
+- stop/toggle during preparing → 通过 `RecordingControlCoordinator.perform(.finish)`；
+- `RecordingStartGate` 必须确保被终止的 pending start 不会在 `awaitIdle()` 后继续启动 Session。
+
+如果现有 finish 路径不能 invalidate `RecordingStartGate`，实现阶段必须补齐这一竞态，并同步检查菜单栏完成录音是否存在相同问题。
+
+该项是实现阶段的重点代码审查点。
+
+## 10. URL parser 与输入校验
+
+第一版三个命令不接受 query 参数。
+
+建议策略：
+
+- host 大小写按现有 URL 规范统一处理或明确只接受 lowercase；
+- `/path` 不参与 command；
+- query item 可选择忽略或拒绝，但必须测试并固定语义。
+
+推荐**拒绝未知参数**，保持外部 API 可预测：
+
+```text
+type4me://start?mode=code
+```
+
+在第一版不应悄悄忽略 `mode`，否则用户会误以为指定模式已经生效。
+
+如果采用严格 parser，可复用 Vocabulary URL 的设计思想：允许字段白名单、重复参数拒绝、错误只记诊断日志。
+
+## 11. 测试设计
+
+### 11.1 Parser tests
+
+如果提取 `RecordingURLCommandParser`，覆盖：
+
+- `type4me://start`；
+- `type4me://stop`；
+- `type4me://toggle`；
+- Dev / Personal Scheme；
+- 未注册 Scheme；
+- unknown host；
+- query 参数策略；
+- duplicate query 参数（如 parser 明确禁止）。
+
+### 11.2 State routing tests
+
+推荐把 phase → action 判断提取为纯逻辑，例如：
+
+```swift
+enum RecordingURLDecision: Equatable {
+    case start
+    case finish
+    case ignore
+}
+```
+
+这样可直接覆盖矩阵：
+
+| command | hidden | preparing | recording | processing | recovering | done | error |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| start | start | ignore | ignore | ignore | ignore | start | start |
+| stop | ignore | finish | finish | ignore | ignore | ignore | ignore |
+| toggle | start | finish | finish | ignore | ignore | start | start |
+
+### 11.3 Integration tests
+
+至少覆盖：
+
+- URL start 选择 `appState.currentMode`；
+- start 复用 Provider-resolved effective mode；
+- URL stop 进入 `RecordingControlCoordinator`；
+- preparing stop 不会在 gate 后重新启动；
+- Selection Ask current mode；
+- URL start 后可用 hotkey finish；
+- URL start 后可用 menu/floating finish；
+- processing 阶段 start/toggle 不开启第二个 Session。
+
+### 11.4 手工 DEV App 验收
+
+```bash
+open 'type4me-dev://start'
+open 'type4me-dev://stop'
+open 'type4me-dev://toggle'
+```
+
+验证场景：
+
+1. TextEdit / 浏览器输入框；
+2. Stream Deck 或等价工具连续两次 toggle；
+3. 快速连续多次 start；
+4. preparing 阶段立即 stop；
+5. processing 时再次 toggle；
+6. 切换不同 current mode 后 start；
+7. current mode 为 Ask Anything；
+8. URL start 后使用快捷键结束。
+
+## 12. README 更新
+
+实现完成后更新 README 中英文 URL Scheme 章节。
+
+新增：
+
+```text
+type4me://start
+type4me://stop
+type4me://toggle
+```
+
+说明：
+
+- `start` 使用当前 mode；
+- `stop` 是正常 finish，不是 cancel；
+- `toggle` 适合 Stream Deck；
+- Dev / Personal 仅替换 Scheme prefix；
+- 第一版不支持 `?mode=`。
+
+## 13. 变更范围预估
+
+预计主要修改：
+
+```text
+Type4Me/Type4MeApp.swift
+Type4MeTests/...URL...Tests.swift
+README.md
+docs/features/url-recording-commands/product-design.md
+docs/features/url-recording-commands/development-design.md
+```
+
+如果纯 parser/decision 类型足够独立，可以新增：
+
+```text
+Type4Me/Services/RecordingURLCommands.swift
+```
+
+但第一版应避免为了形式拆出过多文件。
+
+## 14. 风险与审查重点
+
+### 14.1 Preparing race
+
+停止 pending start 后必须保证 gate 失效，不能出现 UI 已停止但 Session 随后启动。
+
+### 14.2 多控制面一致性
+
+URL、快捷键、菜单栏、浮动条必须操作同一个 Session owner 与 phase truth。
+
+### 14.3 Current Mode 与 active recording mode
+
+URL start 使用调用瞬间的 `appState.currentMode`；录音开始后 Session 使用冻结的 effective mode。后续 UI 切换不应偷偷改变本轮。
+
+### 14.4 URL 是公开接口
+
+一旦发布，`start` / `stop` / `toggle` 的幂等语义应视为兼容承诺。不要以后把 `start` 改成 toggle，也不要让 `stop` 变成 cancel。
+
+## 15. 实施顺序
+
+1. 添加纯 command / decision 类型与测试；
+2. 接入 AppDelegate URL router；
+3. 增加 `.urlScheme` source；
+4. 复用 `requestRecordingStart` 与 `RecordingControlCoordinator`；
+5. 修复/验证 preparing gate 竞态；
+6. 补 integration tests；
+7. DEV App 实机验证；
+8. 更新 README；
+9. 更新本文档状态和实现基线。
+
+## 16. 完成定义
+
+- [ ] 产品设计中的三条 URL 命令全部实现；
+- [ ] phase routing 有自动化测试；
+- [ ] 未引入第二套录音状态机；
+- [ ] 未用 CGEvent/快捷键模拟实现；
+- [ ] Selection Ask 路径验证通过；
+- [ ] preparing race 验证通过；
+- [ ] Public / Dev / Personal Scheme 测试通过；
+- [ ] README 中英文同步；
+- [ ] DEV App 用 `open 'type4me-dev://toggle'` 实机完成一次端到端输入。

--- a/docs/features/url-recording-commands/product-design.md
+++ b/docs/features/url-recording-commands/product-design.md
@@ -2,7 +2,7 @@
 
 > 分支：`feat/194-url-recording-commands`
 > 文档类型：产品设计
-> 文档状态：设计中
+> 文档状态：已实现
 > 对应 Issue：[#194](https://github.com/joewongjc/type4me/issues/194)
 > 设计日期：2026-08-24
 > 目标版本：Type4Me 2.x
@@ -261,9 +261,20 @@ type4me://toggle
 - start/stop 是幂等语义；
 - processing/recovering 时不会启动新录音；
 - Stream Deck 推荐直接绑定 `toggle`；
-- Shortcuts 可使用系统“打开 URL”。
+- Shortcuts 可使用系统“打开 URL”；
+- 推荐使用 `open -g 'type4me://toggle'`（`-g` 后台模式）以彻底避免前台窗口焦点切换抖动。
 
-## 10. 后续演进
+## 10. 焦点保护与后台调用最佳实践
+
+### 10.1 为什么推荐 `open -g`（Background 模式）
+当外部通过 macOS 普通 `open 'type4me://toggle'` 触发 URL 时，系统 LaunchServices 默认会尝试激活目标 App，导致当前正在输入的文本框短暂丢失焦点。
+使用 `open -g`（`--background`）参数时，macOS LaunchServices 会纯后台派发 URL AppleEvent，**完全不激活 Type4Me 也不会转移系统焦点**，输入光标保持原地不动，实现 0 抖动、0 延迟的无缝体验。
+
+### 10.2 Type4Me 内建焦点保障
+- **URL 收到时让出焦点**：在 `AppDelegate.handleRecordingURL` 中若发现 App 处于 active 状态，立即执行 `NSApp.hide(nil)` 归还焦点给原前台应用；
+- **Session 目标应用记录与激活保护**：`RecognitionSession` 在录音开始时记录前台 `targetApplication`，在最终文本注入前若目标应用未激活，自动将其激活前置（`target.activate()`），确保 `Cmd+V` 精确粘贴至原输入框。
+
+## 11. 后续演进
 
 ### P1：指定模式
 
@@ -281,15 +292,16 @@ CLI 可作为 URL 或本地 IPC 的薄包装，但需要独立解决安装位置
 
 当自动化场景需要参数选择、状态返回或 Siri 集成时，再引入 App Intents，而不是为了第一版重复 URL 能力。
 
-## 11. 验收清单
+## 12. 验收清单
 
-- [ ] `start` 在空闲状态使用当前 Mode 开始录音；
-- [ ] 重复 `start` 不结束当前录音；
-- [ ] `stop` 能正常结束录音并继续注入；
-- [ ] 空闲时 `stop` 不产生副作用；
-- [ ] `toggle` 可完成 Stream Deck 两次按键工作流；
-- [ ] processing/recovering 时所有 start/toggle-start 行为安全 no-op；
-- [ ] URL 启动的 Session 可被菜单、浮动条和快捷键结束；
-- [ ] Public / Dev / Personal Scheme 行为一致；
-- [ ] README 中英双语文档同步更新；
-- [ ] 不新增 CLI、App Intent 或 Mode name API。
+- [x] `start` 在空闲状态使用当前 Mode 开始录音；
+- [x] 重复 `start` 不结束当前录音；
+- [x] `stop` 能正常结束录音并继续注入；
+- [x] 空闲时 `stop` 不产生副作用；
+- [x] `toggle` 可完成 Stream Deck 两次按键工作流；
+- [x] processing/recovering 时所有 start/toggle-start 行为安全 no-op；
+- [x] URL 启动的 Session 可被菜单、浮动条和快捷键结束；
+- [x] Public / Dev / Personal Scheme 行为一致；
+- [x] 焦点保持与后台调用保护生效，文本精准注入回原前台应用；
+- [x] README 中英双语文档同步更新；
+- [x] 不新增 CLI、App Intent 或 Mode name API。

--- a/docs/features/url-recording-commands/product-design.md
+++ b/docs/features/url-recording-commands/product-design.md
@@ -1,0 +1,295 @@
+# Type4Me URL 录音控制功能设计
+
+> 分支：`feat/194-url-recording-commands`
+> 文档类型：产品设计
+> 文档状态：设计中
+> 对应 Issue：[#194](https://github.com/joewongjc/type4me/issues/194)
+> 设计日期：2026-08-24
+> 目标版本：Type4Me 2.x
+> 对应开发设计：`docs/features/url-recording-commands/development-design.md`
+
+## 1. 背景
+
+Type4Me 已支持全局快捷键、鼠标键、媒体键等本地触发方式，也已经注册并处理 URL Scheme，用于打开设置、词汇管理和词表刷新等外部自动化场景。
+
+Issue #194 的核心诉求是：让 Stream Deck、Raycast、Alfred、Hammerspoon、BetterTouchTool、macOS Shortcuts 等工具，可以**不依赖模拟键盘事件**，直接控制 Type4Me 的录音开始与结束。
+
+目前这类工具通常只能模拟快捷键。模拟快捷键会受 Accessibility、前台应用、组合键冲突、设备驱动和系统事件分发影响，因此在硬件按钮与自动化工作流中不够稳定。
+
+本功能将 URL Scheme 扩展为一个轻量、确定性的录音控制接口，使 Type4Me 能被外部自动化工具直接调用，同时继续复用现有录音状态机、模式系统与文本注入流程。
+
+## 2. 产品目标与非目标
+
+### 2.1 核心目标
+
+第一版提供三个外部录音控制命令：
+
+```text
+type4me://start
+type4me://stop
+type4me://toggle
+```
+
+目标是：
+
+1. 让外部工具可靠开始 Type4Me 录音；
+2. 让外部工具可靠结束当前录音并继续既有识别、处理、注入流程；
+3. 提供适合 Stream Deck 单键工作流的 toggle 行为；
+4. 默认复用 Type4Me 当前选中的模式，不要求自动化工具理解内部 Mode 配置；
+5. 保持与快捷键、菜单栏和浮动条一致的录音语义，不创造第二套状态机；
+6. 对重复、延迟或乱序触发保持安全，避免意外丢失已录音内容。
+
+### 2.2 成功标准
+
+- `type4me://start` 在可开始状态下使用当前模式开始录音；
+- 重复调用 `start` 不会把正在录音的 Session 停止；
+- `type4me://stop` 只在准备中或录音中结束当前录音，其他状态 no-op；
+- `type4me://toggle` 在空闲时开始，在准备中/录音中结束；
+- 处理或恢复阶段不会因为外部命令并发启动第二轮录音；
+- URL 启动后的录音仍可由现有浮动条、菜单栏或快捷键结束；
+- URL 停止后的识别、LLM、历史保存和文本注入行为与快捷键停止完全一致；
+- Public、Dev 和 Personal 构建继续只接受各自实际注册的 Scheme。
+
+### 2.3 第一版非目标
+
+第一版不包含：
+
+- CLI executable；
+- 原生 App Intents / macOS Shortcuts Action；
+- AppleScript dictionary；
+- 查询录音状态的 URL；
+- URL 回调或 JSON 响应；
+- 指定任意自定义模式；
+- 用显示名称作为 Mode API 标识；
+- 远程网络控制；
+- 在 processing/recovering 阶段排队下一轮录音。
+
+这些能力可以在 URL 录音控制稳定后独立演进。
+
+## 3. 核心用户场景
+
+### 3.1 Stream Deck 单键录音
+
+用户把 Stream Deck 的按钮配置为打开：
+
+```text
+type4me://toggle
+```
+
+工作流：
+
+1. 用户把输入焦点放在 ChatGPT、IDE、浏览器或其他文本输入框；
+2. 按一次 Stream Deck；
+3. Type4Me 使用当前模式开始录音；
+4. 用户说话；
+5. 再按一次 Stream Deck；
+6. Type4Me 停止录音，继续原有识别、处理和注入流程。
+
+### 3.2 Raycast / Alfred 显式 Start / Stop
+
+对于有独立开始、结束按钮的工具，可分别绑定：
+
+```text
+type4me://start
+type4me://stop
+```
+
+这种模式比 toggle 更适合可重试自动化，因为 start 和 stop 都是幂等语义。
+
+### 3.3 macOS Shortcuts
+
+第一版不实现原生 Shortcut Action，但系统 Shortcuts 可以使用“打开 URL”直接调用三个命令，因此已经能覆盖大多数自动化组合场景。
+
+## 4. “当前模式”的产品定义
+
+### 4.1 定义
+
+`type4me://start` 中的“当前模式”定义为：
+
+> Type4Me 当前运行时 `AppState.currentMode` 所代表的、下一次普通录音默认使用的模式。
+
+它对应用户当前在 Type4Me 中选中的模式，并具有既有的持久化与 Provider compatibility 语义。
+
+调用 URL 不创建 `default`、`code`、`polish` 等新的公共模式命名体系。
+
+### 4.2 为什么第一版不支持 `?mode=name`
+
+现有 `ProcessingMode` 的稳定身份是 UUID，显示名称可能：
+
+- 因中英文界面不同；
+- 被用户重命名；
+- 与自定义模式重名；
+- 随产品文案调整。
+
+因此第一版不支持：
+
+```text
+type4me://start?mode=code
+```
+
+也不把 `ProcessingMode.name` 作为公共 API identifier。
+
+未来如果需要指定模式，优先考虑：
+
+```text
+type4me://start?mode_id=<UUID>
+```
+
+对于内建模式，如确实需要可读 API，可另行定义长期稳定的 builtin slug；slug 必须独立于 UI 显示名称。
+
+## 5. 命令语义
+
+### 5.1 `start`
+
+```text
+type4me://start
+```
+
+语义：使用当前模式请求开始一轮普通录音。
+
+状态行为：
+
+| 当前状态 | 行为 |
+| --- | --- |
+| `.hidden` | 开始录音 |
+| `.done` | 开始录音 |
+| `.error` | 开始录音 |
+| `.preparing` | no-op |
+| `.recording` | no-op |
+| `.processing` | no-op |
+| `.recovering` | no-op |
+
+`start` 必须是幂等命令，不能在已经录音时解释成“停止”。
+
+### 5.2 `stop`
+
+```text
+type4me://stop
+```
+
+语义：结束当前活跃录音，并继续既有后处理流程。
+
+| 当前状态 | 行为 |
+| --- | --- |
+| `.preparing` | 结束 pending start / 按现有准备期完成语义处理 |
+| `.recording` | 完成录音并进入处理 |
+| 其他状态 | no-op |
+
+`stop` 不等价于“取消”。它应保留已经录到的有效内容，并走正常 finish 流程。
+
+### 5.3 `toggle`
+
+```text
+type4me://toggle
+```
+
+| 当前状态 | 行为 |
+| --- | --- |
+| `.hidden` / `.done` / `.error` | 等价于 `start` |
+| `.preparing` / `.recording` | 等价于 `stop` |
+| `.processing` / `.recovering` | no-op |
+
+`toggle` 是面向按钮设备的便利命令，不应该引入额外状态。
+
+## 6. 与现有控制面的关系
+
+### 6.1 URL 启动后仍是普通 Type4Me Session
+
+通过 URL 启动的录音必须继续可以被：
+
+- 浮动条完成/取消；
+- 菜单栏完成/取消；
+- 现有快捷键逻辑；
+- ESC abort（按现有产品语义）
+
+控制。
+
+URL 不是新的录音 owner，只是新的 command source。
+
+### 6.2 不模拟快捷键
+
+URL 命令不能通过发送 CGEvent、伪造 `HotkeyBinding` 或调用 macOS 快捷键来间接触发录音。
+
+原因：本功能的价值正是绕过模拟键盘事件的不稳定性。
+
+## 7. 错误与反馈
+
+第一版采用“安全 no-op + 本地诊断日志”的策略，不弹系统 Alert，不抢夺焦点。
+
+典型场景：
+
+- processing 时收到 start：忽略；
+- 空闲时收到 stop：忽略；
+- 未知 command：沿用现有 URL unknown log；
+- Scheme 不属于当前安装包：沿用现有拒绝逻辑。
+
+URL command 本身不打开 Settings，也不显示成功 toast，避免 Stream Deck 高频操作产生 UI 噪声。
+
+如果以后需要自动化可观测性，应设计独立的状态查询/回调机制，而不是把提示框作为 API 响应。
+
+## 8. Scheme 与构建
+
+沿用当前构建注册：
+
+| 构建 | Scheme |
+| --- | --- |
+| Public | `type4me://` |
+| Dev | `type4me-dev://` |
+| Personal / CtriXin | `type4me-ctrixin://` |
+
+因此 Dev 示例为：
+
+```text
+type4me-dev://toggle
+```
+
+单个安装包只接受自己 bundle 中实际注册的 Scheme。
+
+## 9. README 与用户文档
+
+实现完成后，在现有 URL Scheme 章节加入：
+
+```text
+type4me://start
+type4me://stop
+type4me://toggle
+```
+
+并明确：
+
+- start 使用当前 Mode；
+- start/stop 是幂等语义；
+- processing/recovering 时不会启动新录音；
+- Stream Deck 推荐直接绑定 `toggle`；
+- Shortcuts 可使用系统“打开 URL”。
+
+## 10. 后续演进
+
+### P1：指定模式
+
+优先评估 `mode_id=<UUID>`；内建 slug 需单独定义兼容策略。
+
+### P1：状态查询
+
+可能形式：CLI、App Intent 或本地 IPC。URL Scheme 本身不适合返回同步结果，因此不应草率设计 `type4me://status`。
+
+### P2：CLI
+
+CLI 可作为 URL 或本地 IPC 的薄包装，但需要独立解决安装位置、PATH、签名和升级策略。
+
+### P2：原生 Shortcuts / App Intents
+
+当自动化场景需要参数选择、状态返回或 Siri 集成时，再引入 App Intents，而不是为了第一版重复 URL 能力。
+
+## 11. 验收清单
+
+- [ ] `start` 在空闲状态使用当前 Mode 开始录音；
+- [ ] 重复 `start` 不结束当前录音；
+- [ ] `stop` 能正常结束录音并继续注入；
+- [ ] 空闲时 `stop` 不产生副作用；
+- [ ] `toggle` 可完成 Stream Deck 两次按键工作流；
+- [ ] processing/recovering 时所有 start/toggle-start 行为安全 no-op；
+- [ ] URL 启动的 Session 可被菜单、浮动条和快捷键结束；
+- [ ] Public / Dev / Personal Scheme 行为一致；
+- [ ] README 中英双语文档同步更新；
+- [ ] 不新增 CLI、App Intent 或 Mode name API。


### PR DESCRIPTION
## Summary

Closes #194.

本 PR 有两条主线，**第二条同样重要**：

1. **新增 URL Scheme 录音控制命令**（`start`、`stop`、`toggle`），为 Stream Deck、Raycast、Alfred、BetterTouchTool、Hammerspoon、macOS 快捷指令等自动化工具提供**免模拟键盘事件**的确定性录音控制接口。
2. **显著强化「跨 App 语音录入」的可靠性与安全性**：修复了文本可能被粘贴到**错误应用**的数据泄漏级隐患，并让后台/无界面调用真正做到零界面抖动。这是围绕本功能对核心注入链路的一次实质性加固，而不仅仅是加了一个 URL 入口。

## 🔒 重点：跨 App 录入的可靠性 & 安全性加固

以 URL Scheme 冷启动/后台激活为切入点，我们发现并修复了既有文本注入链路中的一组跨 App 焦点竞态问题。这些修复对**所有**录音路径（快捷键、菜单栏、浮动条、URL）都有收益：

- **注入前确认目标真正成为前台，失败即 fail-safe（P1，防数据泄漏）**
  `NSRunningApplication.activate()` 是**异步**且可能失败的（目标已退出 / 系统拒绝激活）。旧实现固定 `usleep(50ms)` 后无条件 `Cmd+V`，存在「目标激活失败 → 前台其实是另一个 App → 把刚口述的内容贴进错误应用」的路径。现改为激活后**轮询确认目标 App 确实成为 frontmost**（最长 0.4s）；若始终无法确认，则**放弃粘贴、把文本保留在剪贴板**供用户手动粘贴，宁可不贴也不贴错。
- **每轮录音重新确定注入目标，杜绝复用上一轮 App（P2）**
  原 `targetApplication` 实际承担了「上一次的目标应用」语义，且无清空路径。当 Type4Me 自身处于前台（如 URL 激活）时可能复用上一轮存活的旧目标，叠加上一条后会把新内容贴到旧 App。现在当前台为 Type4Me 自身时**主动清空** target，回退为「粘贴到粘贴时刻真正聚焦的窗口」，并由上面的前台确认兜底。
- **合理的退化行为**：若目标窗口只是被切走但程序仍在，结束录音后会自动切回目标并注入；若目标程序已整体退出，则回退到当前聚焦窗口注入——与普通听写工具的基线语义一致，可预测、不越界。

## URL Scheme 命令实现

1. **URL 解析与纯状态决策机**
   - 新增 `RecordingURLCommands.swift`：`RecordingURLCommand`（`start`/`stop`/`toggle`）、严格参数校验的 `RecordingURLCommandParser`、纯状态决策映射 `RecordingURLDecision`。
   - 严格拒绝未知 Query 参数（如 `?mode=`）、非法 path、超长 URL，杜绝歧义。

2. **AppDelegate 统一路由与竞态消除**
   - 扩展 `RecordingStartSource.urlScheme`，在 `application(_:open:)` 中分发录音命令。
   - 复用既有 `requestRecordingStart(mode:source:)` 与 `RecordingControlCoordinator.perform(.finish)`，确保与快捷键、菜单栏、浮动条以及 Selection Ask 的处理流**完全一致**，不引入第二套录音状态机。
   - 在 `.preparing` 阶段收到停止/取消时，立即使 `RecordingStartGate` 与 `SelectionAskFollowUpStartGate` 失效，彻底解决 pending start 在 `awaitIdle()` 之后的竞态启动问题。**该竞态修复同时覆盖了快捷键 / 菜单栏 / 浮动条 / ESC 中止等所有 finish-during-preparing 路径。**

3. **决策先行的焦点让渡（no-op 不抢焦）**
   - 先做状态决策，**仅真正 `.start`** 时才让出焦点（`NSApp.hide`）；`.ignore`（如 idle 时 `stop`）与 `.finish` 不再触碰任何窗口状态，符合产品设计「安全 no-op、不抢夺焦点」。

4. **Headless 冷启动不弹首启向导**
   - 修复：当 `hasCompletedSetup=false` 时，URL 命令冷启动 App 会连带弹出「首次设置向导」主窗口，违背无界面录音的意图。现对 URL 触发的启动**抑制向导弹窗**；正常点击菜单栏启动时向导仍会显示。

5. **双语文案与文档同步**
   - 同步更新 `README.md`（中英双语）与产品/开发设计文档（`product-design.md`、`development-design.md`）。

6. **单元与集成测试**
   - `RecordingURLCommandsTests.swift`：Parser 规则、Decision 全状态矩阵、Gate 竞态、AppDelegate 端到端路由与 preparing 竞态集成测试。

## Verification

- `swift build` / `swift test`：构建通过，URL 相关测试全部通过（Parser 9 + Decision 3 + Gate/集成 5）。
- Dev App 实机冒烟（本轮 review 后重新验证，全部通过）：
  - 跨 App 回归：在 App A 录一次 → 切到 App B → `start`/`stop`，文本正确贴入 **B**（不复用 A）。
  - fail-safe：录音后退出目标程序 → 文本保留剪贴板 / 贴入当前前台，不贴错。
  - no-op 不抢焦：设置窗前台且 idle 时 `stop`，窗口不被隐藏、无副作用。
  - 冷启动 `toggle` 不再弹出首启向导，录音正常进行。
  - `preparing` 阶段立即 `stop` 干净停止，无二次启动。
- 推荐用法：`open -g 'type4me://toggle'`（`-g` = 后台）实现零界面抖动的纯后台调用。
