### PR TITLE
feat(floating-bar): 紧凑型录音指示条 / compact recording indicator

### DIFF
--- a/Type4Me/UI/AppState.swift
+++ b/Type4Me/UI/AppState.swift
@@ -24,6 +24,30 @@ enum RecordingControlAction: Equatable {
     case cancel
 }
 
+enum RecordingIndicatorStyle: String, CaseIterable {
+    static let storageKey = "tf_recordingIndicatorStyle"
+    static let defaultValue = Self.regular.rawValue
+
+    case regular
+    case compact
+
+    var displayName: String {
+        switch self {
+        case .regular:
+            return L("常规", "Regular")
+        case .compact:
+            return L("紧凑型", "Compact")
+        }
+    }
+
+    static func current(userDefaults: UserDefaults = .standard) -> Self {
+        guard let raw = userDefaults.string(forKey: storageKey),
+              let style = Self(rawValue: raw)
+        else { return .regular }
+        return style
+    }
+}
+
 enum RecordingVisualStyle: String, CaseIterable {
     static let storageKey = "tf_visualStyle"
     static let defaultValue = Self.timeline.rawValue

--- a/Type4Me/UI/DesignSystem.swift
+++ b/Type4Me/UI/DesignSystem.swift
@@ -124,6 +124,19 @@ enum TF {
     static let transcriptPopupCorner: CGFloat = 10
     static let transcriptPopupGap: CGFloat = 10
 
+    // MARK: Compact Recording Indicator
+
+    static let compactIndicatorWidth: CGFloat = barWidthCompact
+    static let compactIndicatorHeight: CGFloat = 24
+    static let compactIndicatorControlVisualSize: CGFloat = 15
+    static let compactIndicatorWaveBarWidth: CGFloat = 2
+    static let compactIndicatorWaveMinHeight: CGFloat = 2
+    static let compactIndicatorWaveMaxHeight: CGFloat = 18
+    static let compactStatusMaxWidth: CGFloat = barWidth
+
+    static let compactIndicatorActive = floatingControlLight
+    static let compactIndicatorInactive = recordingTooltipBadge
+
     // MARK: Animation
 
     static let springSnappy = Animation.spring(response: 0.35, dampingFraction: 0.8)

--- a/Type4Me/UI/FloatingBar/CompactAudioIndicator.swift
+++ b/Type4Me/UI/FloatingBar/CompactAudioIndicator.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+/// Audio sample captured for the scrolling waveform history.
+private struct CompactWaveSample {
+    let height: CGFloat
+    let isActive: Bool
+}
+
+/// Helper model managing the rolling audio history buffer.
+@MainActor
+private final class CompactAudioHistoryModel {
+    var samples: [CompactWaveSample] = []
+    var lastSampleTime: TimeInterval = 0
+    let sampleInterval: TimeInterval = 0.13
+    let maxSamples: Int = 50
+
+    func update(currentTime: TimeInterval, level: Float) -> CGFloat {
+        if lastSampleTime == 0 {
+            lastSampleTime = currentTime
+        }
+
+        let elapsed = currentTime - lastSampleTime
+        if elapsed >= sampleInterval {
+            let steps = Int(elapsed / sampleInterval)
+            for _ in 0..<min(steps, 10) {
+                let normalized = max(0.0, min(1.0, CGFloat(level)))
+                let silenceThreshold: CGFloat = 0.045
+                let sample: CompactWaveSample
+                if normalized <= silenceThreshold {
+                    sample = CompactWaveSample(height: TF.compactIndicatorWaveMinHeight, isActive: false)
+                } else {
+                    let effective = (normalized - silenceThreshold) / (1.0 - silenceThreshold)
+                    let dynamicGain = min(1.0, pow(effective, 0.95) * 0.85)
+                    let barHeight = TF.compactIndicatorWaveMinHeight + dynamicGain * (TF.compactIndicatorWaveMaxHeight - TF.compactIndicatorWaveMinHeight)
+                    sample = CompactWaveSample(
+                        height: min(TF.compactIndicatorWaveMaxHeight, max(3.0, barHeight)),
+                        isActive: true
+                    )
+                }
+                samples.insert(sample, at: 0)
+                if samples.count > maxSamples {
+                    samples.removeLast()
+                }
+            }
+            lastSampleTime += Double(steps) * sampleInterval
+        }
+
+        let fraction = max(0.0, min(1.0, (currentTime - lastSampleTime) / sampleInterval))
+        return CGFloat(fraction)
+    }
+
+    func reset() {
+        samples.removeAll()
+        lastSampleTime = 0
+    }
+}
+
+/// Dynamic audio waveform indicator for the compact recording bar.
+///
+/// Features a right-to-left scrolling history track:
+/// - Inactive track starts with 2pt quiescent dots.
+/// - Active recording samples stream in from the right and scroll steadily to the left.
+/// - Silence appears as 2pt dots (`TF.compactIndicatorInactive`).
+/// - Audio volume elevates dots into vertical bars up to 18pt (`TF.compactIndicatorActive`).
+/// - Past recorded audio preserves its waveform as it travels leftward.
+struct CompactAudioIndicator: View {
+
+    let meter: AudioLevelMeter
+
+    @State private var history = CompactAudioHistoryModel()
+
+    var body: some View {
+        TimelineView(.animation) { timeline in
+            Canvas { context, size in
+                let time = timeline.date.timeIntervalSinceReferenceDate
+                let fraction = history.update(currentTime: time, level: meter.current)
+
+                let barWidth = TF.compactIndicatorWaveBarWidth
+                let minHeight = TF.compactIndicatorWaveMinHeight
+                let pitch: CGFloat = 4.5 // 2pt bar + 2.5pt spacing
+
+                guard size.width >= barWidth else { return }
+
+                let rightEdge = size.width - 1.0 - fraction * pitch
+                let totalColumns = Int(ceil((size.width + pitch) / pitch)) + 1
+
+                for i in 0..<totalColumns {
+                    let x = rightEdge - CGFloat(i) * pitch
+                    guard x >= -barWidth && x <= size.width else { continue }
+
+                    let barHeight: CGFloat
+                    let barColor: Color
+
+                    if i < history.samples.count {
+                        let sample = history.samples[i]
+                        barHeight = sample.height
+                        barColor = sample.isActive ? TF.compactIndicatorActive : TF.compactIndicatorInactive
+                    } else {
+                        // Unreached / idle track dots
+                        barHeight = minHeight
+                        barColor = TF.compactIndicatorInactive
+                    }
+
+                    let y = (size.height - barHeight) / 2
+                    let rect = CGRect(x: x, y: y, width: barWidth, height: barHeight)
+                    let path = Path(roundedRect: rect, cornerRadius: barWidth / 2)
+                    context.fill(path, with: .color(barColor))
+                }
+            }
+        }
+        .frame(height: TF.compactIndicatorHeight)
+        .onDisappear {
+            history.reset()
+        }
+    }
+}

--- a/Type4Me/UI/FloatingBar/FloatingBarView.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarView.swift
@@ -33,9 +33,14 @@ protocol FloatingBarState: AnyObject, Observable {
 }
 
 struct FloatingBarPresentation: Equatable {
+    var indicatorStyle: RecordingIndicatorStyle = .regular
     var visualStyle: RecordingVisualStyle
     var showsLiveTranscript: Bool
     var enablesHoverTranscriptPreview: Bool
+
+    var showsRecordingIndicator: Bool {
+        indicatorStyle == .compact || visualStyle.showsRecordingPanel
+    }
 }
 
 /// Dark-themed floating transcription bar.
@@ -68,12 +73,19 @@ struct FloatingBarView<S: FloatingBarState>: View {
     @State private var showsModeHint = false
     @State private var modeHintTask: Task<Void, Never>?
     @State private var recordingActionLocked = false
+    @AppStorage(RecordingIndicatorStyle.storageKey) private var indicatorStyle = RecordingIndicatorStyle.defaultValue
     @AppStorage(LiveTranscriptDisplayPreference.storageKey) private var showLiveTranscript = LiveTranscriptDisplayPreference.defaultValue
     @AppStorage("tf_hoverTranscriptPreview") private var hoverTranscriptPreview = true
     @AppStorage(RecordingVisualStyle.storageKey) private var visualStyle = RecordingVisualStyle.defaultValue
     @AppStorage("tf_language") private var language = AppLanguage.systemDefault
 
     // MARK: - Presentation Resolution
+
+    private var effectiveIndicatorStyle: RecordingIndicatorStyle {
+        presentationOverride?.indicatorStyle
+            ?? RecordingIndicatorStyle(rawValue: indicatorStyle)
+            ?? .regular
+    }
 
     private var effectiveRecordingVisualStyle: RecordingVisualStyle {
         presentationOverride?.visualStyle
@@ -82,11 +94,22 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 
     private var effectiveShowsLiveTranscript: Bool {
-        presentationOverride?.showsLiveTranscript ?? showLiveTranscript
+        guard effectiveIndicatorStyle == .regular else { return false }
+        return presentationOverride?.showsLiveTranscript ?? showLiveTranscript
     }
 
     private var effectiveHoverTranscriptPreview: Bool {
-        presentationOverride?.enablesHoverTranscriptPreview ?? hoverTranscriptPreview
+        guard effectiveIndicatorStyle == .regular else { return false }
+        return presentationOverride?.enablesHoverTranscriptPreview ?? hoverTranscriptPreview
+    }
+
+    private var usesCompactPresentation: Bool {
+        effectiveIndicatorStyle == .compact && state.barPhase != .hidden
+    }
+
+    private var usesCompactRecordingLayout: Bool {
+        effectiveIndicatorStyle == .compact
+            && (state.barPhase == .preparing || state.barPhase == .recording)
     }
 
     // MARK: - Transcript Popup
@@ -103,10 +126,15 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 
     private var shouldRenderCapsule: Bool {
-        state.barPhase != .hidden && recordingVisualStyle.showsRecordingPanel
+        guard state.barPhase != .hidden else { return false }
+        if usesCompactPresentation {
+            return true
+        }
+        return recordingVisualStyle.showsRecordingPanel
     }
 
     private var showTranscriptPopup: Bool {
+        guard !usesCompactPresentation else { return false }
         guard recordingVisualStyle.showsRecordingPanel else { return false }
         guard showsTranscriptInCurrentPhase else { return false }
         if state.pinsTranscriptPopup {
@@ -126,9 +154,13 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 
     private var activeTopOverlay: FloatingBarTopOverlay? {
-        guard recordingVisualStyle.showsRecordingPanel else { return nil }
+        if effectiveIndicatorStyle == .regular {
+            guard recordingVisualStyle.showsRecordingPanel else { return nil }
+        }
         if showTranscriptPopup { return .transcript }
-        if let hoveredAction, state.barPhase == .recording { return .action(hoveredAction) }
+        if let hoveredAction, state.barPhase == .recording || state.barPhase == .preparing {
+            return .action(hoveredAction)
+        }
         if showsModeHint,
            (state.barPhase == .preparing || state.barPhase == .recording) {
             return .mode
@@ -136,7 +168,53 @@ struct FloatingBarView<S: FloatingBarState>: View {
         return nil
     }
 
+    private var capsuleHeight: CGFloat {
+        usesCompactPresentation ? TF.compactIndicatorHeight : TF.barHeight
+    }
+
+    private var compactStatusIntrinsicWidth: CGFloat {
+        let textFont = NSFont.systemFont(ofSize: 12, weight: .medium)
+        func measure(_ str: String) -> CGFloat {
+            ceil((str as NSString).size(withAttributes: [.font: textFont]).width)
+        }
+
+        let basePadding: CGFloat = 20.0
+        let iconWidth: CGFloat = 18.0
+
+        switch state.barPhase {
+        case .preparing, .recording, .hidden:
+            return TF.compactIndicatorWidth
+        case .processing, .recovering:
+            let textW = measure(state.effectiveProcessingLabel)
+            return basePadding + iconWidth + textW
+        case .done:
+            let textW = measure(state.feedbackMessage)
+            var actionW: CGFloat = 0
+            if state.activityKind == .revise && state.latestReviseUndoTicketID != nil {
+                actionW = measure(L("撤销", "Undo")) + 22.0
+            }
+            return basePadding + iconWidth + textW + (actionW > 0 ? (actionW + 6.0) : 0)
+        case .error:
+            let textW = measure(state.feedbackMessage)
+            return basePadding + iconWidth + textW
+        }
+    }
+
+    private var compactCapsuleWidth: CGFloat {
+        switch state.barPhase {
+        case .preparing, .recording:
+            return TF.compactIndicatorWidth
+        case .processing, .recovering, .done, .error:
+            return min(TF.compactStatusMaxWidth, max(44.0, compactStatusIntrinsicWidth))
+        case .hidden:
+            return 0
+        }
+    }
+
     private var capsuleWidth: CGFloat {
+        if usesCompactPresentation {
+            return compactCapsuleWidth
+        }
         switch state.barPhase {
         case .preparing:
             let defaultWidth = measureText(recordingDisplayText) + TF.recordingChromeWidth
@@ -176,7 +254,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
             handlePhaseChange(newPhase)
         }
         .onChange(of: state.segments) { _, newSegments in
-            guard state.barPhase == .recording, effectiveShowsLiveTranscript else { return }
+            guard !usesCompactPresentation, state.barPhase == .recording, effectiveShowsLiveTranscript else { return }
             let text = newSegments.map(\.text).joined()
             let textWidth = measureText(text)
             let needed = min(TF.barWidth, max(TF.barWidthCompact, textWidth + TF.recordingChromeWidth))
@@ -187,12 +265,12 @@ struct FloatingBarView<S: FloatingBarState>: View {
             }
         }
         .onChange(of: state.transcriptionText) { _, text in
-            if !text.isEmpty {
+            if !text.isEmpty && !usesCompactPresentation {
                 dismissModeHint()
             }
         }
         .onChange(of: effectiveShowsLiveTranscript) { _, showsLive in
-            guard state.barPhase == .recording else { return }
+            guard !usesCompactPresentation, state.barPhase == .recording else { return }
             if showsLive && !state.segments.isEmpty {
                 let text = state.transcriptionText
                 let textWidth = measureText(text)
@@ -213,7 +291,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
     private var capsuleBar: some View {
         barContent
-            .frame(width: capsuleWidth, height: TF.barHeight)
+            .frame(width: capsuleWidth, height: capsuleHeight)
             .clipShape(Capsule())
             .background {
                 capsuleBackground
@@ -221,16 +299,42 @@ struct FloatingBarView<S: FloatingBarState>: View {
             }
             .shadow(color: Color(white: 0.08, opacity: 0.5), radius: 5, x: 0, y: 0)
             .animation(TF.springSnappy, value: capsuleWidth)
+            .animation(TF.springSnappy, value: capsuleHeight)
     }
 
     // MARK: - Content by Phase
 
     @ViewBuilder
     private var barContent: some View {
+        if usesCompactPresentation {
+            compactPhaseContent
+        } else {
+            regularPhaseContent
+        }
+    }
+
+    @ViewBuilder
+    private var compactPhaseContent: some View {
         switch state.barPhase {
-        case .preparing:
-            recordingContent
-        case .recording:
+        case .preparing, .recording:
+            compactRecordingContent
+        case .processing:
+            compactStatusContent(phase: .processing, text: state.effectiveProcessingLabel)
+        case .recovering:
+            compactStatusContent(phase: .recovering, text: state.effectiveProcessingLabel)
+        case .done:
+            compactDoneContent
+        case .error:
+            compactStatusContent(phase: .error, text: state.feedbackMessage)
+        case .hidden:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private var regularPhaseContent: some View {
+        switch state.barPhase {
+        case .preparing, .recording:
             recordingContent
         case .processing:
             processingContent
@@ -242,6 +346,151 @@ struct FloatingBarView<S: FloatingBarState>: View {
             errorContent
         case .hidden:
             EmptyView()
+        }
+    }
+
+    private var compactRecordingContent: some View {
+        HStack(spacing: 0) {
+            compactRecordingButton(.finish)
+                .frame(width: 32, height: TF.compactIndicatorHeight)
+
+            CompactAudioIndicator(meter: state.audioLevel)
+                .frame(maxWidth: .infinity, maxHeight: TF.compactIndicatorHeight)
+
+            compactRecordingButton(.cancel)
+                .frame(width: 32, height: TF.compactIndicatorHeight)
+        }
+        .frame(width: TF.compactIndicatorWidth, height: TF.compactIndicatorHeight)
+    }
+
+    @ViewBuilder
+    private func compactStatusContent(phase: FloatingBarPhase, text: String) -> some View {
+        HStack(spacing: 6) {
+            compactPhaseIcon(phase)
+
+            Text(text)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .padding(.horizontal, 10)
+        .frame(height: TF.compactIndicatorHeight)
+        .accessibilityLabel(text)
+    }
+
+    @ViewBuilder
+    private var compactDoneContent: some View {
+        HStack(spacing: 6) {
+            compactDoneIcon
+
+            Text(state.feedbackMessage)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            if state.activityKind == .revise && state.latestReviseUndoTicketID != nil {
+                Button(action: {
+                    state.performReviseUndo()
+                }) {
+                    HStack(spacing: 2) {
+                        Image(systemName: "arrow.uturn.backward")
+                            .font(.system(size: 9, weight: .semibold))
+                        Text(L("撤销", "Undo"))
+                            .font(.system(size: 10, weight: .medium))
+                    }
+                    .foregroundStyle(TF.floatingBackground)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(TF.compactIndicatorActive)
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 10)
+        .frame(height: TF.compactIndicatorHeight)
+        .accessibilityLabel(state.feedbackMessage)
+    }
+
+    @ViewBuilder
+    private func compactPhaseIcon(_ phase: FloatingBarPhase) -> some View {
+        switch phase {
+        case .processing:
+            ProgressView()
+                .scaleEffect(0.42)
+                .frame(width: 12, height: 12)
+        case .recovering:
+            Circle()
+                .fill(TF.recording)
+                .frame(width: 6, height: 6)
+                .shadow(color: TF.recording.opacity(0.4), radius: 2)
+        case .error:
+            if let icon = feedbackIcon {
+                Image(systemName: icon.symbol)
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(icon.color)
+            } else {
+                Image(systemName: "exclamationmark.circle.fill")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(TF.settingsAccentRed)
+            }
+        default:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private var compactDoneIcon: some View {
+        if let icon = feedbackIcon {
+            Image(systemName: icon.symbol)
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(icon.color)
+        } else {
+            Image(systemName: "checkmark")
+                .font(.system(size: 10, weight: .bold))
+                .foregroundStyle(TF.success)
+        }
+    }
+
+    private func compactRecordingButton(_ action: RecordingControlAction) -> some View {
+        ZStack {
+            Circle()
+                .fill(TF.compactIndicatorActive)
+                .frame(
+                    width: TF.compactIndicatorControlVisualSize,
+                    height: TF.compactIndicatorControlVisualSize
+                )
+                .overlay {
+                    if action == .finish {
+                        RoundedRectangle(cornerRadius: 1, style: .continuous)
+                            .fill(TF.floatingBackground)
+                            .frame(width: 6, height: 6)
+                    } else {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 8, weight: .heavy))
+                            .foregroundStyle(TF.floatingBackground)
+                    }
+                }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .contentShape(Rectangle())
+        .accessibilityLabel(action == .finish
+            ? L("完成录制", "Finish Recording")
+            : L("取消录制", "Cancel Recording"))
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction {
+            triggerRecordingAction(action)
+        }
+        .overlay {
+            FloatingBarButtonInteraction(
+                onHoverChanged: { hovered in
+                    guard !recordingActionLocked else { return }
+                    hoveredAction = hovered ? action : (hoveredAction == action ? nil : hoveredAction)
+                },
+                onClick: { triggerRecordingAction(action) }
+            )
         }
     }
 
@@ -449,27 +698,30 @@ struct FloatingBarView<S: FloatingBarState>: View {
         ZStack {
             TF.floatingBackground
 
-            if state.barPhase == .recording && recordingVisualStyle.showsBackgroundEffect {
-                AudioRipple(meter: state.audioLevel, style: recordingVisualStyle)
-                    .id(recordingVisualStyle.rawValue)
-            }
+            if !usesCompactPresentation {
+                if state.barPhase == .recording,
+                   recordingVisualStyle.showsBackgroundEffect {
+                    AudioRipple(meter: state.audioLevel, style: recordingVisualStyle)
+                        .id(recordingVisualStyle.rawValue)
+                }
 
-            if (state.barPhase == .processing || state.barPhase == .recovering || state.barPhase == .done),
-               recordingVisualStyle.showsBackgroundEffect {
-                ProcessingProgress(
-                    style: recordingVisualStyle,
-                    finishTime: state.processingFinishTime,
-                    processingStartDate: processingStartDate,
-                    doneStartDate: doneStartDate
-                )
-            }
+                if (state.barPhase == .processing || state.barPhase == .recovering || state.barPhase == .done),
+                   recordingVisualStyle.showsBackgroundEffect {
+                    ProcessingProgress(
+                        style: recordingVisualStyle,
+                        finishTime: state.processingFinishTime,
+                        processingStartDate: processingStartDate,
+                        doneStartDate: doneStartDate
+                    )
+                }
 
-            if state.barPhase == .error {
-                LinearGradient(
-                    colors: [TF.settingsAccentRed.opacity(0.16), .clear],
-                    startPoint: .leading,
-                    endPoint: UnitPoint(x: 0.45, y: 0.5)
-                )
+                if state.barPhase == .error {
+                    LinearGradient(
+                        colors: [TF.settingsAccentRed.opacity(0.16), .clear],
+                        startPoint: .leading,
+                        endPoint: UnitPoint(x: 0.45, y: 0.5)
+                    )
+                }
             }
         }
     }
@@ -599,9 +851,14 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 
     private func alignedActionHint(_ action: RecordingControlAction) -> some View {
-        let distanceFromCenter = capsuleWidth / 2
-            - TF.recordingEdgeInset
-            - TF.recordingControlSize / 2
+        let distanceFromCenter: CGFloat
+        if usesCompactRecordingLayout {
+            distanceFromCenter = capsuleWidth / 2 - 16
+        } else {
+            distanceFromCenter = capsuleWidth / 2
+                - TF.recordingEdgeInset
+                - TF.recordingControlSize / 2
+        }
         let horizontalOffset = action == .finish ? -distanceFromCenter : distanceFromCenter
 
         return actionHintBubble(action)

--- a/Type4Me/UI/Settings/AppearancePreviewStage.swift
+++ b/Type4Me/UI/Settings/AppearancePreviewStage.swift
@@ -54,7 +54,7 @@ struct AppearancePreviewStage: View {
                     RoundedRectangle(cornerRadius: 10, style: .continuous)
                         .fill(TF.settingsCardAlt.opacity(0.6))
 
-                    if presentation.visualStyle.showsRecordingPanel {
+                    if presentation.showsRecordingIndicator {
                         FloatingBarView(
                             state: demoState,
                             presentationOverride: presentation

--- a/Type4Me/UI/Settings/AppearanceSettingsTab.swift
+++ b/Type4Me/UI/Settings/AppearanceSettingsTab.swift
@@ -6,6 +6,9 @@ import SwiftUI
 
 struct AppearanceSettingsTab: View, SettingsCardHelpers {
 
+    @AppStorage(RecordingIndicatorStyle.storageKey)
+    private var indicatorStyle = RecordingIndicatorStyle.defaultValue
+
     @AppStorage(RecordingVisualStyle.storageKey)
     private var visualStyle = RecordingVisualStyle.defaultValue
 
@@ -27,8 +30,13 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
     @AppStorage("tf_language")
     private var language = AppLanguage.systemDefault
 
+    private var isCompact: Bool {
+        indicatorStyle == RecordingIndicatorStyle.compact.rawValue
+    }
+
     private var presentation: FloatingBarPresentation {
         FloatingBarPresentation(
+            indicatorStyle: RecordingIndicatorStyle(rawValue: indicatorStyle) ?? .regular,
             visualStyle: RecordingVisualStyle(rawValue: visualStyle) ?? .timeline,
             showsLiveTranscript: showLiveTranscript,
             enablesHoverTranscriptPreview: hoverTranscriptPreview
@@ -57,6 +65,8 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
             // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
             settingsGroupCard(L("录音显示", "Recording Display"), icon: "macwindow") {
+                indicatorStyleRow
+                SettingsDivider()
                 visualStyleRow
                 SettingsDivider()
                 liveTranscriptRow
@@ -82,27 +92,46 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
 
     // MARK: - Row Builders
 
+    private var indicatorStyleRow: some View {
+        settingsOptionRow(L("指示条外观", "Indicator Style")) {
+            settingsDropdown(
+                selection: $indicatorStyle,
+                options: RecordingIndicatorStyle.allCases.map { ($0.rawValue, $0.displayName) }
+            )
+        }
+    }
+
     private var visualStyleRow: some View {
-        settingsOptionRow(L("录音动效", "Visual Style")) {
+        settingsOptionRow(
+            L("录音动效", "Visual Style"),
+            subtitle: isCompact ? L("仅常规外观可用", "Available in Regular only") : nil
+        ) {
             settingsDropdown(
                 selection: $visualStyle,
                 options: RecordingVisualStyle.allCases.map { ($0.rawValue, $0.displayName) }
             )
+            .disabled(isCompact)
+            .opacity(isCompact ? 0.6 : 1.0)
         }
     }
 
     private var liveTranscriptRow: some View {
         settingsToggleRow(
             L("实时展示文本", "Live Transcript"),
-            subtitle: L("开启后在录音时显示识别文本", "Show recognized text while recording"),
-            isOn: $showLiveTranscript
+            subtitle: isCompact
+                ? L("仅常规外观可用", "Available in Regular only")
+                : L("开启后在录音时显示识别文本", "Show recognized text while recording"),
+            isOn: $showLiveTranscript,
+            isEnabled: !isCompact
         )
     }
 
     private var hoverPreviewRow: some View {
         settingsToggleRow(
             L("悬停文字预览", "Hover Text Preview"),
-            isOn: $hoverTranscriptPreview
+            subtitle: isCompact ? L("仅常规外观可用", "Available in Regular only") : nil,
+            isOn: $hoverTranscriptPreview,
+            isEnabled: !isCompact
         )
     }
 

--- a/Type4MeTests/AppearancePreviewTests.swift
+++ b/Type4MeTests/AppearancePreviewTests.swift
@@ -8,14 +8,71 @@ final class AppearancePreviewTests: XCTestCase {
 
     func testFloatingBarPresentationInit() {
         let presentation = FloatingBarPresentation(
+            indicatorStyle: .regular,
             visualStyle: .dual,
             showsLiveTranscript: false,
             enablesHoverTranscriptPreview: false
         )
 
+        XCTAssertEqual(presentation.indicatorStyle, .regular)
         XCTAssertEqual(presentation.visualStyle, .dual)
         XCTAssertFalse(presentation.showsLiveTranscript)
         XCTAssertFalse(presentation.enablesHoverTranscriptPreview)
+        XCTAssertTrue(presentation.showsRecordingIndicator)
+    }
+
+    func testFloatingBarPresentation_compactShowsRecordingIndicatorEvenWhenVisualStyleHidden() {
+        let compactHidden = FloatingBarPresentation(
+            indicatorStyle: .compact,
+            visualStyle: .hidden,
+            showsLiveTranscript: true,
+            enablesHoverTranscriptPreview: true
+        )
+        XCTAssertTrue(compactHidden.showsRecordingIndicator)
+
+        let regularHidden = FloatingBarPresentation(
+            indicatorStyle: .regular,
+            visualStyle: .hidden,
+            showsLiveTranscript: true,
+            enablesHoverTranscriptPreview: true
+        )
+        XCTAssertFalse(regularHidden.showsRecordingIndicator)
+    }
+
+    func testRecordingIndicatorStyle_allCases() {
+        XCTAssertEqual(RecordingIndicatorStyle.allCases.count, 2)
+        XCTAssertEqual(RecordingIndicatorStyle.regular.rawValue, "regular")
+        XCTAssertEqual(RecordingIndicatorStyle.compact.rawValue, "compact")
+        XCTAssertEqual(RecordingIndicatorStyle.defaultValue, "regular")
+        XCTAssertEqual(RecordingIndicatorStyle.regular.displayName, L("常规", "Regular"))
+        XCTAssertEqual(RecordingIndicatorStyle.compact.displayName, L("紧凑型", "Compact"))
+    }
+
+    func testRecordingIndicatorStyle_currentResolution() {
+        let suite = "Type4MeTests.RecordingIndicatorStyle.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        // Missing key falls back to .regular
+        XCTAssertEqual(RecordingIndicatorStyle.current(userDefaults: defaults), .regular)
+
+        // Stored "compact"
+        defaults.set("compact", forKey: RecordingIndicatorStyle.storageKey)
+        XCTAssertEqual(RecordingIndicatorStyle.current(userDefaults: defaults), .compact)
+
+        // Invalid raw value falls back to .regular
+        defaults.set("invalid_style", forKey: RecordingIndicatorStyle.storageKey)
+        XCTAssertEqual(RecordingIndicatorStyle.current(userDefaults: defaults), .regular)
+    }
+
+    func testCompactIndicatorDesignDimensionsMatchSpecification() {
+        XCTAssertEqual(TF.compactIndicatorWidth, 180)
+        XCTAssertEqual(TF.compactIndicatorHeight, 24)
+        XCTAssertEqual(TF.compactIndicatorControlVisualSize, 15)
+        XCTAssertEqual(TF.compactIndicatorWaveBarWidth, 2)
+        XCTAssertEqual(TF.compactIndicatorWaveMinHeight, 2)
+        XCTAssertEqual(TF.compactIndicatorWaveMaxHeight, 18)
+        XCTAssertEqual(TF.compactStatusMaxWidth, TF.barWidth)
     }
 
     func testRecordingVisualStyle_allCases() {

--- a/docs/features/compact-recording-indicator/development-design.md
+++ b/docs/features/compact-recording-indicator/development-design.md
@@ -1,0 +1,782 @@
+# Type4Me 紧凑型录音指示条开发设计
+
+> 分支：`feat/compact-recording-indicator`
+> 文档类型：开发设计
+> 文档状态：设计中
+> 设计日期：2026-08-25
+> 对应产品设计：`docs/features/compact-recording-indicator/product-design.md`
+
+## 1. 设计摘要
+
+本功能在现有 Floating Bar presentation 上增加独立的录音指示条外观维度：`Regular` 与 `Compact`。
+
+现有 `RecordingVisualStyle` 保持职责不变，只描述 Regular 内部的 Lines / Particles / Levels / No Effects / None。Compact 不加入该 enum，而由新的持久化 preference 控制。
+
+Compact 在整个可见 Floating Bar 生命周期中保持 24pt 高的 Compact chrome，但宽度采用 phase-aware 策略。`.preparing` / `.recording` 固定为 180 × 24，左右为 15 × 15 Finish / Cancel 视觉按钮，中间由独立 `CompactAudioIndicator` 使用现有 `AudioLevelMeter` 驱动 2pt 宽、2–18pt 高的动态声纹柱；`.processing` / `.recovering` / `.done` / `.error` 则由 Compact 专属 status content 按 `icon + text + optional action + insets` 的 intrinsic content width 自适应，不以 180pt 为最小宽度。
+
+Compact 不进入 Regular transcript、Transcript hover popup、`AudioRipple`、`ProcessingProgress` 或 55pt feedback 路径。录音阶段继续支持模式提示气泡与按钮悬停操作气泡（对齐 15×15 按钮中心）。选择 Compact 后，phase transition 只能改变 compact content，不能切回 Regular renderer。
+
+## 2. 核心工程原则
+
+1. Compact 是 layout/presentation preference，不是新的 `RecordingVisualStyle`；
+2. 老用户缺少新 key 时必须回退 Regular；
+3. Compact 只屏蔽 Regular-only 能力，不修改这些能力的保存值；
+4. 复用现有 `RecordingControlAction` 与 AppKit first-click interaction；
+5. 复用 `AudioLevelMeter`，不新增麦克风读取或 ASR 依赖；
+6. Compact renderer 使用轻量声纹柱，不复用现有高成本背景动效；
+7. Settings Preview 继续运行真实 `FloatingBarView`；
+8. 用户指定颜色通过 Design Token 表达，不在组件写 raw RGB；
+9. 第一版保持 `FloatingBarPanel` host 尺寸不变；Compact 高度始终为 24pt，录音态固定 180pt 宽，提示态按内容自适应宽度；
+10. Compact 必须覆盖 preparing / recording / processing / recovering / done / error 全部可见 phase；
+11. 所有新增用户可见文案继续提供中英文并跟随当前语言即时刷新。
+
+## 3. 已验证的当前实现
+
+### 3.1 RecordingVisualStyle
+
+当前 `Type4Me/UI/AppState.swift`：
+
+```swift
+enum RecordingVisualStyle: String, CaseIterable {
+    static let storageKey = "tf_visualStyle"
+    static let defaultValue = Self.timeline.rawValue
+
+    case classic
+    case dual
+    case timeline
+    case effectless
+    case hidden
+}
+```
+
+这组值只描述 Regular 的视觉效果，因此不增加 `.compact`。
+
+### 3.2 FloatingBarPresentation
+
+当前：
+
+```swift
+struct FloatingBarPresentation: Equatable {
+    var visualStyle: RecordingVisualStyle
+    var showsLiveTranscript: Bool
+    var enablesHoverTranscriptPreview: Bool
+}
+```
+
+已有 production AppStorage + preview override seam，可以直接扩展。
+
+### 3.3 FloatingBarView
+
+当前实现已具备：
+
+- `.preparing` / `.recording` → `recordingContent`；
+- 中间 `recordingText`；
+- 35pt Regular 控件；
+- 55pt capsule 高度；
+- transcript / action / mode top overlay；
+- `AudioRipple` recording background；
+- `FloatingBarButtonInteraction` 的 non-activating panel first click；
+- 统一 `triggerRecordingAction` 与 accessibility action。
+
+Compact 应复用 action/interaction 基础设施，但使用单独布局。
+
+### 3.4 FloatingBarPanel
+
+当前 Panel 是足够容纳最大 Regular bar、Transcript Popup 和 action tooltip overhang 的透明固定 host。
+
+第一版只改变 SwiftUI 可见 capsule，不根据 Compact 动态 resize NSPanel，可以避免录音中切换 preference 时出现 panel resize/reposition flicker。
+
+### 3.5 Design Token
+
+当前 `Type4Me/UI/DesignSystem.swift` 已有：
+
+```swift
+TF.floatingControlLight   // 对应 #FBFBFB
+TF.recordingTooltipBadge // 对应 #8A8A8A
+TF.floatingBackground
+TF.barWidthCompact       // 180
+```
+
+Compact 组件不再定义相同 RGB。
+
+## 4. 新增 RecordingIndicatorStyle
+
+建议在 Recording preferences 相邻位置新增：
+
+```swift
+enum RecordingIndicatorStyle: String, CaseIterable {
+    static let storageKey = "tf_recordingIndicatorStyle"
+    static let defaultValue = Self.regular.rawValue
+
+    case regular
+    case compact
+
+    var displayName: String {
+        switch self {
+        case .regular:
+            return L("常规", "Regular")
+        case .compact:
+            return L("紧凑型", "Compact")
+        }
+    }
+
+    static func current(userDefaults: UserDefaults = .standard) -> Self {
+        guard let raw = userDefaults.string(forKey: storageKey),
+              let style = Self(rawValue: raw)
+        else { return .regular }
+        return style
+    }
+}
+```
+
+不做 migration。旧用户缺少 `tf_recordingIndicatorStyle` 时自然回退 `.regular`。
+
+不要重写：
+
+```text
+tf_visualStyle
+tf_showLiveTranscript
+tf_hoverTranscriptPreview
+```
+
+## 5. FloatingBarPresentation 扩展
+
+修改为：
+
+```swift
+struct FloatingBarPresentation: Equatable {
+    var indicatorStyle: RecordingIndicatorStyle
+    var visualStyle: RecordingVisualStyle
+    var showsLiveTranscript: Bool
+    var enablesHoverTranscriptPreview: Bool
+}
+```
+
+`FloatingBarView` 增加：
+
+```swift
+@AppStorage(RecordingIndicatorStyle.storageKey)
+private var indicatorStyle = RecordingIndicatorStyle.defaultValue
+```
+
+并统一解析：
+
+```swift
+private var effectiveIndicatorStyle: RecordingIndicatorStyle {
+    presentationOverride?.indicatorStyle
+        ?? RecordingIndicatorStyle(rawValue: indicatorStyle)
+        ?? .regular
+}
+```
+
+## 6. Capability Resolution
+
+Compact 不能通过修改 stored settings 实现。
+
+建议：
+
+```swift
+private var usesCompactPresentation: Bool {
+    effectiveIndicatorStyle == .compact
+        && state.barPhase != .hidden
+}
+```
+
+Regular-only capability：
+
+```swift
+private var effectiveShowsLiveTranscript: Bool {
+    guard effectiveIndicatorStyle == .regular else { return false }
+    return presentationOverride?.showsLiveTranscript ?? showLiveTranscript
+}
+
+private var effectiveHoverTranscriptPreview: Bool {
+    guard effectiveIndicatorStyle == .regular else { return false }
+    return presentationOverride?.enablesHoverTranscriptPreview ?? hoverTranscriptPreview
+}
+```
+
+`effectiveRecordingVisualStyle` 仍解析 stored / override style，但只有 Regular recording path 使用。
+
+## 7. Render Visibility
+
+当前 `shouldRenderCapsule` 依赖 `recordingVisualStyle.showsRecordingPanel`。如果 Regular 保存为 `.hidden`，直接沿用会错误隐藏 Compact。
+
+建议：
+
+```swift
+private var shouldRenderCapsule: Bool {
+    guard state.barPhase != .hidden else { return false }
+
+    if usesCompactPresentation {
+        return true
+    }
+
+    return recordingVisualStyle.showsRecordingPanel
+}
+```
+
+实现阶段需要补充 post-recording feedback 的回归，确保 `.hidden` 只影响 Regular recording presentation，不吞掉必要的 Done / Error 反馈。
+
+## 8. Capsule Geometry
+
+当前 capsule 固定使用 `TF.barHeight`。Compact 高度统一为 24pt：
+
+```swift
+private var capsuleHeight: CGFloat {
+    usesCompactPresentation ? TF.compactIndicatorHeight : TF.barHeight
+}
+```
+
+宽度需要按 phase 分流，而不是 Compact 一律返回 180：
+
+```swift
+private var compactCapsuleWidth: CGFloat {
+    switch state.barPhase {
+    case .preparing, .recording:
+        return TF.compactIndicatorWidth
+    case .processing, .recovering, .done, .error:
+        return min(compactStatusIntrinsicWidth, TF.compactStatusMaxWidth)
+    case .hidden:
+        return 0
+    }
+}
+```
+
+其中：
+
+```text
+compactStatusIntrinsicWidth =
+    semanticGlyphWidth
+  + glyphTextSpacing
+  + measuredStatusTextWidth
+  + optionalActionWidth
+  + optionalActionSpacing
+  + horizontalInsets × 2
+```
+
+提示态**不设置 180pt 最小宽度**，也不使用 high-water mark；文案从长变短时 capsule 必须能够同步收窄。只有自然宽度超过 `TF.compactStatusMaxWidth` 时才 clamp 并对文字做 tail truncation。
+
+建议 `TF.compactStatusMaxWidth` 直接复用现有最大 Floating Bar 宽度能力（例如以 `TF.barWidth` 为上限或建立其语义别名），避免引入新的随意硬编码值。
+
+Compact 仍不使用 Regular transcript width measurement，也不参与 `recordingPeakWidth`、Regular processing width 或 Regular feedback width 计算；提示态使用独立的 status-content measurement。
+
+## 9. Design Token 扩展
+
+建议在 `TF` 增加：
+
+```swift
+static let compactIndicatorWidth: CGFloat = barWidthCompact
+static let compactIndicatorHeight: CGFloat = 24
+static let compactIndicatorControlVisualSize: CGFloat = 15
+static let compactIndicatorWaveBarWidth: CGFloat = 2
+static let compactIndicatorWaveMinHeight: CGFloat = 2
+static let compactIndicatorWaveMaxHeight: CGFloat = 18
+static let compactStatusMaxWidth: CGFloat = barWidth
+```
+
+颜色用语义别名，而不是重写 RGB：
+
+```swift
+static let compactIndicatorActive = floatingControlLight
+static let compactIndicatorInactive = recordingTooltipBadge
+```
+
+这样 Compact View 只引用语义 token。
+
+## 10. Compact Content Router
+
+不要缩放或复用 Regular `recordingContent` / `processingContent` / `doneContent` / `errorContent`。Compact 需要一个覆盖全部 phase 的内容路由：
+
+```swift
+@ViewBuilder
+private var phaseContent: some View {
+    if usesCompactPresentation {
+        compactPhaseContent
+    } else {
+        regularPhaseContent
+    }
+}
+
+@ViewBuilder
+private var compactPhaseContent: some View {
+    switch state.barPhase {
+    case .preparing, .recording:
+        compactRecordingContent
+    case .processing:
+        compactStatusContent(.processing, text: state.effectiveProcessingLabel)
+    case .recovering:
+        compactStatusContent(.recovering, text: state.effectiveProcessingLabel)
+    case .done:
+        compactDoneContent
+    case .error:
+        compactStatusContent(.error, text: state.feedbackMessage)
+    case .hidden:
+        EmptyView()
+    }
+}
+```
+
+录音布局：
+
+```swift
+private var compactRecordingContent: some View {
+    HStack(spacing: 0) {
+        compactRecordingButton(.finish)
+
+        CompactAudioIndicator(meter: state.audioLevel)
+            .frame(maxWidth: .infinity)
+
+        compactRecordingButton(.cancel)
+    }
+}
+```
+
+左右 edge cell 可以大于 15pt，但内部视觉控件必须为 15 × 15。Processing / Recovery / Done / Error 不显示录音按钮，而是使用 Compact status content。
+
+## 11. Compact Button
+
+复用：
+
+```swift
+triggerRecordingAction(_ action: RecordingControlAction)
+FloatingBarButtonInteraction
+```
+
+不要创建第二套 action callback。
+
+视觉建议：
+
+- Finish：`TF.compactIndicatorActive` 控制面 + `TF.floatingBackground` stop glyph；
+- Cancel：`TF.compactIndicatorActive` 控制面 + `TF.floatingBackground` xmark；
+- 视觉 frame 15 × 15；
+- interaction overlay 覆盖分配到的 edge cell，而不是只覆盖 15 × 15；
+- 保留现有 accessibility label / action；
+- Compact 在 hover 时正常更新 `hoveredAction`，并在按钮正上方展示操作提示气泡（完成录制、取消录制 esc）。
+
+## 12. CompactAudioIndicator
+
+建议新增：
+
+```text
+Type4Me/UI/FloatingBar/CompactAudioIndicator.swift
+```
+
+API：
+
+```swift
+struct CompactAudioIndicator: View {
+    let meter: AudioLevelMeter
+}
+```
+
+### 12.1 几何约束
+
+```text
+bar width:   2 pt
+min height:  2 pt
+max height: 18 pt
+```
+
+18pt 最大高度在 24pt capsule 中留下上下安全空间。
+
+柱数量与柱间距根据 center lane 可用宽度计算，不作为持久化设置。
+
+### 12.2 数据源
+
+直接读取：
+
+```swift
+meter.current
+```
+
+并 clamp 到 `0...1`。
+
+不要读取 transcript / segment，不新增 microphone capture，不依赖 `RecordingVisualStyle`。
+
+### 12.3 动画模型
+
+推荐 `TimelineView(.animation(...))` + `Canvas`：
+
+```text
+AudioLevelMeter.current
+    ↓ clamp
+lightweight smoothing
+    ↓
+recent level history / phased columns
+    ↓
+map to 2...18pt
+    ↓
+active / inactive token
+```
+
+静音阈值以下主要使用 inactive token，超过阈值的柱使用 active token。
+
+阈值、平滑参数和柱间距属于实现调校参数，不暴露为 UserDefaults。
+
+### 12.4 性能
+
+Compact renderer 应比现有 particle style 更轻：
+
+- 只画简单 rounded rect；
+- 约 30fps 即可；
+- 不把 mic level 放入 SwiftUI Observable state；
+- 继续利用 `AudioLevelMeter` 高频读取不触发整棵 View invalidation 的现有设计。
+
+## 13. Compact Top Overlay 与 Status Content
+
+Compact 在录音阶段保留气泡提示支持：
+
+- **模式提示**：录音准备/开始阶段（`preparing` / `recording`），在 180pt 胶囊正上方居中展示当前模式名称气泡（如 `快速模式`），2 秒后自动淡出；
+- **按钮悬停提示**：鼠标悬停在左侧 Finish 按钮上方时展示 `完成录制`，悬停在右侧 Cancel 按钮上方时展示 `取消录制 esc`，提示气泡中心水平偏移精准对齐两侧按钮（偏移量为 `±(capsuleWidth / 2 - 16)`）；
+- **Transcript 隔离**：Compact 不支持实时文字测量与 Transcript Popup，因此 `showTranscriptPopup` 在 Compact 阶段恒为 `false`；
+- **后处理阶段无气泡**：`processing` / `recovering` / `done` / `error` 阶段无悬停气泡，纯靠 24pt 胶囊内部的紧凑状态呈现。
+
+Compact status 建议统一为一行：
+
+```text
+[semantic glyph] [single-line status text] [optional compact action]
+```
+
+- Processing：轻量动画 glyph + `state.effectiveProcessingLabel`；
+- Recovering：recovery glyph + `state.effectiveProcessingLabel`；
+- Done：success / `feedbackKind` glyph + `state.feedbackMessage`；
+- Error：error glyph + `state.feedbackMessage`；
+- Revise Done 且存在 `latestReviseUndoTicketID`：尾部保留 compact Undo hit target；
+- Mac Action success / failure / unsure：沿用 `feedbackKind` 的语义 icon/color，但使用 Compact geometry。
+
+状态内容优先按 intrinsic width 单行完整展示；只有计算后的自然宽度超过 `TF.compactStatusMaxWidth` 时，文本才使用 `.lineLimit(1)` + tail truncation。完整状态文本写入 accessibility label。不能因为文本过长而走 Regular feedback width/height。
+
+## 14. Background Effect 隔离
+
+Compact 所有 phase 的基础背景都使用 `TF.floatingBackground`，通过小型 semantic glyph / tint 表达 processing、success、error 等状态，不使用 Regular 大面积背景动画。
+
+Regular AudioRipple 条件增加 indicator style 限制：
+
+```swift
+if state.barPhase == .recording,
+   effectiveIndicatorStyle == .regular,
+   recordingVisualStyle.showsBackgroundEffect {
+    AudioRipple(...)
+}
+```
+
+Regular 的 Processing / Done 等阶段维持当前 feedback 逻辑；Compact 则不得渲染 `ProcessingProgress`、Regular error gradient 或 Regular 55pt status content。
+
+## 15. Width Measurement 隔离
+
+Compact 的录音态固定 180pt，因此 Regular transcript 的以下逻辑仍只在 Regular 执行：
+
+- segment change 后 transcript `measureText`；
+- `recordingPeakWidth` high-water mark；
+- live transcript preference change 后重算 width；
+- transcript overflow mask。
+
+Compact 提示态另外维护**无历史峰值**的 status-content measurement：Processing / Recovering 使用 `effectiveProcessingLabel`，Done / Error 使用 `feedbackMessage`，并把 semantic glyph、可选 Undo/action 与水平内边距计入本次宽度。状态文本或 action 改变时直接重新计算当前 intrinsic width，允许宽度增大也允许缩小。
+
+不要复用 `recordingPeakWidth`，也不要因为 Compact 提示态需要测文字而重新启用 transcript measurement。
+
+## 16. Settings 接入
+
+`AppearanceSettingsTab` 新增：
+
+```swift
+@AppStorage(RecordingIndicatorStyle.storageKey)
+private var indicatorStyle = RecordingIndicatorStyle.defaultValue
+```
+
+presentation：
+
+```swift
+FloatingBarPresentation(
+    indicatorStyle: RecordingIndicatorStyle(rawValue: indicatorStyle) ?? .regular,
+    visualStyle: RecordingVisualStyle(rawValue: visualStyle) ?? .timeline,
+    showsLiveTranscript: showLiveTranscript,
+    enablesHoverTranscriptPreview: hoverTranscriptPreview
+)
+```
+
+Recording Display card 顺序：
+
+1. Indicator Style；
+2. Visual Style；
+3. Live Transcript；
+4. Hover Text Preview。
+
+Compact 时后三项 `.disabled(isCompact)`，但不写回 binding。
+
+如增加说明文案，使用：
+
+```swift
+L("仅常规外观可用", "Available in Regular only")
+```
+
+## 17. Appearance Preview 接入
+
+现有 `AppearancePreviewStage` 已直接运行：
+
+```swift
+FloatingBarView(
+    state: demoState,
+    presentationOverride: presentation
+)
+```
+
+所以不新增第二套 compact preview。
+
+需要修正当前 outer condition `presentation.visualStyle.showsRecordingPanel`：Compact 必须忽略 Regular `.hidden`。
+
+可以抽出 presentation helper：
+
+```swift
+var showsRecordingIndicator: Bool {
+    indicatorStyle == .compact || visualStyle.showsRecordingPanel
+}
+```
+
+Compact Preview 继续使用 `DemoState.startAppearancePreview` 的 synthetic audio 驱动声纹。
+
+> **注意（QA 提示）**：`DemoState` 如果进入 `.processing` / `.done` / `.error` 等相位，Compact Preview 必须继续呈现 24pt 高 Compact status，并根据当前提示内容自适应宽度。固定 180pt 的提示态或任何 55pt Regular feedback 都是回归错误。
+
+## 18. Panel 策略
+
+第一版保持 `FloatingBarController.panelSize` 不变。
+
+理由：
+
+1. Regular 仍需要最大 400pt + tooltip overhang；
+2. AppKit panel 本身透明，用户只看到 SwiftUI capsule；
+3. Compact 录音态固定 180 × 24；提示态在同一 host 内以 24pt 高、内容自适应宽度 bottom-center；
+4. preference 在录音过程中变化时不需要 resize panel；
+5. 避免重新 position 导致可见跳动。
+
+## 19. Processing / Recovering / Done / Error
+
+第一版必须实现 Compact 专属后处理反馈；这是 Indicator Style 一致性的组成部分，不再视为后续增强。
+
+geometry：
+
+```text
+preparing + compact  -> 180 × 24
+recording + compact  -> 180 × 24
+processing + compact -> intrinsic(content), height 24
+recovering + compact -> intrinsic(content), height 24
+done + compact       -> intrinsic(content), height 24
+error + compact      -> intrinsic(content), height 24
+```
+
+提示态宽度计算以本次内容为准，并 clamp 到 `compactStatusMaxWidth`；不设置 180pt minimum。
+
+状态数据继续复用现有 source of truth：
+
+- Processing：`effectiveProcessingLabel`；
+- Recovering：`effectiveProcessingLabel` + existing recovery semantics；
+- Done：`feedbackMessage` + `feedbackKind`；
+- Error：`feedbackMessage` + `feedbackKind`；
+- Revise Done：`latestReviseUndoTicketID` 决定是否显示 Compact Undo；
+- Mac Action：继续用 `feedbackKind` 区分 success / failure / unsure。
+
+关键约束是**只复用状态语义，不复用 Regular renderer**。从 Recording 进入 Processing、Done 或 Error 时 capsule 高度保持 24pt、整体布局风格不变，但宽度应从录音态的 180pt 过渡到当前提示内容的 intrinsic width；状态文案变化后还要能够继续向两侧扩展或收窄。
+
+## 20. 文件变更规划
+
+预计修改：
+
+```text
+Type4Me/UI/AppState.swift
+Type4Me/UI/DesignSystem.swift
+Type4Me/UI/FloatingBar/FloatingBarView.swift
+Type4Me/UI/Settings/AppearanceSettingsTab.swift
+Type4Me/UI/Settings/AppearancePreviewStage.swift
+Type4MeTests/AppearancePreviewTests.swift
+```
+
+预计新增：
+
+```text
+Type4Me/UI/FloatingBar/CompactAudioIndicator.swift
+```
+
+第一版预计不修改 `FloatingBarPanel.swift`。
+
+## 21. 单元测试
+
+### 21.1 Preference
+
+覆盖：
+
+- missing storage → `.regular`；
+- valid regular / compact raw values；
+- invalid raw value → `.regular`；
+- zh/en display name。
+
+### 21.2 Presentation
+
+覆盖：
+
+- Regular 保留 visual style / live / hover；
+- Compact 强制 live transcript effective false；
+- Compact 强制 hover effective false；
+- Compact 不受 Regular `.hidden` 影响；
+- nil override 继续使用 AppStorage fallback。
+
+如果 effective resolution 仍是 private computed property，建议抽出小型纯 helper 后测试，而不是依赖 pixel snapshot。
+
+### 21.3 Geometry 与 Phase Coverage
+
+覆盖 contract：
+
+```text
+preparing / recording -> 180 × 24
+processing / recovering / done / error -> height 24, width = current intrinsic content width clamped to max
+control visual -> 15 × 15
+wave width -> 2
+wave min -> 2
+wave max -> 18
+```
+
+额外覆盖：
+
+- 短提示的实际宽度可小于 180pt；
+- 长提示在 max width 内自然增长；
+- 内容由长变短时宽度能够回缩，不保留 high-water mark；
+- 超过 max width 才发生 tail truncation；
+- Compact phase resolution 永远不调用 Regular `feedbackWidth` / 55pt capsule geometry。
+
+### 21.4 Existing Regression
+
+`RecordingVisualStyle.allCases` 不应因为 Compact 增加新 case；现有 DemoState lifecycle、formatting、Appearance navigation tests 继续通过。
+
+## 22. 手工验收
+
+### Settings / Preview
+
+- Indicator Style 中英文正确；
+- Regular 下三项 regular-only setting 可用；
+- Compact 下三项 disabled；
+- 来回切换不改变保存值；
+- Compact Preview 录音态固定 180 × 24，提示态根据当前内容自适应宽度且高度保持 24pt；
+- synthetic audio 驱动波形；
+- Compact 不显示 transcript / transcript hover popup，但录音阶段支持模式提示与按钮悬停提示；
+- Regular visual style = hidden 后切 Compact，Compact 仍显示。
+
+### Production Floating Bar
+
+- Compact 录音尺寸固定；
+- ASR partial/final 到达不改变 width；
+- Finish / Cancel first click 在非激活 app 中生效；
+- finish 后 Processing / Recovering / Done / Error 全部继续保持 24pt 高 Compact，并根据当前提示内容自适应宽度；
+- processing 显示当前 `effectiveProcessingLabel`，包括润色、校准、改口等；
+- Done / Error 使用 Compact icon + `feedbackMessage`；
+- Revise recording 不显示 revise prompt text，而使用 compact audio indicator；Revise Done 的 Undo 仍可操作；
+- Mac Action success / failure / unsure 不回退 Regular。
+
+### Audio / Accessibility
+
+- silence 接近 2pt；
+- speech 不超过 18pt；
+- 所有柱宽 2pt；
+- 不出现 layout overflow；
+- Finish / Cancel accessibility label 正确；
+- visual 15pt 不导致 action target 失效。
+
+## 23. 构建与回归计划
+
+实现完成后至少：
+
+```bash
+swift test
+swift build
+```
+
+重点回归：
+
+- Existing AppearancePreviewTests；
+- Settings language switch；
+- all RecordingVisualStyle；
+- production FloatingBarPanel；
+- Quick Mode / Revise Finish / Cancel；
+- Regular Live Transcript / Hover Popup；
+- Compact + Regular visualStyle hidden；
+- Processing / Recovery / Done / Error phase transitions。
+
+当前文档阶段是 Markdown-only change，不强制执行 Swift build。
+
+## 24. 实现顺序
+
+1. 新增 `RecordingIndicatorStyle`；
+2. 增加 Compact geometry / semantic tokens；
+3. 扩展 `FloatingBarPresentation`；
+4. 增加 effective Indicator Style / capability resolution；
+5. 实现 phase-aware Compact geometry：录音态固定 180pt，提示态 intrinsic content width；
+6. 新增 `CompactAudioIndicator`；
+7. 复用现有 button action + AppKit interaction 实现 compact controls；
+8. 屏蔽 compact top overlay、transcript measurement、AudioRipple；
+9. 接入 Appearance Settings dropdown + disabled states；
+10. 实现 Compact Processing / Recovering / Done / Error status content 与 Revise Undo / Mac Action feedback；
+11. 修正 AppearancePreviewStage 的 Regular hidden / Compact visibility 与 full-lifecycle phase preview；
+12. 添加 preference / presentation / full-phase geometry tests；
+13. 手工 QA Regular 与 Compact 全生命周期；
+14. `swift test`；
+15. `swift build`。
+
+## 25. 风险与缓解
+
+### 风险 1：Compact 被混入 RecordingVisualStyle
+
+缓解：独立 `RecordingIndicatorStyle`，保持 layout 与 effect 正交。
+
+### 风险 2：Compact 覆盖用户旧设置
+
+缓解：只做 effective capability gating，不写回 Live / Hover / Visual Style。
+
+### 风险 3：Regular `.hidden` 把 Compact 隐藏
+
+缓解：render visibility 优先看 Indicator Style。
+
+### 风险 4：15pt 按钮难点击
+
+缓解：区分 visual size 与 interaction cell，复用 `FloatingBarButtonInteraction`。
+
+### 风险 5：音频动画过重
+
+缓解：简单 rounded bars + `AudioLevelMeter`，不复制 particle renderer，不把 mic level 放入 Observable state。
+
+### 风险 6：提示宽度抖动或过度增长
+
+缓解：提示宽度只跟随当前 `icon + text + optional action` 的 intrinsic width，不使用 high-water mark；在内容变化时使用现有宽度动画节奏平滑过渡，并以 `compactStatusMaxWidth` 限制极长文案。只有超过 max width 才尾部截断，同时把完整 `effectiveProcessingLabel` / `feedbackMessage` 暴露给 accessibility。
+
+### 风险 7：Preview 与 Production 分叉
+
+缓解：Preview 继续直接运行真实 `FloatingBarView` + presentation override。
+
+### 风险 8：颜色 token 名称语义不稳定
+
+`recordingTooltipBadge` 数值符合 inactive color，但名称偏 Tooltip。建议建立 Compact semantic alias，由现有 token 提供实际颜色值。
+
+## 26. 第一版技术决策汇总
+
+| 项目 | 决策 |
+|---|---|
+| Preference | `RecordingIndicatorStyle.regular / compact` |
+| Storage key | `tf_recordingIndicatorStyle` |
+| Default | `.regular` |
+| Migration | 无 |
+| RecordingVisualStyle | 不增加 Compact case |
+| Presentation | `FloatingBarPresentation` 增加 indicatorStyle |
+| Compact phases | preparing / recording / processing / recovering / done / error |
+| Compact geometry | 录音态固定 180 × 24；提示态高 24、宽度按 intrinsic content 自适应并设 max |
+| Control visual | 15 × 15 |
+| Wave geometry | width 2, height 2–18 |
+| Wave source | existing `AudioLevelMeter` |
+| Wave renderer | 独立轻量 `CompactAudioIndicator` |
+| Color | Design Token，不写 raw RGB |
+| Transcript / Hover | Compact effective disabled |
+| Regular AudioRipple | Compact recording 不使用 |
+| Mode/action hint | 录音阶段支持模式提示与按钮悬停操作提示 |
+| Buttons | 复用 RecordingControlAction + AppKit interaction |
+| Regular hidden value | 不影响 Compact visibility |
+| Panel size | 第一版保持现有 fixed host |
+| Preview | 复用真实 FloatingBarView |
+| Processing / Recovery / Result | Compact 专属 status content，复用状态数据但不复用 Regular renderer |
+| Build requirement for docs | 不需要；实现阶段执行 swift test + swift build |

--- a/docs/features/compact-recording-indicator/product-design.md
+++ b/docs/features/compact-recording-indicator/product-design.md
@@ -1,0 +1,341 @@
+# Type4Me 紧凑型录音指示条产品设计
+
+> 分支：`feat/compact-recording-indicator`
+> 文档类型：产品设计
+> 文档状态：设计中
+> 设计日期：2026-08-25
+> 目标版本：Type4Me 2.x
+> 对应开发设计：`docs/features/compact-recording-indicator/development-design.md`
+
+## 1. 背景
+
+Type4Me 当前只有一套录音悬浮条外观。它会根据实时文本长度动态扩展宽度，并支持录音动效、实时展示文本、悬停文字预览、模式提示和按钮悬停提示。
+
+这套设计适合希望获得完整录音反馈的用户，但对于已经熟悉 Type4Me、只需要确认“正在录音”以及快速结束或取消的用户，当前悬浮条占用空间较大，视觉信息也偏多。
+
+因此，本功能把当前整套录音悬浮条定义为 **“常规 / Regular”**，并新增一套 **“紧凑型 / Compact”** 外观。Compact 是整个 Floating Bar 生命周期的 presentation，而不是只作用于录音阶段的局部皮肤：录音时使用左右操作按钮 + 动态音频指示器；录音结束后的处理、润色、恢复、完成和错误反馈也继续使用同一套 24pt 高的 Compact chrome，不再跳回 Regular。
+
+## 2. 产品目标
+
+1. 在“外观 / Appearance”设置中允许用户选择“常规”或“紧凑型”录音指示条；
+2. 保持当前用户体验兼容：已有用户升级后默认仍为“常规”；
+3. Compact 在所有可见 Floating Bar phase 中保持 24pt 高度和 Compact 视觉语言：Preparing / Recording 固定为 180 × 24 pt；Processing / Recovering / Done / Error 根据提示内容自适应宽度，不切回 Regular 尺寸；
+4. 紧凑型支持录音开始时的居中模式提示（如快速模式）与按钮悬停操作提示（完成录制、取消录制 esc），但不展示实时识别文本、悬停文字预览（Transcript Popup）或现有 Regular 背景动效；
+5. 录音阶段仍保留可直接点击的“完成”和“取消”操作；
+6. 录音阶段由动态音频指示器反馈声音输入；Processing / Recovering / Done / Error 使用 Compact 专属的图标、进度和短状态文案；
+7. 用户切换回常规后，之前设置的录音动效、实时文本和悬停预览保持原值；
+8. 所有颜色继续使用 Type4Me Design Token，不在组件中写死颜色值。
+
+## 3. 非目标
+
+第一版不包含：
+
+- 重新设计常规录音悬浮条；
+- 用户自定义紧凑型尺寸、按钮尺寸、声纹尺寸或颜色；
+- 紧凑型实时文本；
+- 紧凑型 Transcript Popup；
+- 紧凑型 Lines / Particles / Levels 等现有录音动效；
+- 为 Compact 增加可扩展的大型后处理卡片、第二层弹窗或 55pt Regular fallback；
+- 改变完成、取消、处理、恢复或录音状态机的业务语义；
+- 新增独立主题系统。
+
+## 4. 外观层级
+
+录音显示设置拆成两个不同维度：
+
+```text
+指示条外观 / Indicator Style
+├── 常规 / Regular
+│   ├── 录音动效 / Visual Style
+│   ├── 实时展示文本 / Live Transcript
+│   └── 悬停文字预览 / Hover Text Preview
+└── 紧凑型 / Compact
+    ├── 录音：Finish + Audio Indicator + Cancel
+    ├── 处理/润色：Compact Progress + Status
+    ├── 恢复：Compact Recovery Status
+    └── 完成/错误：Compact Result Feedback
+```
+
+“常规 / 紧凑型”是录音指示条的整体布局类型；“线条 / 粒子云 / 电平 / 无特效 / 无”仍然只是常规外观内部的录音动效选择。
+
+因此，紧凑型不能被实现成新的 `RecordingVisualStyle` 项，否则会把“整体布局”和“背景动效”两个独立概念混在一起。
+
+## 5. 设置页设计
+
+### 5.1 新增选项
+
+在 Settings → Appearance → “录音显示 / Recording Display”卡片第一行新增：
+
+```text
+指示条外观 / Indicator Style    [ 常规 ▾ ]
+                                  [ 紧凑型 ]
+```
+
+默认值为“常规 / Regular”。
+
+### 5.2 常规模式
+
+选择“常规”时，现有设置全部保持可用：
+
+- 录音动效；
+- 实时展示文本；
+- 悬停文字预览。
+
+行为与当前版本一致。
+
+### 5.3 紧凑型模式
+
+选择“紧凑型”时：
+
+- 录音动效设置保留显示，但置灰不可操作；
+- 实时展示文本设置保留显示，但置灰不可操作；
+- 悬停文字预览设置保留显示，但置灰不可操作；
+- 这些设置的已保存值不被修改。
+
+这样用户能理解这些能力只属于常规外观，同时不会因为临时切换紧凑型而丢失原来的偏好。切回常规后，三项设置恢复可用，并继续使用切换前保存的值。
+
+## 6. 紧凑型录音指示条
+
+### 6.1 录音态尺寸
+
+Preparing / Recording 阶段的紧凑型录音指示条固定为：
+
+```text
+180 × 24 pt
+```
+
+180 × 24 指录音态整个紧凑型悬浮条，而不是仅指中间声纹区域。Processing / Recovering / Done / Error 不继承 180pt 固定宽度，而由提示内容决定实际宽度。所有 Compact phase 继续保持 24pt 高度、深色背景设计语言和胶囊形态。
+
+### 6.2 布局
+
+```text
+┌──────────────────────────────────────────┐
+│  [■]      dynamic audio indicator    [×] │
+└──────────────────────────────────────────┘
+   完成                              取消
+```
+
+- 左侧：完成 / Finish；
+- 中间：动态音频指示器；
+- 右侧：取消 / Cancel；
+- 不放置任何文字。
+
+### 6.3 按钮
+
+按钮视觉尺寸为：
+
+```text
+15 × 15 pt
+```
+
+按钮主色目标为用户指定的 `#FBFBFB`，但实现必须引用现有 Design Token，而不是在 View 内写十六进制或 RGB 常量。当前 Design System 中 `TF.floatingControlLight` 已对应这一颜色，应优先复用该 token 或建立基于它的语义别名。
+
+按钮语义：
+
+- Finish：白色控制面，内部使用清晰的停止/完成符号；
+- Cancel：白色控制面，内部使用 `×` 取消符号；
+- 两个按钮继续执行与常规模式相同的业务 action；
+- 15 × 15 是视觉尺寸，实际可点击区域应在 24pt 高度允许的范围内尽量扩大。
+
+### 6.4 动态音频指示器
+
+中间区域使用一组垂直声纹柱表达声音输入。
+
+| 属性 | 值 |
+|---|---:|
+| 柱宽 | 2 pt |
+| 最小高度 | 2 pt |
+| 最大高度 | 18 pt |
+| 非激活颜色目标 | `#8A8A8A` |
+| 激活颜色目标 | `#FBFBFB` |
+
+颜色必须使用现有 Design Token。当前 `TF.recordingTooltipBadge` 对应 `#8A8A8A`，`TF.floatingControlLight` 对应 `#FBFBFB`。
+
+产品层不固定柱数量和柱间距；实现需要在左右按钮占位后的中间可用宽度内均匀排布，确保 2pt 柱宽和 2–18pt 高度约束不变。
+
+### 6.5 动态语义
+
+- 静音或输入很弱时，声纹接近最小高度，并主要使用非激活色；
+- 有明确声音输入时，声纹随 `AudioLevelMeter` 动态变化，激活柱使用激活色；
+- 动画连续稳定，不因 ASR 文本分段或修正发生横向尺寸变化；
+- 动效只表达麦克风音量，不表达文本内容，也不复用常规模式的背景视觉效果。
+
+## 7. 提示与气泡支持
+
+紧凑型在录音阶段提供精简的气泡提示支持：
+
+- **模式提示**：录音开始（Preparing / Recording 阶段）在胶囊正上方展示当前模式（如“快速模式 / Quick Mode”），2 秒后自动淡出；
+- **按钮悬停提示**：鼠标悬停在左侧 Finish 按钮上方展示“完成录制 / Finish Recording”，悬停在右侧 Cancel 按钮上方展示“取消录制 esc / Cancel Recording esc”（带 esc 徽标），气泡中心与两侧 15×15 按钮对齐；
+- **不展示实时文本与 Transcript Popup**：不显示实时识别文字、`倾听中 / Listening`，也不触发 Transcript 文本悬停弹窗；
+- **不展示 Regular 背景动效**：不渲染 Lines / Particles / Levels 等背景波纹。
+
+按钮继续保留完整的 accessibility label 与 action。
+
+## 8. Compact 全生命周期状态
+
+Compact 一旦被选中，从 Floating Bar 出现到最终隐藏，所有可见 phase 都使用同一套 **24pt 高 Compact chrome**，但宽度策略按内容类型区分。状态变化只替换内容和必要操作，不切换回 Regular。
+
+| Phase | Compact 内容 | 宽度策略 |
+|---|---|---|
+| Preparing | Finish + 静态/低幅 Audio Indicator + Cancel | 固定 180pt |
+| Recording | Finish + 动态 Audio Indicator + Cancel | 固定 180pt |
+| Processing | Compact progress glyph + `effectiveProcessingLabel`，例如“润色中 / Polishing”“校准中 / Calibrating” | 根据内容自适应 |
+| Recovering | Recovery glyph + 当前恢复状态短文案 | 根据内容自适应 |
+| Done | Success icon + `feedbackMessage` | 根据内容自适应 |
+| Error | Error icon + `feedbackMessage` | 根据内容自适应 |
+| Hidden | 不显示 | — |
+
+示意：
+
+```text
+Recording   [■]  ▁▃▆▂▅▇▃  [×]
+Processing      ◌  润色中…
+Done            ✓  已完成
+Error           !  处理失败
+```
+
+所有状态维持 24pt 高度和 Compact 视觉语言。提示态宽度按 `semantic icon + 状态文本 + 可选操作 + 水平内边距` 的实际内容自然伸缩：短提示应明显短于录音态，较长提示可以自然变宽；仅当自然宽度超过最大允许宽度时才做尾部截断。完整信息继续通过 accessibility 暴露，不能因为文案较长而回退到 55pt Regular UI。
+
+提示宽度不使用 180pt 作为最小值，也不保留类似 recording high-water mark 的历史最大宽度；状态内容变短后，胶囊应同步收窄。
+
+Revise 完成且存在 Undo ticket 时，Done 状态把 Undo 计入自适应内容宽度；Mac Action 的 success / failure / unsure 也使用 Compact icon + message，并按实际内容自适应，而不是 Regular feedback。
+
+## 9. 与 Regular 的 Visual Style = None 的关系
+
+`RecordingVisualStyle.hidden` 属于常规外观设置。
+
+因此：
+
+- Regular + Visual Style = None → 录音时不显示常规悬浮条；
+- Compact → 始终显示紧凑型指示条，不受 Regular 的 Visual Style = None 影响；
+- 切回 Regular 后继续恢复此前保存的 None / Lines / Particles / Levels / No Effects 值。
+
+## 10. Appearance Preview
+
+设置页顶部 Preview Stage 必须真实预览当前 Indicator Style。
+
+### Regular
+
+继续使用现有真实 `FloatingBarView` 预览 Visual Style、Live Transcript 和 Hover Popup。
+
+### Compact
+
+预览直接呈现 180 × 24 紧凑型录音条：
+
+- 左 Finish；
+- 中间动态声纹；
+- 右 Cancel；
+- 合成 AudioLevel 继续驱动声纹；
+- 不显示示例 transcript；
+- 不显示 Transcript hover popup。
+
+切换 Regular / Compact 时 Preview 立即更新。Compact Preview 如果进入 Processing / Done / Error 等 phase，必须继续保持 24pt 高的 Compact 状态反馈，并像真实 UI 一样根据提示内容自适应宽度；Preview 中出现固定 180pt 提示宽度或 55pt Regular feedback 都应视为实现错误。
+
+## 11. 设置保存与兼容性
+
+新增 Indicator Style 使用独立持久化值。
+
+升级兼容原则：
+
+- 老版本不存在该值 → 自动按 Regular 处理；
+- 不迁移、不重写 `tf_visualStyle`；
+- 不迁移、不重写 `tf_showLiveTranscript`；
+- 不迁移、不重写 `tf_hoverTranscriptPreview`；
+- Compact 只在运行时屏蔽这些能力，不修改其保存值。
+
+## 12. 可访问性与本地化
+
+新增用户可见文案提供中英文：
+
+- 指示条外观 / Indicator Style；
+- 常规 / Regular；
+- 紧凑型 / Compact；
+- 如需说明“仅常规外观可用”，同样提供中英文。
+
+Compact 本体没有可见文字，但两个按钮继续暴露：
+
+- `完成录制 / Finish Recording`；
+- `取消录制 / Cancel Recording`。
+
+## 13. 验收场景
+
+### 13.1 默认兼容
+
+已有用户升级后不修改设置，录音悬浮条外观和升级前一致，Indicator Style 显示 Regular。
+
+### 13.2 Regular
+
+选择 Regular 后，Visual Style / Live Transcript / Hover Preview 均可操作，现有行为保持不变。
+
+### 13.3 Compact 基础布局
+
+- 录音时固定 180 × 24；
+- 左右按钮视觉尺寸 15 × 15；
+- 中间只有动态音频指示器；
+- 不显示 transcript 或 Listening 文案。
+
+### 13.4 Compact 音频反馈
+
+- 静音时声纹接近 2pt，呈非激活状态；
+- 说话时声纹在 2–18pt 范围内变化；
+- 柱宽始终 2pt；
+- 激活/非激活颜色来自 Design Token。
+
+### 13.5 Compact 能力隔离
+
+先在 Regular 中设置任意 Visual Style 并开启 Live Transcript + Hover Preview，再切 Compact：三项设置不可操作但值不改变，Compact 不显示对应能力；切回 Regular 后旧设置和值原样恢复。
+
+### 13.6 控件与 Preview
+
+- 左 Finish 与常规完成行为一致；
+- 右 Cancel 与常规取消行为一致；
+- 非激活应用上首次点击仍可触发；
+- Accessibility 可识别两个按钮；
+- Settings 中 Regular / Compact 切换立即反映到 Preview；
+- Compact Preview 的合成音量持续驱动声纹；
+- Preview 中的 Finish / Cancel 不破坏 Demo 状态。
+
+### 13.7 后续状态
+
+Finish 后进入 Processing / Recovering / Done / Error 时，始终保持 24pt 高 Compact chrome，并按实际提示内容自适应宽度：
+
+- Processing 显示紧凑进度提示 + 当前处理文案，宽度随文案变化；
+- Done 显示成功 icon + feedback，短反馈自然收窄；
+- Error 显示错误 icon + feedback，较长反馈可在最大宽度内自然展开；
+- Revise Undo 与 Mac Action 状态仍保留必要交互/语义，并计入内容宽度；
+- 提示态不以 180pt 为固定宽度或最小宽度；
+- 全程不得切回 55pt Regular indicator。
+
+## 14. 后续演进
+
+稳定后可再评估：
+
+- 更丰富的 Compact Processing 动效；
+- 更完整的 Compact 长错误信息展开方式；
+- 紧凑型尺寸档位；
+- 声纹密度或灵敏度；
+- 根据 Reduce Motion 调整声纹动画；
+- 为视觉按钮和交互 hit target 增加更系统的 Design Token。
+
+## 15. 第一版产品决策汇总
+
+| 项目 | 决策 |
+|---|---|
+| 当前外观命名 | 常规 / Regular |
+| 新外观 | 紧凑型 / Compact |
+| 层级 | Indicator Style 独立于 RecordingVisualStyle |
+| 默认值 | Regular |
+| Compact 尺寸 | Preparing / Recording 固定 180 × 24；提示态高 24pt、宽度按内容自适应 |
+| 控件 | 左 Finish、中 Audio Indicator、右 Cancel |
+| 按钮视觉尺寸 | 15 × 15 pt |
+| 声纹柱宽 | 2 pt |
+| 声纹高度 | 2–18 pt |
+| 激活色 | 复用 `TF.floatingControlLight` 对应 token |
+| 非激活色 | 复用 `TF.recordingTooltipBadge` 对应 token |
+| Live Transcript | Compact 不支持，保存值不改 |
+| Hover Text Preview | Compact 不支持，保存值不改 |
+| Recording Visual Style | Compact 不支持，保存值不改 |
+| Mode / Action Hint | 录音阶段支持居中模式提示与按钮悬停气泡提示 |
+| Preview | 真实组件 + 合成 AudioLevel |
+| Processing / Recovery / Result | 使用 Compact 专属状态内容，不回退 Regular |
+| 数据迁移 | 无；缺省即 Regular |


### PR DESCRIPTION
## 概述

<img width="1110" height="298" alt="image" src="https://github.com/user-attachments/assets/e3a3dbd8-e08c-41f3-bc13-c49cf478d1d5" />

为录音悬浮条新增独立的 **Indicator Style** 维度（常规 / Regular、紧凑型 / Compact），与 `RecordingVisualStyle`（Lines/Particles/Levels…）正交。设计文档见 `docs/features/compact-recording-indicator/`，已与实现同步。

## 改动

- **`RecordingIndicatorStyle`** 新偏好（`tf_recordingIndicatorStyle`），默认 Regular；无迁移，缺 key/非法值回退 Regular。
- **紧凑型录音条**：固定 180×24 胶囊，左右 15×15 Finish/Cancel，中间 `CompactAudioIndicator` 由现有 `AudioLevelMeter` 驱动的滚动声纹（不新增麦克风/ASR 依赖，Canvas 渲染避免 View 失效级联）。
- **全生命周期一致**：Compact 覆盖 preparing/recording/processing/recovering/done/error 全部可见 phase，统一 24pt chrome；录音态固定 180pt，状态态按内容（icon + 文案 + 可选 Undo/action + 内边距）自适应宽度，不回退 55pt Regular。
- **提示气泡**：录音阶段支持居中 mode hint 与按钮悬停操作气泡（气泡中心对齐 15×15 按钮，偏移 `±(capsuleWidth/2 - 16)`）；不显示实时文本 / Transcript Popup / Regular 背景动效。
- **能力隔离**：Compact 通过 effective 解析关闭 Regular-only 能力（实时文本、悬停预览、AudioRipple、transcript 宽度测量），**不改写**其保存值。
- **颜色/文案**：全部引用现有 Design Token（新增 compact 语义别名）；新增用户可见文案中英双语。
- **设置页**：新增「指示条外观」行，Compact 下禁用后三项（保留值）并标注「仅常规外观可用」。
- **预览**：改用 `presentation.showsRecordingIndicator`，使 Regular 视觉样式为 hidden 时 Compact 仍可预览。

## 验证

- `swift build` ✅
- `swift test` ✅ 835 项通过，0 失败（新增 preference / presentation / geometry 测试）
- 设计文档（product / development）已逐段核对，与实现一致。

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>