### PR TITLE
fix: match floating panel hit area to visible content

### DIFF
--- a/Type4Me/UI/AppState.swift
+++ b/Type4Me/UI/AppState.swift
@@ -1467,9 +1467,8 @@ final class AppState {
         processingLabelOverride = nil
         pinsTranscriptPopup = false
         barPhase = .preparing
-        // Keep the transparent panel alive for every style so a live settings
-        // change from `.hidden` can reveal the indicator immediately. The view
-        // itself is responsible for rendering nothing for `.hidden`.
+        // Notify the controller for every style so a live settings change from
+        // `.hidden` can reveal the indicator immediately.
         onShowPanel?()
     }
 

--- a/Type4Me/UI/DesignSystem.swift
+++ b/Type4Me/UI/DesignSystem.swift
@@ -99,15 +99,16 @@ enum TF {
     static let barWidthCompact: CGFloat = 180
     static let barHeight: CGFloat = 55
     static let barBottomOffset: CGFloat = 48
+    static let floatingPanelShadowInset: CGFloat = 8
     static let recordingFinishControlSize: CGFloat = 45
     static let recordingCancelControlSize: CGFloat = 35
-    static let recordingControlSize: CGFloat = recordingFinishControlSize
     static let recordingLeadingInset: CGFloat = 5
     static let recordingTrailingInset: CGFloat = 10
     static let recordingEdgeInset: CGFloat = recordingTrailingInset
     static let recordingControlGap: CGFloat = 8
     static let recordingTooltipGap: CGFloat = 5
     static let recordingTooltipMaxWidth: CGFloat = 180
+    static let recordingCapsuleSpringResponse = 0.3
     static let recordingTooltipBadge = Color(
         red: 138 / 255,
         green: 138 / 255,

--- a/Type4Me/UI/DesignSystem.swift
+++ b/Type4Me/UI/DesignSystem.swift
@@ -133,7 +133,7 @@ enum TF {
 
     static let transcriptPopupWidth: CGFloat = 350
     static let transcriptPopupMaxHeight: CGFloat = 120
-    static let transcriptPopupCorner: CGFloat = 10
+    static let transcriptPopupCorner: CGFloat = cornerLG
     static let transcriptPopupGap: CGFloat = 10
 
     // MARK: Compact Recording Indicator

--- a/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
@@ -6,6 +6,7 @@ struct FloatingBarPanelLayout: Equatable {
 
     let contentSize: NSSize
     var horizontalOverflow: CGFloat = 0
+    var capsuleSize: NSSize? = nil
 
     var hasVisibleContent: Bool {
         contentSize.width > 0 && contentSize.height > 0
@@ -14,16 +15,17 @@ struct FloatingBarPanelLayout: Equatable {
     var panelSize: NSSize {
         guard hasVisibleContent else { return NSSize(width: 1, height: 1) }
         return NSSize(
-            width: ceil(contentSize.width + 2 * horizontalOverflow),
-            height: ceil(contentSize.height)
+            width: ceil(contentSize.width + 2 * (horizontalOverflow + TF.floatingPanelShadowInset)),
+            height: ceil(contentSize.height + 2 * TF.floatingPanelShadowInset)
         )
     }
 
     static func fallback(for style: RecordingIndicatorStyle) -> FloatingBarPanelLayout {
-        FloatingBarPanelLayout(contentSize: NSSize(
+        let size = NSSize(
             width: TF.barWidthCompact,
             height: style == .compact ? TF.compactIndicatorHeight : TF.barHeight
-        ))
+        )
+        return FloatingBarPanelLayout(contentSize: size, capsuleSize: size)
     }
 }
 
@@ -45,7 +47,7 @@ final class FloatingBarPanel: NSPanel {
         level = .floating
         isOpaque = false
         backgroundColor = .clear
-        hasShadow = true
+        hasShadow = false
         collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         isMovableByWindowBackground = false
         hidesOnDeactivate = false
@@ -73,7 +75,7 @@ final class FloatingBarPanel: NSPanel {
     static func bottomCenteredFrame(size: NSSize, visibleFrame: NSRect) -> NSRect {
         NSRect(
             x: visibleFrame.midX - size.width / 2,
-            y: visibleFrame.minY + TF.barBottomOffset,
+            y: visibleFrame.minY + TF.barBottomOffset - TF.floatingPanelShadowInset,
             width: size.width,
             height: size.height
         )
@@ -87,7 +89,7 @@ final class FloatingBarPanel: NSPanel {
 @MainActor
 final class FloatingBarController {
 
-    private static let panelShrinkDelay: Duration = .milliseconds(350)
+    private static let capsuleShrinkDelay: Duration = .seconds(TF.recordingCapsuleSpringResponse)
 
     let panel: FloatingBarPanel
     private let state: AppState
@@ -123,6 +125,7 @@ final class FloatingBarController {
     }
 
     func updatePanelLayout(_ layout: FloatingBarPanelLayout) {
+        let previousLayout = currentLayout
         currentLayout = layout
 
         panel.ignoresMouseEvents = !layout.hasVisibleContent || state.barPhase == .hidden
@@ -138,7 +141,7 @@ final class FloatingBarController {
             && state.barPhase != .hidden
             && !panel.isVisible
             && panelGeneration > 0
-        resizePanel(to: layout.panelSize, display: panel.isVisible)
+        resizePanel(from: previousLayout, to: layout, display: panel.isVisible)
 
         if shouldShow {
             show()
@@ -160,7 +163,7 @@ final class FloatingBarController {
             return
         }
 
-        resizePanel(to: layout.panelSize, display: panel.isVisible)
+        resizePanel(from: currentLayout, to: layout, display: panel.isVisible)
         panel.ignoresMouseEvents = false
 
         panel.contentView?.layer?.removeAllAnimations()
@@ -201,31 +204,44 @@ final class FloatingBarController {
         return .fallback(for: RecordingIndicatorStyle.current())
     }
 
-    private func resizePanel(to targetSize: NSSize, display: Bool) {
+    private func resizePanel(
+        from previousLayout: FloatingBarPanelLayout,
+        to layout: FloatingBarPanelLayout,
+        display: Bool
+    ) {
         cancelPendingPanelShrink()
 
+        let targetSize = layout.panelSize
         let currentSize = panel.frame.size
         guard !approximatelyEqual(currentSize, targetSize) else { return }
 
-        let isShrinking = targetSize.width < currentSize.width - 0.5
-            || targetSize.height < currentSize.height - 0.5
-        guard display, isShrinking else {
-            applyPanelSize(targetSize, display: display)
-            return
-        }
+        let capsuleWidthShrinks = previousLayout.capsuleSize.map { previous in
+            layout.capsuleSize.map { $0.width < previous.width - 0.5 } ?? false
+        } ?? false
+        let capsuleHeightShrinks = previousLayout.capsuleSize.map { previous in
+            layout.capsuleSize.map { $0.height < previous.height - 0.5 } ?? false
+        } ?? false
+        let delaysWidth = display
+            && targetSize.width < currentSize.width - 0.5
+            && capsuleWidthShrinks
+        let delaysHeight = display
+            && targetSize.height < currentSize.height - 0.5
+            && capsuleHeightShrinks
 
-        // Expand either axis immediately, but keep shrinking axes large enough
-        // for the capsule spring and overlay fade to finish without clipping.
+        // Overlay-only axes resize immediately. Only axes whose visible capsule
+        // is still springing retain their old bounds until that spring ends.
         let transitionSize = NSSize(
-            width: max(currentSize.width, targetSize.width),
-            height: max(currentSize.height, targetSize.height)
+            width: delaysWidth ? max(currentSize.width, targetSize.width) : targetSize.width,
+            height: delaysHeight ? max(currentSize.height, targetSize.height) : targetSize.height
         )
         if !approximatelyEqual(currentSize, transitionSize) {
-            applyPanelSize(transitionSize, display: true)
+            applyPanelSize(transitionSize, display: display)
         }
 
+        guard delaysWidth || delaysHeight else { return }
+
         panelShrinkTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: Self.panelShrinkDelay)
+            try? await Task.sleep(for: Self.capsuleShrinkDelay)
             guard !Task.isCancelled, let self else { return }
             guard self.state.barPhase != .hidden,
                   self.approximatelyEqual(self.currentLayout.panelSize, targetSize)
@@ -248,10 +264,6 @@ final class FloatingBarController {
             visibleFrame: screen.visibleFrame
         )
         panel.setFrame(frame, display: display)
-        Task { @MainActor [weak self] in
-            self?.panel.contentView?.layoutSubtreeIfNeeded()
-            self?.panel.invalidateShadow()
-        }
     }
 
     private func resolvedAnchorScreen() -> NSScreen? {

--- a/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
@@ -1,6 +1,32 @@
 import AppKit
 import SwiftUI
 
+struct FloatingBarPanelLayout: Equatable {
+    static let hidden = FloatingBarPanelLayout(contentSize: .zero)
+
+    let contentSize: NSSize
+    var horizontalOverflow: CGFloat = 0
+
+    var hasVisibleContent: Bool {
+        contentSize.width > 0 && contentSize.height > 0
+    }
+
+    var panelSize: NSSize {
+        guard hasVisibleContent else { return NSSize(width: 1, height: 1) }
+        return NSSize(
+            width: ceil(contentSize.width + 2 * horizontalOverflow),
+            height: ceil(contentSize.height)
+        )
+    }
+
+    static func fallback(for style: RecordingIndicatorStyle) -> FloatingBarPanelLayout {
+        FloatingBarPanelLayout(contentSize: NSSize(
+            width: TF.barWidthCompact,
+            height: style == .compact ? TF.compactIndicatorHeight : TF.barHeight
+        ))
+    }
+}
+
 // MARK: - NSPanel Subclass
 
 /// Non-activating floating panel that never steals focus from the target app.
@@ -19,11 +45,11 @@ final class FloatingBarPanel: NSPanel {
         level = .floating
         isOpaque = false
         backgroundColor = .clear
-        hasShadow = false
+        hasShadow = true
         collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         isMovableByWindowBackground = false
         hidesOnDeactivate = false
-        ignoresMouseEvents = false
+        ignoresMouseEvents = true
         acceptsMouseMovedEvents = true
         animationBehavior = .utilityWindow
         appearance = NSAppearance(named: .darkAqua)
@@ -32,67 +58,113 @@ final class FloatingBarPanel: NSPanel {
     override var canBecomeKey: Bool { false }
     override var canBecomeMain: Bool { false }
 
-    func positionAtBottomCenter() {
+    static func screenUnderMouse() -> NSScreen? {
         let mouseLocation = NSEvent.mouseLocation
-        let screen = NSScreen.screens.first(where: { $0.frame.contains(mouseLocation) }) ?? NSScreen.main ?? NSScreen.screens.first
-        guard let screen else { return }
-        let visible = screen.visibleFrame
-        let x = visible.midX - frame.width / 2
-        let y = visible.origin.y + TF.barBottomOffset - 16  // compensate for shadow inset
-        setFrameOrigin(NSPoint(x: x, y: y))
+        return NSScreen.screens.first(where: { $0.frame.contains(mouseLocation) })
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
+    }
+
+    static func displayID(for screen: NSScreen) -> CGDirectDisplayID? {
+        (screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?
+            .uint32Value
+    }
+
+    static func bottomCenteredFrame(size: NSSize, visibleFrame: NSRect) -> NSRect {
+        NSRect(
+            x: visibleFrame.midX - size.width / 2,
+            y: visibleFrame.minY + TF.barBottomOffset,
+            width: size.width,
+            height: size.height
+        )
     }
 }
 
 // MARK: - Controller
 
-/// Manages the floating bar panel lifecycle.
-/// All visual styling is handled in SwiftUI (FloatingBarView).
+/// Manages the floating bar panel lifecycle and keeps its mouse hit area at the
+/// smallest single rectangle containing the currently visible bar and overlay.
 @MainActor
 final class FloatingBarController {
 
-    private let panel: FloatingBarPanel
+    let panel: FloatingBarPanel
     private let state: AppState
-    private let panelSize: NSSize
+    private var currentLayout = FloatingBarPanelLayout.hidden
+    private var anchorDisplayID: CGDirectDisplayID?
     private var panelGeneration = 0
 
     init(state: AppState) {
         self.state = state
 
-        let inset: CGFloat = 16  // extra room for shadow/glow
-        // Action tooltips are centered over the edge controls, so they extend
-        // beyond the 400-point capsule at full width.
-        let horizontalInset = inset + TF.recordingTooltipOverhang
-        let contentHeight = TF.barHeight + TF.transcriptPopupGap + TF.transcriptPopupMaxHeight
-        let frame = NSRect(
-            x: 0,
-            y: 0,
-            width: TF.barWidth + horizontalInset * 2,
-            height: contentHeight + inset * 2
-        )
-        panelSize = frame.size
+        let initialLayout = FloatingBarPanelLayout.fallback(for: RecordingIndicatorStyle.current())
+        let frame = NSRect(origin: .zero, size: initialLayout.panelSize)
         panel = FloatingBarPanel(contentRect: frame)
 
-        let barView = FloatingBarView<AppState>(state: state)
+        let barView = FloatingBarView<AppState>(
+            state: state,
+            onPanelLayoutChange: { [weak self] layout in
+                self?.updatePanelLayout(layout)
+            }
+        )
         let hosting = NSHostingView(rootView: barView)
+        hosting.sizingOptions = []
         hosting.layer?.backgroundColor = .clear
-        hosting.frame = NSRect(origin: .zero, size: frame.size)
+        hosting.frame = frame
         hosting.autoresizingMask = [.width, .height]
 
         panel.contentView = hosting
         panel.setFrame(frame, display: false)
-        panel.positionAtBottomCenter()
 
         state.onShowPanel = { [weak self] in self?.show() }
         state.onHidePanel = { [weak self] in self?.hide() }
     }
 
+    func updatePanelLayout(_ layout: FloatingBarPanelLayout) {
+        currentLayout = layout
+
+        panel.ignoresMouseEvents = !layout.hasVisibleContent || state.barPhase == .hidden
+
+        // Let the existing fade-out finish at its current size. Mouse events are
+        // already disabled above, so the disappearing panel cannot block clicks.
+        guard state.barPhase != .hidden || !panel.isVisible else { return }
+
+        let shouldShow = layout.hasVisibleContent
+            && state.barPhase != .hidden
+            && !panel.isVisible
+            && panelGeneration > 0
+        let targetSize = layout.panelSize
+        if !approximatelyEqual(panel.frame.size, targetSize) {
+            applyPanelSize(targetSize, display: panel.isVisible)
+            Task { @MainActor [weak self] in
+                self?.panel.contentView?.layoutSubtreeIfNeeded()
+                self?.panel.invalidateShadow()
+            }
+        }
+
+        if shouldShow {
+            show()
+        }
+    }
+
     func show() {
         panelGeneration &+= 1
 
+        if anchorDisplayID == nil || state.barPhase == .preparing {
+            anchorDisplayID = FloatingBarPanel.screenUnderMouse()
+                .flatMap(FloatingBarPanel.displayID)
+        }
+
+        let layout = layoutForShow()
+        guard layout.hasVisibleContent else {
+            panel.ignoresMouseEvents = true
+            panel.orderOut(nil)
+            return
+        }
+
+        applyPanelSize(layout.panelSize, display: panel.isVisible)
+        panel.ignoresMouseEvents = false
+
         panel.contentView?.layer?.removeAllAnimations()
-        panel.setContentSize(panelSize)
-        panel.setFrame(NSRect(origin: panel.frame.origin, size: panelSize), display: false)
-        panel.positionAtBottomCenter()
         panel.alphaValue = 0
         panel.orderFrontRegardless()
         NSAnimationContext.runAnimationGroup { ctx in
@@ -104,6 +176,8 @@ final class FloatingBarController {
 
     func hide() {
         guard panel.isVisible else { return }
+        panel.ignoresMouseEvents = true
+
         let expectedGeneration = panelGeneration
         let panelRef = panel
         NSAnimationContext.runAnimationGroup({ ctx in
@@ -114,7 +188,41 @@ final class FloatingBarController {
             MainActor.assumeIsolated {
                 guard let self, self.panelGeneration == expectedGeneration else { return }
                 panelRef.orderOut(nil)
+                self.anchorDisplayID = nil
             }
         })
+    }
+
+    private func layoutForShow() -> FloatingBarPanelLayout {
+        if currentLayout.hasVisibleContent {
+            return currentLayout
+        }
+
+        return .fallback(for: RecordingIndicatorStyle.current())
+    }
+
+    private func applyPanelSize(_ size: NSSize, display: Bool) {
+        guard let screen = resolvedAnchorScreen() else { return }
+        let frame = FloatingBarPanel.bottomCenteredFrame(
+            size: size,
+            visibleFrame: screen.visibleFrame
+        )
+        panel.setFrame(frame, display: display)
+    }
+
+    private func resolvedAnchorScreen() -> NSScreen? {
+        if let anchorDisplayID,
+           let screen = NSScreen.screens.first(where: {
+               FloatingBarPanel.displayID(for: $0) == anchorDisplayID
+           }) {
+            return screen
+        }
+        let replacement = FloatingBarPanel.screenUnderMouse()
+        anchorDisplayID = replacement.flatMap(FloatingBarPanel.displayID)
+        return replacement
+    }
+
+    private func approximatelyEqual(_ lhs: NSSize, _ rhs: NSSize) -> Bool {
+        abs(lhs.width - rhs.width) < 0.5 && abs(lhs.height - rhs.height) < 0.5
     }
 }

--- a/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
@@ -87,11 +87,14 @@ final class FloatingBarPanel: NSPanel {
 @MainActor
 final class FloatingBarController {
 
+    private static let panelShrinkDelay: Duration = .milliseconds(350)
+
     let panel: FloatingBarPanel
     private let state: AppState
     private var currentLayout = FloatingBarPanelLayout.hidden
     private var anchorDisplayID: CGDirectDisplayID?
     private var panelGeneration = 0
+    private var panelShrinkTask: Task<Void, Never>?
 
     init(state: AppState) {
         self.state = state
@@ -126,20 +129,16 @@ final class FloatingBarController {
 
         // Let the existing fade-out finish at its current size. Mouse events are
         // already disabled above, so the disappearing panel cannot block clicks.
-        guard state.barPhase != .hidden || !panel.isVisible else { return }
+        guard state.barPhase != .hidden || !panel.isVisible else {
+            cancelPendingPanelShrink()
+            return
+        }
 
         let shouldShow = layout.hasVisibleContent
             && state.barPhase != .hidden
             && !panel.isVisible
             && panelGeneration > 0
-        let targetSize = layout.panelSize
-        if !approximatelyEqual(panel.frame.size, targetSize) {
-            applyPanelSize(targetSize, display: panel.isVisible)
-            Task { @MainActor [weak self] in
-                self?.panel.contentView?.layoutSubtreeIfNeeded()
-                self?.panel.invalidateShadow()
-            }
-        }
+        resizePanel(to: layout.panelSize, display: panel.isVisible)
 
         if shouldShow {
             show()
@@ -161,7 +160,7 @@ final class FloatingBarController {
             return
         }
 
-        applyPanelSize(layout.panelSize, display: panel.isVisible)
+        resizePanel(to: layout.panelSize, display: panel.isVisible)
         panel.ignoresMouseEvents = false
 
         panel.contentView?.layer?.removeAllAnimations()
@@ -176,6 +175,7 @@ final class FloatingBarController {
 
     func hide() {
         guard panel.isVisible else { return }
+        cancelPendingPanelShrink()
         panel.ignoresMouseEvents = true
 
         let expectedGeneration = panelGeneration
@@ -201,6 +201,46 @@ final class FloatingBarController {
         return .fallback(for: RecordingIndicatorStyle.current())
     }
 
+    private func resizePanel(to targetSize: NSSize, display: Bool) {
+        cancelPendingPanelShrink()
+
+        let currentSize = panel.frame.size
+        guard !approximatelyEqual(currentSize, targetSize) else { return }
+
+        let isShrinking = targetSize.width < currentSize.width - 0.5
+            || targetSize.height < currentSize.height - 0.5
+        guard display, isShrinking else {
+            applyPanelSize(targetSize, display: display)
+            return
+        }
+
+        // Expand either axis immediately, but keep shrinking axes large enough
+        // for the capsule spring and overlay fade to finish without clipping.
+        let transitionSize = NSSize(
+            width: max(currentSize.width, targetSize.width),
+            height: max(currentSize.height, targetSize.height)
+        )
+        if !approximatelyEqual(currentSize, transitionSize) {
+            applyPanelSize(transitionSize, display: true)
+        }
+
+        panelShrinkTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: Self.panelShrinkDelay)
+            guard !Task.isCancelled, let self else { return }
+            guard self.state.barPhase != .hidden,
+                  self.approximatelyEqual(self.currentLayout.panelSize, targetSize)
+            else { return }
+
+            self.applyPanelSize(targetSize, display: self.panel.isVisible)
+            self.panelShrinkTask = nil
+        }
+    }
+
+    private func cancelPendingPanelShrink() {
+        panelShrinkTask?.cancel()
+        panelShrinkTask = nil
+    }
+
     private func applyPanelSize(_ size: NSSize, display: Bool) {
         guard let screen = resolvedAnchorScreen() else { return }
         let frame = FloatingBarPanel.bottomCenteredFrame(
@@ -208,6 +248,10 @@ final class FloatingBarController {
             visibleFrame: screen.visibleFrame
         )
         panel.setFrame(frame, display: display)
+        Task { @MainActor [weak self] in
+            self?.panel.contentView?.layoutSubtreeIfNeeded()
+            self?.panel.invalidateShadow()
+        }
     }
 
     private func resolvedAnchorScreen() -> NSScreen? {

--- a/Type4Me/UI/FloatingBar/FloatingBarView.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarView.swift
@@ -56,13 +56,16 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
     let state: S
     let presentationOverride: FloatingBarPresentation?
+    let onPanelLayoutChange: ((FloatingBarPanelLayout) -> Void)?
 
     init(
         state: S,
-        presentationOverride: FloatingBarPresentation? = nil
+        presentationOverride: FloatingBarPresentation? = nil,
+        onPanelLayoutChange: ((FloatingBarPanelLayout) -> Void)? = nil
     ) {
         self.state = state
         self.presentationOverride = presentationOverride
+        self.onPanelLayoutChange = onPanelLayoutChange
     }
 
     /// High-water mark: only grows during recording, never shrinks (prevents ASR correction jitter)
@@ -266,6 +269,42 @@ struct FloatingBarView<S: FloatingBarState>: View {
         }
     }
 
+    private var panelLayout: FloatingBarPanelLayout {
+        guard shouldRenderCapsule else { return .hidden }
+
+        let capsuleSize = NSSize(width: capsuleWidth, height: capsuleHeight)
+        guard let overlay = activeTopOverlay else {
+            return FloatingBarPanelLayout(contentSize: capsuleSize)
+        }
+
+        let overlaySize = topOverlaySize(overlay)
+        let contentWidth: CGFloat
+        let horizontalOverflow: CGFloat
+
+        switch overlay {
+        case .transcript:
+            contentWidth = max(capsuleSize.width, overlaySize.width)
+            horizontalOverflow = 0
+        case .mode:
+            contentWidth = max(capsuleSize.width, overlaySize.width)
+            horizontalOverflow = 0
+        case .action(let action):
+            contentWidth = capsuleSize.width
+            horizontalOverflow = actionOverlayOverflow(
+                action: action,
+                bubbleWidth: overlaySize.width
+            )
+        }
+
+        return FloatingBarPanelLayout(
+            contentSize: NSSize(
+                width: contentWidth,
+                height: capsuleSize.height + topOverlayGap + overlaySize.height
+            ),
+            horizontalOverflow: horizontalOverflow
+        )
+    }
+
     var body: some View {
         VStack(spacing: topOverlayGap) {
             if let overlay = activeTopOverlay {
@@ -278,8 +317,13 @@ struct FloatingBarView<S: FloatingBarState>: View {
                     .id("floating_capsule_bar")
             }
         }
-        .padding(.bottom, 16)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        .onAppear {
+            onPanelLayoutChange?(panelLayout)
+        }
+        .onChange(of: panelLayout) { _, layout in
+            onPanelLayoutChange?(layout)
+        }
         .onChange(of: state.barPhase) { _, newPhase in
             handlePhaseChange(newPhase)
         }
@@ -322,7 +366,14 @@ struct FloatingBarView<S: FloatingBarState>: View {
             .overlay {
                 capsuleBorder
             }
-            .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 2)
+            .shadow(
+                color: onPanelLayoutChange == nil
+                    ? Color.black.opacity(0.35)
+                    : .clear,
+                radius: 6,
+                x: 0,
+                y: 2
+            )
             // Critically damped (dampingFraction 1.0) so the width never
             // overshoots and settles back leftward between characters. An
             // underdamped spring makes the right edge/cancel button wiggle
@@ -878,7 +929,69 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
     /// Measure actual rendered width using the same font as the floating bar text.
     private func measureText(_ string: String) -> CGFloat {
-        ceil((string as NSString).size(withAttributes: [.font: floatingBarFont]).width)
+        measureText(string, font: floatingBarFont)
+    }
+
+    private func measureText(_ string: String, font: NSFont) -> CGFloat {
+        ceil((string as NSString).size(withAttributes: [.font: font]).width)
+    }
+
+    private func topOverlaySize(_ overlay: FloatingBarTopOverlay) -> NSSize {
+        switch overlay {
+        case .transcript:
+            return NSSize(
+                width: TF.transcriptPopupWidth,
+                height: transcriptPopupHeight
+            )
+        case .mode:
+            let font = NSFont.systemFont(ofSize: 14, weight: .semibold)
+            let maxWidth = TF.barWidth + TF.recordingTooltipOverhang * 2
+            return NSSize(
+                width: min(maxWidth, measureText(localizedCurrentModeName, font: font) + 24),
+                height: ceil(font.boundingRectForFont.height) + 18
+            )
+        case .action(let action):
+            return actionHintSize(action)
+        }
+    }
+
+    private var transcriptPopupHeight: CGFloat {
+        let textWidth = TF.transcriptPopupWidth - 24
+        let bounds = (state.transcriptionText as NSString).boundingRect(
+            with: NSSize(width: textWidth, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: floatingBarFont]
+        )
+        // TranscriptPopup adds 12 pt vertical padding on both sides and a
+        // one-point scroll anchor after the text.
+        return min(TF.transcriptPopupMaxHeight, max(1, ceil(bounds.height) + 25))
+    }
+
+    private func actionHintSize(_ action: RecordingControlAction) -> NSSize {
+        let labelFont = NSFont.systemFont(ofSize: 14, weight: .semibold)
+        let shortcutFont = NSFont.systemFont(ofSize: 12, weight: .semibold)
+        var width = measureText(actionTitle(action), font: labelFont) + 24
+        var contentHeight = ceil(labelFont.boundingRectForFont.height)
+
+        if action == .cancel {
+            width += 7 + measureText("esc", font: shortcutFont) + 14
+            contentHeight = max(contentHeight, ceil(shortcutFont.boundingRectForFont.height) + 4)
+        }
+
+        return NSSize(
+            width: min(TF.recordingTooltipMaxWidth, width),
+            height: contentHeight + 18
+        )
+    }
+
+    private func actionOverlayOverflow(
+        action: RecordingControlAction,
+        bubbleWidth: CGFloat
+    ) -> CGFloat {
+        max(
+            0,
+            abs(actionHorizontalOffset(action)) + bubbleWidth / 2 - capsuleWidth / 2
+        )
     }
 
     // MARK: - Top overlays
@@ -898,6 +1011,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
         case .transcript:
             TranscriptPopup(
                 text: state.transcriptionText,
+                height: transcriptPopupHeight,
                 onHoverChanged: updateTranscriptHover
             )
         case .mode:
@@ -918,6 +1032,12 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 
     private func alignedActionHint(_ action: RecordingControlAction) -> some View {
+        return actionHintBubble(action)
+            .offset(x: actionHorizontalOffset(action))
+            .frame(width: capsuleWidth)
+    }
+
+    private func actionHorizontalOffset(_ action: RecordingControlAction) -> CGFloat {
         let distanceFromCenter: CGFloat
         if usesCompactRecordingLayout {
             distanceFromCenter = capsuleWidth / 2 - 16
@@ -926,18 +1046,19 @@ struct FloatingBarView<S: FloatingBarState>: View {
                 - TF.recordingEdgeInset
                 - TF.recordingControlSize / 2
         }
-        let horizontalOffset = action == .finish ? -distanceFromCenter : distanceFromCenter
+        return action == .finish ? -distanceFromCenter : distanceFromCenter
+    }
 
-        return actionHintBubble(action)
-            .offset(x: horizontalOffset)
-            .frame(width: capsuleWidth)
+    private func actionTitle(_ action: RecordingControlAction) -> String {
+        _ = language
+        return action == .finish
+            ? L("完成录制", "Finish Recording")
+            : L("取消录制", "Cancel Recording")
     }
 
     private func actionHintBubble(_ action: RecordingControlAction) -> some View {
         HStack(spacing: 7) {
-            Text(action == .finish
-                ? L("完成录制", "Finish Recording")
-                : L("取消录制", "Cancel Recording"))
+            Text(actionTitle(action))
 
             if action == .cancel {
                 Text("esc")
@@ -970,8 +1091,10 @@ struct FloatingBarView<S: FloatingBarState>: View {
             .font(.system(size: 14, weight: .semibold))
             .foregroundStyle(TF.floatingText)
             .lineLimit(1)
+            .truncationMode(.tail)
             .padding(.horizontal, 12)
             .padding(.vertical, 9)
+            .frame(maxWidth: TF.barWidth + TF.recordingTooltipOverhang * 2)
             .background(
                 RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous)
                     .fill(TF.floatingBackground)
@@ -1017,6 +1140,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
 private struct TranscriptPopup: View {
     let text: String
+    let height: CGFloat
     let onHoverChanged: (Bool) -> Void
 
     var body: some View {
@@ -1033,9 +1157,7 @@ private struct TranscriptPopup: View {
                     .id("transcript-end")
             }
             .scrollIndicators(.hidden)
-            .frame(width: TF.transcriptPopupWidth)
-            .frame(maxHeight: TF.transcriptPopupMaxHeight)
-            .fixedSize(horizontal: false, vertical: true)
+            .frame(width: TF.transcriptPopupWidth, height: height)
             .background(
                 RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous)
                     .fill(TF.floatingBackground)
@@ -1048,7 +1170,6 @@ private struct TranscriptPopup: View {
                 FloatingBarHoverTracker(onHoverChanged: onHoverChanged)
             }
             .clipShape(RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous))
-            .shadow(color: Color.black.opacity(0.3), radius: 8, y: -2)
             .onAppear { proxy.scrollTo("transcript-end", anchor: .bottom) }
             .onChange(of: text) { _, _ in
                 proxy.scrollTo("transcript-end", anchor: .bottom)
@@ -1198,7 +1319,6 @@ struct FloatingBarHoverTracker: NSViewRepresentable {
 
 final class HoverTrackingNSView: NSView {
     var onHoverChanged: ((Bool) -> Void)?
-    private var enterWorkItem: DispatchWorkItem?
 
     /// Tracking areas should observe hover without intercepting SwiftUI button
     /// clicks or scroll-wheel events from controls underneath this helper view.
@@ -1215,22 +1335,18 @@ final class HoverTrackingNSView: NSView {
     }
 
     override func mouseEntered(with event: NSEvent) {
-        enterWorkItem?.cancel()
-        let work = DispatchWorkItem { [weak self] in
-            guard let self, let window = self.window else { return }
-            // Re-check mouse position at trigger time: updateTrackingAreas()
-            // sends synthetic mouseEntered when the tracking area is recreated
-            // with the cursor inside (e.g. bar grows during recording).
-            let mouseInView = self.convert(window.mouseLocationOutsideOfEventStream, from: nil)
-            guard self.bounds.contains(mouseInView) else { return }
-            self.onHoverChanged?(true)
-        }
-        enterWorkItem = work
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: work)
+        guard containsMouse(event) else { return }
+        onHoverChanged?(true)
     }
 
     override func mouseExited(with event: NSEvent) {
-        enterWorkItem?.cancel()
+        // Resizing the panel rebuilds tracking areas and can synthesize an exit
+        // even though the pointer never left the visible view.
+        guard !containsMouse(event) else { return }
         onHoverChanged?(false)
+    }
+
+    private func containsMouse(_ event: NSEvent) -> Bool {
+        bounds.contains(convert(event.locationInWindow, from: nil))
     }
 }

--- a/Type4Me/UI/FloatingBar/FloatingBarView.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarView.swift
@@ -9,6 +9,26 @@ private enum FloatingBarTopOverlay: Equatable {
     case mode
 }
 
+func recordingActionHorizontalOffset(
+    _ action: RecordingControlAction,
+    capsuleWidth: CGFloat,
+    usesCompactLayout: Bool
+) -> CGFloat {
+    let distanceFromCenter: CGFloat
+    if usesCompactLayout {
+        distanceFromCenter = capsuleWidth / 2 - 16
+    } else if action == .finish {
+        distanceFromCenter = capsuleWidth / 2
+            - TF.recordingLeadingInset
+            - TF.recordingFinishControlSize / 2
+    } else {
+        distanceFromCenter = capsuleWidth / 2
+            - TF.recordingTrailingInset
+            - TF.recordingCancelControlSize / 2
+    }
+    return action == .finish ? -distanceFromCenter : distanceFromCenter
+}
+
 // MARK: - FloatingBarState Protocol
 
 @MainActor
@@ -75,6 +95,8 @@ struct FloatingBarView<S: FloatingBarState>: View {
     @State private var isTranscriptHoverActive = false
     @State private var transcriptHoverExitTask: Task<Void, Never>?
     @State private var hoveredAction: RecordingControlAction?
+    @State private var hintedAction: RecordingControlAction?
+    @State private var actionHintTask: Task<Void, Never>?
     @State private var pressedAction: RecordingControlAction?
     @State private var cancelDragOffset: CGSize = .zero
     @State private var showsModeHint = false
@@ -173,8 +195,8 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
         guard effectiveShowsTooltips else { return nil }
 
-        if let hoveredAction, state.barPhase == .recording || state.barPhase == .preparing {
-            return .action(hoveredAction)
+        if let hintedAction, state.barPhase == .recording || state.barPhase == .preparing {
+            return .action(hintedAction)
         }
         if showsModeHint,
            (state.barPhase == .preparing || state.barPhase == .recording) {
@@ -274,7 +296,10 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
         let capsuleSize = NSSize(width: capsuleWidth, height: capsuleHeight)
         guard let overlay = activeTopOverlay else {
-            return FloatingBarPanelLayout(contentSize: capsuleSize)
+            return FloatingBarPanelLayout(
+                contentSize: capsuleSize,
+                capsuleSize: capsuleSize
+            )
         }
 
         let overlaySize = topOverlaySize(overlay)
@@ -301,7 +326,8 @@ struct FloatingBarView<S: FloatingBarState>: View {
                 width: contentWidth,
                 height: capsuleSize.height + topOverlayGap + overlaySize.height
             ),
-            horizontalOverflow: horizontalOverflow
+            horizontalOverflow: horizontalOverflow,
+            capsuleSize: capsuleSize
         )
     }
 
@@ -309,7 +335,6 @@ struct FloatingBarView<S: FloatingBarState>: View {
         VStack(spacing: topOverlayGap) {
             if let overlay = activeTopOverlay {
                 topOverlay(overlay)
-                    .transition(.opacity.animation(.easeInOut(duration: 0.18)))
             }
 
             if shouldRenderCapsule {
@@ -317,6 +342,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
                     .id("floating_capsule_bar")
             }
         }
+        .padding(TF.floatingPanelShadowInset)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
         .onAppear {
             onPanelLayoutChange?(panelLayout)
@@ -350,6 +376,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
         .onDisappear {
             modeHintTask?.cancel()
             transcriptHoverExitTask?.cancel()
+            actionHintTask?.cancel()
         }
     }
 
@@ -366,21 +393,20 @@ struct FloatingBarView<S: FloatingBarState>: View {
             .overlay {
                 capsuleBorder
             }
-            .shadow(
-                color: onPanelLayoutChange == nil
-                    ? Color.black.opacity(0.35)
-                    : .clear,
-                radius: 6,
-                x: 0,
-                y: 2
-            )
+            .shadow(color: Color.black.opacity(0.12), radius: 8)
             // Critically damped (dampingFraction 1.0) so the width never
             // overshoots and settles back leftward between characters. An
             // underdamped spring makes the right edge/cancel button wiggle
             // "inward then outward" on every widen while the left (MTKView orb)
             // edge jumps instantly and appears stable.
-            .animation(.spring(response: 0.3, dampingFraction: 1.0), value: capsuleWidth)
-            .animation(.spring(response: 0.3, dampingFraction: 1.0), value: capsuleHeight)
+            .animation(
+                .spring(response: TF.recordingCapsuleSpringResponse, dampingFraction: 1.0),
+                value: capsuleWidth
+            )
+            .animation(
+                .spring(response: TF.recordingCapsuleSpringResponse, dampingFraction: 1.0),
+                value: capsuleHeight
+            )
     }
 
     // MARK: - Content by Phase
@@ -584,7 +610,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
                 },
                 onHoverChanged: { hovered in
                     guard !recordingActionLocked else { return }
-                    hoveredAction = hovered ? action : (hoveredAction == action ? nil : hoveredAction)
+                    updateActionHover(action, hovering: hovered)
                 },
                 onClick: { triggerRecordingAction(action) }
             )
@@ -706,7 +732,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
                 } : nil,
                 onHoverChanged: { hovered in
                     guard !recordingActionLocked else { return }
-                    hoveredAction = hovered ? action : (hoveredAction == action ? nil : hoveredAction)
+                    updateActionHover(action, hovering: hovered)
                 },
                 onClick: { triggerRecordingAction(action) }
             )
@@ -720,6 +746,8 @@ struct FloatingBarView<S: FloatingBarState>: View {
         pressedAction = nil
         cancelDragOffset = .zero
         hoveredAction = nil
+        hintedAction = nil
+        actionHintTask?.cancel()
         transcriptHoverExitTask?.cancel()
         isTranscriptHoverActive = false
         state.performRecordingControlAction(action)
@@ -881,6 +909,8 @@ struct FloatingBarView<S: FloatingBarState>: View {
             transcriptHoverExitTask?.cancel()
             isTranscriptHoverActive = false
             hoveredAction = nil
+            hintedAction = nil
+            actionHintTask?.cancel()
             pressedAction = nil
             cancelDragOffset = .zero
         }
@@ -1038,15 +1068,11 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 
     private func actionHorizontalOffset(_ action: RecordingControlAction) -> CGFloat {
-        let distanceFromCenter: CGFloat
-        if usesCompactRecordingLayout {
-            distanceFromCenter = capsuleWidth / 2 - 16
-        } else {
-            distanceFromCenter = capsuleWidth / 2
-                - TF.recordingEdgeInset
-                - TF.recordingControlSize / 2
-        }
-        return action == .finish ? -distanceFromCenter : distanceFromCenter
+        recordingActionHorizontalOffset(
+            action,
+            capsuleWidth: capsuleWidth,
+            usesCompactLayout: usesCompactRecordingLayout
+        )
     }
 
     private func actionTitle(_ action: RecordingControlAction) -> String {
@@ -1084,6 +1110,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
         )
         .frame(maxWidth: TF.recordingTooltipMaxWidth)
         .fixedSize(horizontal: true, vertical: false)
+        .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 2)
     }
 
     private func hintBubble(text: String) -> some View {
@@ -1103,6 +1130,8 @@ struct FloatingBarView<S: FloatingBarState>: View {
                             .strokeBorder(TF.floatingBorder, lineWidth: 0.5)
                     }
             )
+            .fixedSize(horizontal: true, vertical: false)
+            .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 2)
     }
 
     private func showModeHint() {
@@ -1120,6 +1149,30 @@ struct FloatingBarView<S: FloatingBarState>: View {
         modeHintTask = nil
         if showsModeHint {
             showsModeHint = false
+        }
+    }
+
+    private func updateActionHover(_ action: RecordingControlAction, hovering: Bool) {
+        if hovering {
+            guard hoveredAction != action else { return }
+            actionHintTask?.cancel()
+            hoveredAction = action
+            hintedAction = nil
+            actionHintTask = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(150))
+                guard !Task.isCancelled, hoveredAction == action else { return }
+                hintedAction = action
+            }
+            return
+        }
+
+        guard hoveredAction == action || hintedAction == action else { return }
+        actionHintTask?.cancel()
+        if hoveredAction == action {
+            hoveredAction = nil
+        }
+        if hintedAction == action {
+            hintedAction = nil
         }
     }
 
@@ -1170,6 +1223,7 @@ private struct TranscriptPopup: View {
                 FloatingBarHoverTracker(onHoverChanged: onHoverChanged)
             }
             .clipShape(RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous))
+            .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 2)
             .onAppear { proxy.scrollTo("transcript-end", anchor: .bottom) }
             .onChange(of: text) { _, _ in
                 proxy.scrollTo("transcript-end", anchor: .bottom)
@@ -1263,11 +1317,20 @@ final class FloatingBarButtonNSView: NSView {
     }
 
     override func mouseEntered(with event: NSEvent) {
+        guard containsMouse else { return }
         onHoverChanged?(true)
     }
 
     override func mouseExited(with event: NSEvent) {
+        // Panel resizing can rebuild tracking areas and synthesize an exit while
+        // the pointer is still over the control.
+        guard !containsMouse else { return }
         onHoverChanged?(false)
+    }
+
+    private var containsMouse: Bool {
+        guard let window else { return false }
+        return bounds.contains(convert(window.mouseLocationOutsideOfEventStream, from: nil))
     }
 
     override func mouseDown(with event: NSEvent) {
@@ -1319,6 +1382,11 @@ struct FloatingBarHoverTracker: NSViewRepresentable {
 
 final class HoverTrackingNSView: NSView {
     var onHoverChanged: ((Bool) -> Void)?
+    private var enterWorkItem: DispatchWorkItem?
+
+    deinit {
+        enterWorkItem?.cancel()
+    }
 
     /// Tracking areas should observe hover without intercepting SwiftUI button
     /// clicks or scroll-wheel events from controls underneath this helper view.
@@ -1335,18 +1403,25 @@ final class HoverTrackingNSView: NSView {
     }
 
     override func mouseEntered(with event: NSEvent) {
-        guard containsMouse(event) else { return }
-        onHoverChanged?(true)
+        enterWorkItem?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.containsMouse else { return }
+            self.onHoverChanged?(true)
+        }
+        enterWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: work)
     }
 
     override func mouseExited(with event: NSEvent) {
+        enterWorkItem?.cancel()
         // Resizing the panel rebuilds tracking areas and can synthesize an exit
         // even though the pointer never left the visible view.
-        guard !containsMouse(event) else { return }
+        guard !containsMouse else { return }
         onHoverChanged?(false)
     }
 
-    private func containsMouse(_ event: NSEvent) -> Bool {
-        bounds.contains(convert(event.locationInWindow, from: nil))
+    private var containsMouse: Bool {
+        guard let window else { return false }
+        return bounds.contains(convert(window.mouseLocationOutsideOfEventStream, from: nil))
     }
 }

--- a/Type4MeTests/AppStateTests.swift
+++ b/Type4MeTests/AppStateTests.swift
@@ -233,6 +233,7 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(TF.barHeight, 55)
         XCTAssertEqual(TF.barWidthCompact, 180)
         XCTAssertEqual(TF.barWidth, 400)
+        XCTAssertEqual(TF.floatingPanelShadowInset, 8)
         XCTAssertEqual(TF.recordingFinishControlSize, 45)
         XCTAssertEqual(TF.recordingCancelControlSize, 35)
         XCTAssertEqual(TF.recordingLeadingInset, 5)
@@ -251,16 +252,16 @@ final class AppStateTests: XCTestCase {
         let shortBar = FloatingBarPanelLayout(
             contentSize: NSSize(width: TF.barWidthCompact, height: TF.barHeight)
         )
-        XCTAssertEqual(shortBar.panelSize, NSSize(width: 180, height: 55))
+        XCTAssertEqual(shortBar.panelSize, NSSize(width: 196, height: 71))
         XCTAssertEqual(
             FloatingBarPanelLayout.fallback(for: .compact).panelSize,
-            NSSize(width: 180, height: 24)
+            NSSize(width: 196, height: 40)
         )
 
         let fullBar = FloatingBarPanelLayout(
             contentSize: NSSize(width: TF.barWidth, height: TF.barHeight)
         )
-        XCTAssertEqual(fullBar.panelSize, NSSize(width: 400, height: 55))
+        XCTAssertEqual(fullBar.panelSize, NSSize(width: 416, height: 71))
 
         let transcript = FloatingBarPanelLayout(
             contentSize: NSSize(
@@ -268,13 +269,13 @@ final class AppStateTests: XCTestCase {
                 height: TF.barHeight + TF.transcriptPopupGap + 60
             )
         )
-        XCTAssertEqual(transcript.panelSize, NSSize(width: 350, height: 125))
+        XCTAssertEqual(transcript.panelSize, NSSize(width: 366, height: 141))
 
         let action = FloatingBarPanelLayout(
             contentSize: NSSize(width: TF.barWidthCompact, height: TF.barHeight + 5 + 35),
             horizontalOverflow: 60
         )
-        XCTAssertEqual(action.panelSize, NSSize(width: 300, height: 95))
+        XCTAssertEqual(action.panelSize, NSSize(width: 316, height: 111))
     }
 
     func testFloatingPanelFrameKeepsBarBottomCentered() {
@@ -285,7 +286,10 @@ final class AppStateTests: XCTestCase {
         )
 
         XCTAssertEqual(frame.midX, visibleFrame.midX)
-        XCTAssertEqual(frame.minY, visibleFrame.minY + TF.barBottomOffset)
+        XCTAssertEqual(
+            frame.minY + TF.floatingPanelShadowInset,
+            visibleFrame.minY + TF.barBottomOffset
+        )
 
         let expandedFrame = FloatingBarPanel.bottomCenteredFrame(
             size: NSSize(width: 400, height: 185),
@@ -294,24 +298,53 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(expandedFrame.minY, frame.minY)
     }
 
+    func testRecordingActionHintsAreCenteredOverTheirControls() {
+        let width: CGFloat = 180
+        let finishOffset = recordingActionHorizontalOffset(
+            .finish,
+            capsuleWidth: width,
+            usesCompactLayout: false
+        )
+        let cancelOffset = recordingActionHorizontalOffset(
+            .cancel,
+            capsuleWidth: width,
+            usesCompactLayout: false
+        )
+
+        XCTAssertEqual(width / 2 + finishOffset, TF.recordingLeadingInset + TF.recordingFinishControlSize / 2)
+        XCTAssertEqual(width / 2 + cancelOffset, width - TF.recordingTrailingInset - TF.recordingCancelControlSize / 2)
+        XCTAssertEqual(
+            width / 2 + recordingActionHorizontalOffset(.finish, capsuleWidth: width, usesCompactLayout: true),
+            16
+        )
+        XCTAssertEqual(
+            width / 2 + recordingActionHorizontalOffset(.cancel, capsuleWidth: width, usesCompactLayout: true),
+            width - 16
+        )
+    }
+
     func testFloatingPanelControllerEnablesMouseOnlyForVisibleContent() async throws {
         let appState = AppState()
         let controller = FloatingBarController(state: appState)
+        // This test injects layouts directly; detach the live SwiftUI reporter.
+        controller.panel.contentView = nil
         appState.barPhase = .recording
 
         let visibleLayout = FloatingBarPanelLayout(
-            contentSize: NSSize(width: TF.barWidthCompact, height: TF.barHeight)
+            contentSize: NSSize(width: TF.barWidthCompact, height: TF.barHeight),
+            capsuleSize: NSSize(width: TF.barWidthCompact, height: TF.barHeight)
         )
         controller.updatePanelLayout(visibleLayout)
         XCTAssertFalse(controller.panel.ignoresMouseEvents)
         XCTAssertEqual(controller.panel.frame.size, visibleLayout.panelSize)
-        XCTAssertTrue(controller.panel.hasShadow)
+        XCTAssertFalse(controller.panel.hasShadow)
 
         let previewLayout = FloatingBarPanelLayout(
             contentSize: NSSize(
                 width: TF.transcriptPopupWidth,
                 height: TF.barHeight + TF.transcriptPopupGap + TF.transcriptPopupMaxHeight
-            )
+            ),
+            capsuleSize: NSSize(width: TF.barWidthCompact, height: TF.barHeight)
         )
         controller.updatePanelLayout(previewLayout)
         XCTAssertEqual(controller.panel.frame.size, previewLayout.panelSize)
@@ -321,10 +354,30 @@ final class AppStateTests: XCTestCase {
         defer { controller.panel.orderOut(nil) }
 
         controller.updatePanelLayout(visibleLayout)
-        XCTAssertEqual(controller.panel.frame.size, previewLayout.panelSize)
-
-        try await Task.sleep(for: .milliseconds(400))
         XCTAssertEqual(controller.panel.frame.size, visibleLayout.panelSize)
+
+        let wideCapsuleLayout = FloatingBarPanelLayout(
+            contentSize: NSSize(
+                width: TF.barWidth,
+                height: TF.barHeight + TF.transcriptPopupGap + TF.transcriptPopupMaxHeight
+            ),
+            capsuleSize: NSSize(width: TF.barWidth, height: TF.barHeight)
+        )
+        controller.updatePanelLayout(wideCapsuleLayout)
+        XCTAssertEqual(controller.panel.frame.size, wideCapsuleLayout.panelSize)
+
+        let animatedCapsuleLayout = FloatingBarPanelLayout(
+            contentSize: visibleLayout.contentSize,
+            capsuleSize: visibleLayout.capsuleSize
+        )
+        controller.updatePanelLayout(animatedCapsuleLayout)
+        XCTAssertEqual(
+            controller.panel.frame.size,
+            NSSize(width: wideCapsuleLayout.panelSize.width, height: animatedCapsuleLayout.panelSize.height)
+        )
+
+        try await Task.sleep(for: .milliseconds(450))
+        XCTAssertEqual(controller.panel.frame.size, animatedCapsuleLayout.panelSize)
 
         controller.panel.orderOut(nil)
         appState.barPhase = .hidden

--- a/Type4MeTests/AppStateTests.swift
+++ b/Type4MeTests/AppStateTests.swift
@@ -241,8 +241,88 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(TF.recordingTooltipGap, 5)
         XCTAssertEqual(TF.transcriptPopupWidth, 350)
         XCTAssertEqual(TF.transcriptPopupMaxHeight, 120)
-        XCTAssertEqual(TF.transcriptPopupCorner, 10)
+        XCTAssertEqual(TF.transcriptPopupCorner, TF.cornerLG)
         XCTAssertEqual(TF.transcriptPopupGap, 10)
+    }
+
+    func testFloatingPanelLayoutTracksOnlyVisibleBounds() {
+        XCTAssertEqual(FloatingBarPanelLayout.hidden.panelSize, NSSize(width: 1, height: 1))
+
+        let shortBar = FloatingBarPanelLayout(
+            contentSize: NSSize(width: TF.barWidthCompact, height: TF.barHeight)
+        )
+        XCTAssertEqual(shortBar.panelSize, NSSize(width: 180, height: 55))
+        XCTAssertEqual(
+            FloatingBarPanelLayout.fallback(for: .compact).panelSize,
+            NSSize(width: 180, height: 24)
+        )
+
+        let fullBar = FloatingBarPanelLayout(
+            contentSize: NSSize(width: TF.barWidth, height: TF.barHeight)
+        )
+        XCTAssertEqual(fullBar.panelSize, NSSize(width: 400, height: 55))
+
+        let transcript = FloatingBarPanelLayout(
+            contentSize: NSSize(
+                width: TF.transcriptPopupWidth,
+                height: TF.barHeight + TF.transcriptPopupGap + 60
+            )
+        )
+        XCTAssertEqual(transcript.panelSize, NSSize(width: 350, height: 125))
+
+        let action = FloatingBarPanelLayout(
+            contentSize: NSSize(width: TF.barWidthCompact, height: TF.barHeight + 5 + 35),
+            horizontalOverflow: 60
+        )
+        XCTAssertEqual(action.panelSize, NSSize(width: 300, height: 95))
+    }
+
+    func testFloatingPanelFrameKeepsBarBottomCentered() {
+        let visibleFrame = NSRect(x: 100, y: 50, width: 1000, height: 800)
+        let frame = FloatingBarPanel.bottomCenteredFrame(
+            size: NSSize(width: 180, height: 55),
+            visibleFrame: visibleFrame
+        )
+
+        XCTAssertEqual(frame.midX, visibleFrame.midX)
+        XCTAssertEqual(frame.minY, visibleFrame.minY + TF.barBottomOffset)
+
+        let expandedFrame = FloatingBarPanel.bottomCenteredFrame(
+            size: NSSize(width: 400, height: 185),
+            visibleFrame: visibleFrame
+        )
+        XCTAssertEqual(expandedFrame.minY, frame.minY)
+    }
+
+    func testFloatingPanelControllerEnablesMouseOnlyForVisibleContent() {
+        let appState = AppState()
+        let controller = FloatingBarController(state: appState)
+        appState.barPhase = .recording
+
+        let visibleLayout = FloatingBarPanelLayout(
+            contentSize: NSSize(width: TF.barWidthCompact, height: TF.barHeight)
+        )
+        controller.updatePanelLayout(visibleLayout)
+        XCTAssertFalse(controller.panel.ignoresMouseEvents)
+        XCTAssertEqual(controller.panel.frame.size, visibleLayout.panelSize)
+        XCTAssertTrue(controller.panel.hasShadow)
+
+        let previewLayout = FloatingBarPanelLayout(
+            contentSize: NSSize(
+                width: TF.transcriptPopupWidth,
+                height: TF.barHeight + TF.transcriptPopupGap + TF.transcriptPopupMaxHeight
+            )
+        )
+        controller.updatePanelLayout(previewLayout)
+        XCTAssertEqual(controller.panel.frame.size, previewLayout.panelSize)
+
+        controller.updatePanelLayout(visibleLayout)
+        XCTAssertEqual(controller.panel.frame.size, visibleLayout.panelSize)
+
+        appState.barPhase = .hidden
+        controller.updatePanelLayout(.hidden)
+        XCTAssertTrue(controller.panel.ignoresMouseEvents)
+        XCTAssertEqual(controller.panel.frame.size, FloatingBarPanelLayout.hidden.panelSize)
     }
 
     func testFloatingIndicatorHoverTrackingDoesNotInterceptControls() {
@@ -252,7 +332,8 @@ final class AppStateTests: XCTestCase {
         var clickCount = 0
         buttonTarget.onClick = { clickCount += 1 }
 
-        XCTAssertFalse(panel.ignoresMouseEvents)
+        XCTAssertTrue(panel.ignoresMouseEvents)
+        panel.ignoresMouseEvents = false
         XCTAssertTrue(panel.acceptsMouseMovedEvents)
         XCTAssertNil(tracker.hitTest(NSPoint(x: 22, y: 22)))
         XCTAssertTrue(buttonTarget.acceptsFirstMouse(for: nil))

--- a/Type4MeTests/AppStateTests.swift
+++ b/Type4MeTests/AppStateTests.swift
@@ -294,7 +294,7 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(expandedFrame.minY, frame.minY)
     }
 
-    func testFloatingPanelControllerEnablesMouseOnlyForVisibleContent() {
+    func testFloatingPanelControllerEnablesMouseOnlyForVisibleContent() async throws {
         let appState = AppState()
         let controller = FloatingBarController(state: appState)
         appState.barPhase = .recording
@@ -316,9 +316,17 @@ final class AppStateTests: XCTestCase {
         controller.updatePanelLayout(previewLayout)
         XCTAssertEqual(controller.panel.frame.size, previewLayout.panelSize)
 
+        controller.panel.alphaValue = 0
+        controller.panel.orderFrontRegardless()
+        defer { controller.panel.orderOut(nil) }
+
         controller.updatePanelLayout(visibleLayout)
+        XCTAssertEqual(controller.panel.frame.size, previewLayout.panelSize)
+
+        try await Task.sleep(for: .milliseconds(400))
         XCTAssertEqual(controller.panel.frame.size, visibleLayout.panelSize)
 
+        controller.panel.orderOut(nil)
         appState.barPhase = .hidden
         controller.updatePanelLayout(.hidden)
         XCTAssertTrue(controller.panel.ignoresMouseEvents)

--- a/scripts/dev-run.sh
+++ b/scripts/dev-run.sh
@@ -18,6 +18,9 @@ fi
 if [ -z "$SIGNING_IDENTITY" ]; then
     SIGNING_IDENTITY="$(find_identity 'Developer ID Application:')"
 fi
+if [ -z "$SIGNING_IDENTITY" ]; then
+    SIGNING_IDENTITY="$(find_identity 'Type4Me Dev')"
+fi
 
 if [ -z "$SIGNING_IDENTITY" ]; then
     if [ "${ALLOW_ADHOC_SIGNING:-0}" = "1" ]; then


### PR DESCRIPTION
## Summary

- Resize the floating `NSPanel` to the current visible recording bar and overlay bounds instead of keeping a large transparent hit area alive.
- Disable panel mouse handling while hidden or fading out, and expand the same panel only while transcript, mode, or action overlays are visible.
- Stabilize transcript popup sizing and hover tracking so short previews do not compress or move the recording bar.
- Use the native panel shadow outside the interactive frame and preserve smooth capsule size transitions.
- Reuse a persistent `Type4Me Dev` signing identity when available so local development rebuilds do not unnecessarily invalidate macOS permissions.

## Problem

The recording indicator used a fixed transparent panel large enough for every possible overlay. Even when the transcript preview was not visible, that transparent area intercepted clicks in the application underneath. Short transcript previews could also report a different SwiftUI height than the panel calculation, intermittently compressing the capsule and clipping its rounded bottom edge.

## Validation

- `swift build --product Type4Me` passed.
- `git diff --check` and `bash -n scripts/dev-run.sh` passed.
- A signed development build was installed and exercised through the real Fn hotkey, microphone capture, and system floating panel on macOS 27.0 arm64.
- Repeated pointer transitions across the real recording bar and transcript preview kept the bar position and height stable while the panel expanded and collapsed.
- Added regression coverage for visible panel bounds, bottom anchoring, overlay expansion/collapse, native shadow, and hidden-state mouse handling.
- After #260 merged, this branch was merged with the new Liquid Glass recording UI. The combined source preserves its border and critically damped animation, keeps the native panel shadow behavior, and builds successfully.

## Not yet verified

- Intel Macs.
- External or mixed-scale multi-display configurations.
- macOS 14-16 runtime behavior.
- A second real-panel smoke test after the #260 integration; the original fix was exercised on the real panel before that integration, while the combined source has been build-verified.
- The complete XCTest suite could not be launched locally because the selected Command Line Tools installation does not provide the `XCTest` module; no test failure from the changed code was observed.

