### PR TITLE
feat: support embedded live transcript in compact recording indicator

### DIFF
--- a/Type4Me/UI/AppState.swift
+++ b/Type4Me/UI/AppState.swift
@@ -135,6 +135,11 @@ enum LiveTranscriptDisplayPreference {
     static let storageKey = "tf_showLiveTranscript"
     static let defaultValue = true
 
+    static func isEnabled(userDefaults: UserDefaults = .standard) -> Bool {
+        guard userDefaults.object(forKey: storageKey) != nil else { return defaultValue }
+        return userDefaults.bool(forKey: storageKey)
+    }
+
     /// Disabling live text only affects the active recording phase. Recovery
     /// and final-result feedback can still show text that needs the user's attention.
     static func showsTranscript(isEnabled: Bool, phase: FloatingBarPhase) -> Bool {

--- a/Type4Me/UI/DesignSystem.swift
+++ b/Type4Me/UI/DesignSystem.swift
@@ -141,6 +141,12 @@ enum TF {
 
     static let compactIndicatorWidth: CGFloat = barWidthCompact
     static let compactIndicatorHeight: CGFloat = 24
+    static let compactTranscriptLaneHeight: CGFloat = 24
+    static let compactTranscriptExpandedHeight: CGFloat = 48
+    static let compactTranscriptFontSize: CGFloat = 12
+    static let compactTranscriptCornerRadius: CGFloat = 10
+    static let compactTranscriptHorizontalInset: CGFloat = 8
+    static let compactTranscriptLeadingFadeWidth: CGFloat = 10
     static let compactIndicatorControlVisualSize: CGFloat = 15
     static let compactIndicatorWaveBarWidth: CGFloat = 2
     static let compactIndicatorWaveMinHeight: CGFloat = 2

--- a/Type4Me/UI/FloatingBar/CompactLiveTranscriptRow.swift
+++ b/Type4Me/UI/FloatingBar/CompactLiveTranscriptRow.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import AppKit
+
+/// Pure helper to calculate follow-tail horizontal offset for compact transcript.
+///
+/// When text width is within viewport, offset is 0 (leading aligned).
+/// When text width exceeds viewport, offset is negative so the tail aligns with the right edge.
+func compactTranscriptOffset(textWidth: CGFloat, viewportWidth: CGFloat) -> CGFloat {
+    -max(0, textWidth - viewportWidth)
+}
+
+/// Single-line live transcript row embedded in the expanded compact recording capsule.
+///
+/// Displays 12pt medium text in a 24pt lane (180pt total width, 164pt viewport width).
+/// Follows the tail when text overflows, applying a subtle leading fade mask.
+struct CompactLiveTranscriptRow: View {
+
+    let text: String
+
+    private static let measurementFont = NSFont.systemFont(
+        ofSize: TF.compactTranscriptFontSize,
+        weight: .medium
+    )
+
+    private var textWidth: CGFloat {
+        guard !text.isEmpty else { return 0 }
+        return ceil((text as NSString).size(withAttributes: [.font: Self.measurementFont]).width)
+    }
+
+    private var viewportWidth: CGFloat {
+        TF.compactIndicatorWidth - TF.compactTranscriptHorizontalInset * 2
+    }
+
+    private var offset: CGFloat {
+        compactTranscriptOffset(textWidth: textWidth, viewportWidth: viewportWidth)
+    }
+
+    private var isOverflowing: Bool {
+        textWidth > viewportWidth
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Text(text)
+                .font(.system(size: TF.compactTranscriptFontSize, weight: .medium))
+                .foregroundStyle(TF.floatingText)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .offset(x: offset)
+                .frame(width: viewportWidth, alignment: .leading)
+                .mask {
+                    if isOverflowing {
+                        HStack(spacing: 0) {
+                            LinearGradient(
+                                colors: [.clear, .white],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                            .frame(width: TF.compactTranscriptLeadingFadeWidth)
+                            Rectangle()
+                        }
+                    } else {
+                        Rectangle()
+                    }
+                }
+                .clipped()
+        }
+        .padding(.horizontal, TF.compactTranscriptHorizontalInset)
+        .frame(width: TF.compactIndicatorWidth, height: TF.compactTranscriptLaneHeight)
+        .accessibilityLabel(text)
+        .accessibilityHidden(text.isEmpty)
+    }
+}

--- a/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
@@ -20,10 +20,21 @@ struct FloatingBarPanelLayout: Equatable {
         )
     }
 
-    static func fallback(for style: RecordingIndicatorStyle) -> FloatingBarPanelLayout {
+    static func fallback(
+        for style: RecordingIndicatorStyle,
+        showsLiveTranscript: Bool = LiveTranscriptDisplayPreference.isEnabled()
+    ) -> FloatingBarPanelLayout {
+        let height: CGFloat
+        if style == .compact {
+            height = showsLiveTranscript
+                ? TF.compactTranscriptExpandedHeight
+                : TF.compactIndicatorHeight
+        } else {
+            height = TF.barHeight
+        }
         let size = NSSize(
             width: TF.barWidthCompact,
-            height: style == .compact ? TF.compactIndicatorHeight : TF.barHeight
+            height: height
         )
         return FloatingBarPanelLayout(contentSize: size, capsuleSize: size)
     }

--- a/Type4Me/UI/FloatingBar/FloatingBarView.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarView.swift
@@ -125,8 +125,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 
     private var effectiveShowsLiveTranscript: Bool {
-        guard effectiveIndicatorStyle == .regular else { return false }
-        return presentationOverride?.showsLiveTranscript ?? showLiveTranscript
+        presentationOverride?.showsLiveTranscript ?? showLiveTranscript
     }
 
     private var effectiveHoverTranscriptPreview: Bool {
@@ -153,6 +152,10 @@ struct FloatingBarView<S: FloatingBarState>: View {
     private var usesCompactRecordingLayout: Bool {
         effectiveIndicatorStyle == .compact
             && (state.barPhase == .preparing || state.barPhase == .recording)
+    }
+
+    private var usesCompactExpandedRecordingLayout: Bool {
+        usesCompactRecordingLayout && effectiveShowsLiveTranscript
     }
 
     // MARK: - Transcript Popup
@@ -206,7 +209,10 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 
     private var capsuleHeight: CGFloat {
-        usesCompactPresentation ? TF.compactIndicatorHeight : TF.barHeight
+        guard usesCompactPresentation else { return TF.barHeight }
+        return usesCompactExpandedRecordingLayout
+            ? TF.compactTranscriptExpandedHeight
+            : TF.compactIndicatorHeight
     }
 
     private var compactStatusIntrinsicWidth: CGFloat {
@@ -331,6 +337,23 @@ struct FloatingBarView<S: FloatingBarState>: View {
         )
     }
 
+    private func updateRecordingPeakWidthIfNeeded() {
+        guard !usesCompactPresentation, state.barPhase == .recording, effectiveShowsLiveTranscript else {
+            if !effectiveShowsLiveTranscript && state.barPhase == .recording {
+                recordingPeakWidth = baseRecordingWidth
+            }
+            return
+        }
+        let text = state.transcriptionText.isEmpty
+            ? state.segments.map(\.text).joined()
+            : state.transcriptionText
+        guard !text.isEmpty else { return }
+        let needed = recordingNeededWidth(for: text)
+        if needed > recordingPeakWidth {
+            recordingPeakWidth = needed
+        }
+    }
+
     var body: some View {
         VStack(spacing: topOverlayGap) {
             if let overlay = activeTopOverlay {
@@ -345,6 +368,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
         .padding(TF.floatingPanelShadowInset)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
         .onAppear {
+            updateRecordingPeakWidthIfNeeded()
             onPanelLayoutChange?(panelLayout)
         }
         .onChange(of: panelLayout) { _, layout in
@@ -353,24 +377,25 @@ struct FloatingBarView<S: FloatingBarState>: View {
         .onChange(of: state.barPhase) { _, newPhase in
             handlePhaseChange(newPhase)
         }
-        .onChange(of: state.segments) { _, newSegments in
-            guard !usesCompactPresentation, state.barPhase == .recording, effectiveShowsLiveTranscript else { return }
-            let text = newSegments.map(\.text).joined()
-            let needed = recordingNeededWidth(for: text)
-            if needed > recordingPeakWidth {
-                recordingPeakWidth = needed
-            }
+        .onChange(of: state.segments) { _, _ in
+            updateRecordingPeakWidthIfNeeded()
         }
         .onChange(of: state.transcriptionText) { _, text in
             if !text.isEmpty && !usesCompactPresentation {
                 dismissModeHint()
             }
+            updateRecordingPeakWidthIfNeeded()
         }
-        .onChange(of: effectiveShowsLiveTranscript) { _, _ in
-            guard !usesCompactPresentation, state.barPhase == .recording else { return }
-            let needed = recordingNeededWidth(for: state.transcriptionText)
-            if needed > recordingPeakWidth {
-                recordingPeakWidth = needed
+        .onChange(of: effectiveShowsLiveTranscript) { _, showsLive in
+            if showsLive {
+                updateRecordingPeakWidthIfNeeded()
+            } else {
+                recordingPeakWidth = baseRecordingWidth
+            }
+        }
+        .onChange(of: effectiveIndicatorStyle) { _, newStyle in
+            if newStyle == .regular {
+                updateRecordingPeakWidthIfNeeded()
             }
         }
         .onDisappear {
@@ -382,13 +407,24 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
     // MARK: - Capsule Container
 
+    private var barCornerRadius: CGFloat {
+        if usesCompactExpandedRecordingLayout {
+            return TF.compactTranscriptCornerRadius
+        }
+        return capsuleHeight / 2
+    }
+
+    private var barShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: barCornerRadius, style: .continuous)
+    }
+
     private var capsuleBar: some View {
         barContent
             .frame(width: capsuleWidth, height: capsuleHeight)
-            .clipShape(Capsule())
+            .clipShape(barShape)
             .background {
                 capsuleBackground
-                    .clipShape(Capsule())
+                    .clipShape(barShape)
             }
             .overlay {
                 capsuleBorder
@@ -406,6 +442,10 @@ struct FloatingBarView<S: FloatingBarState>: View {
             .animation(
                 .spring(response: TF.recordingCapsuleSpringResponse, dampingFraction: 1.0),
                 value: capsuleHeight
+            )
+            .animation(
+                .spring(response: TF.recordingCapsuleSpringResponse, dampingFraction: 1.0),
+                value: barCornerRadius
             )
     }
 
@@ -464,7 +504,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
         .animation(.easeInOut(duration: 0.18), value: state.barPhase)
     }
 
-    private var compactRecordingContent: some View {
+    private var compactRecordingControls: some View {
         HStack(spacing: 0) {
             compactRecordingButton(.finish)
                 .frame(width: 32, height: TF.compactIndicatorHeight)
@@ -480,6 +520,19 @@ struct FloatingBarView<S: FloatingBarState>: View {
             }
         }
         .frame(width: TF.compactIndicatorWidth, height: TF.compactIndicatorHeight)
+    }
+
+    @ViewBuilder
+    private var compactRecordingContent: some View {
+        if effectiveShowsLiveTranscript {
+            VStack(spacing: 0) {
+                CompactLiveTranscriptRow(text: state.transcriptionText)
+                compactRecordingControls
+            }
+            .frame(width: TF.compactIndicatorWidth, height: TF.compactTranscriptExpandedHeight)
+        } else {
+            compactRecordingControls
+        }
     }
 
     @ViewBuilder
@@ -631,6 +684,10 @@ struct FloatingBarView<S: FloatingBarState>: View {
         .padding(.trailing, TF.recordingTrailingInset)
     }
 
+    private var isLiveTranscriptTrailingAligned: Bool {
+        effectiveShowsLiveTranscript && !state.segments.isEmpty && recordingPeakWidth >= TF.barWidth
+    }
+
     private var recordingText: some View {
         // The text is an overlay on a flexible Color.clear so it never
         // participates in the HStack layout: it can never push the cancel
@@ -638,13 +695,13 @@ struct FloatingBarView<S: FloatingBarState>: View {
         // is exactly the space between the two controls; the text is masked to
         // it, so overflow only fades on the leading edge.
         Color.clear
-            .overlay(alignment: recordingPeakWidth >= TF.barWidth ? .trailing : .center) {
+            .overlay(alignment: isLiveTranscriptTrailingAligned ? .trailing : .center) {
                 recordingTextContent
                     .lineLimit(1)
                     .fixedSize(horizontal: true, vertical: false)
             }
             .mask {
-                if effectiveShowsLiveTranscript && !state.segments.isEmpty && recordingPeakWidth >= TF.barWidth {
+                if isLiveTranscriptTrailingAligned {
                     HStack(spacing: 0) {
                         LinearGradient(
                             colors: [.clear, .white],
@@ -876,7 +933,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 
     private var capsuleBorder: some View {
-        Capsule()
+        barShape
             .strokeBorder(borderColor, lineWidth: 0.5)
     }
 
@@ -928,6 +985,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
             if recordingPeakWidth < base {
                 recordingPeakWidth = base
             }
+            updateRecordingPeakWidthIfNeeded()
             recordingActionLocked = false
         case .processing:
             dismissModeHint()

--- a/Type4Me/UI/Settings/AppearanceSettingsTab.swift
+++ b/Type4Me/UI/Settings/AppearanceSettingsTab.swift
@@ -74,12 +74,16 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
 
             settingsGroupCard(L("录音显示", "Recording Display"), icon: "macwindow") {
                 indicatorStyleRow
+                SettingsDivider()
 
                 if !isCompact {
-                    SettingsDivider()
                     visualStyleRow
                     SettingsDivider()
-                    liveTranscriptRow
+                }
+
+                liveTranscriptRow
+
+                if !isCompact {
                     SettingsDivider()
                     hoverPreviewRow
                 }

--- a/Type4MeTests/AppStateTests.swift
+++ b/Type4MeTests/AppStateTests.swift
@@ -254,8 +254,12 @@ final class AppStateTests: XCTestCase {
         )
         XCTAssertEqual(shortBar.panelSize, NSSize(width: 196, height: 71))
         XCTAssertEqual(
-            FloatingBarPanelLayout.fallback(for: .compact).panelSize,
+            FloatingBarPanelLayout.fallback(for: .compact, showsLiveTranscript: false).panelSize,
             NSSize(width: 196, height: 40)
+        )
+        XCTAssertEqual(
+            FloatingBarPanelLayout.fallback(for: .compact, showsLiveTranscript: true).panelSize,
+            NSSize(width: 196, height: 64)
         )
 
         let fullBar = FloatingBarPanelLayout(

--- a/Type4MeTests/AppearancePreviewTests.swift
+++ b/Type4MeTests/AppearancePreviewTests.swift
@@ -242,6 +242,91 @@ final class AppearancePreviewTests: XCTestCase {
         demoState.stop()
     }
 
+    // MARK: - Compact Live Transcript Tests
+
+    func testCompactTranscriptOffset() {
+        // Text fits comfortably inside viewport: no offset (leading aligned)
+        XCTAssertEqual(compactTranscriptOffset(textWidth: 0, viewportWidth: 164), 0)
+        XCTAssertEqual(compactTranscriptOffset(textWidth: 80, viewportWidth: 164), 0)
+        // Exactly at viewport boundary: no offset
+        XCTAssertEqual(compactTranscriptOffset(textWidth: 164, viewportWidth: 164), 0)
+        // Text overflows viewport: negative offset aligns text tail to right edge
+        XCTAssertEqual(compactTranscriptOffset(textWidth: 190, viewportWidth: 164), -26)
+        XCTAssertEqual(compactTranscriptOffset(textWidth: 300, viewportWidth: 164), -136)
+    }
+
+    func testCompactLiveTranscriptDesignTokens() {
+        XCTAssertEqual(TF.compactIndicatorWidth, 180)
+        XCTAssertEqual(TF.compactIndicatorHeight, 24)
+        XCTAssertEqual(TF.compactTranscriptLaneHeight, 24)
+        XCTAssertEqual(TF.compactTranscriptExpandedHeight, 48)
+        XCTAssertEqual(TF.compactTranscriptFontSize, 12)
+        XCTAssertEqual(TF.compactTranscriptCornerRadius, 10)
+        XCTAssertEqual(TF.compactTranscriptHorizontalInset, 8)
+        XCTAssertEqual(TF.compactTranscriptLeadingFadeWidth, 10)
+
+        // Viewport width arithmetic contract
+        let viewportWidth = TF.compactIndicatorWidth - TF.compactTranscriptHorizontalInset * 2
+        XCTAssertEqual(viewportWidth, 164)
+
+        // Height arithmetic contract
+        XCTAssertEqual(
+            TF.compactTranscriptLaneHeight + TF.compactIndicatorHeight,
+            TF.compactTranscriptExpandedHeight
+        )
+    }
+
+    func testFloatingBarPresentation_compactLiveTranscriptSupport() {
+        let compactLiveOn = FloatingBarPresentation(
+            indicatorStyle: .compact,
+            showsLiveTranscript: true
+        )
+        XCTAssertEqual(compactLiveOn.indicatorStyle, .compact)
+        XCTAssertTrue(compactLiveOn.showsLiveTranscript)
+
+        let compactLiveOff = FloatingBarPresentation(
+            indicatorStyle: .compact,
+            showsLiveTranscript: false
+        )
+        XCTAssertEqual(compactLiveOff.indicatorStyle, .compact)
+        XCTAssertFalse(compactLiveOff.showsLiveTranscript)
+    }
+
+    func testFloatingBarPresentation_switchingStylesPreservesCorrectPreferences() {
+        var presentation = FloatingBarPresentation(
+            indicatorStyle: .compact,
+            showsLiveTranscript: true
+        )
+        XCTAssertEqual(presentation.indicatorStyle, .compact)
+        XCTAssertTrue(presentation.showsLiveTranscript)
+
+        // Switch to regular
+        presentation.indicatorStyle = .regular
+        XCTAssertEqual(presentation.indicatorStyle, .regular)
+        XCTAssertTrue(presentation.showsLiveTranscript)
+
+        // Switch live transcript off
+        presentation.showsLiveTranscript = false
+        XCTAssertFalse(presentation.showsLiveTranscript)
+    }
+
+    func testFloatingBarPanelLayout_fallbackWithLiveTranscript() {
+        let compactLiveOn = FloatingBarPanelLayout.fallback(for: .compact, showsLiveTranscript: true)
+        XCTAssertEqual(compactLiveOn.contentSize, NSSize(width: TF.barWidthCompact, height: TF.compactTranscriptExpandedHeight))
+        XCTAssertEqual(compactLiveOn.capsuleSize, NSSize(width: TF.barWidthCompact, height: TF.compactTranscriptExpandedHeight))
+        XCTAssertEqual(compactLiveOn.panelSize, NSSize(width: 196, height: 64))
+
+        let compactLiveOff = FloatingBarPanelLayout.fallback(for: .compact, showsLiveTranscript: false)
+        XCTAssertEqual(compactLiveOff.contentSize, NSSize(width: TF.barWidthCompact, height: TF.compactIndicatorHeight))
+        XCTAssertEqual(compactLiveOff.capsuleSize, NSSize(width: TF.barWidthCompact, height: TF.compactIndicatorHeight))
+        XCTAssertEqual(compactLiveOff.panelSize, NSSize(width: 196, height: 40))
+
+        let regular = FloatingBarPanelLayout.fallback(for: .regular)
+        XCTAssertEqual(regular.contentSize, NSSize(width: TF.barWidthCompact, height: TF.barHeight))
+        XCTAssertEqual(regular.capsuleSize, NSSize(width: TF.barWidthCompact, height: TF.barHeight))
+        XCTAssertEqual(regular.panelSize, NSSize(width: 196, height: 71))
+    }
+
     // MARK: - SettingsTab Appearance Tests
 
     func testSettingsTab_appearanceProperties() {

--- a/docs/features/compact-live-transcript/development-design.md
+++ b/docs/features/compact-live-transcript/development-design.md
@@ -1,0 +1,858 @@
+# Type4Me Compact 实时识别文本开发设计
+
+> 分支：`feat/compact-live-transcript`
+> 文档类型：开发设计
+> 文档状态：设计中
+> 设计日期：2026-08-27
+> 基线：`main` @ `8c3f0c0`
+> 产品设计：`docs/features/compact-live-transcript/product-design.md`
+> 说明：本文档独立维护，不修改 `docs/features/compact-recording-indicator/` 既有设计。
+
+## 1. 设计摘要
+
+当前 Compact 在 `.preparing` / `.recording` 使用固定 180 × 24 capsule：左右是 Finish / Cancel，中间是 `CompactAudioIndicator`。`effectiveShowsLiveTranscript` 当前明确对 Compact 返回 `false`，Settings 也在 Compact 下隐藏 Live Transcript。
+
+本功能让已有 `tf_showLiveTranscript` 同时作用于 Regular 与 Compact：
+
+```text
+Compact + Live Transcript Off
+preparing / recording -> 180 × 24
+
+Compact + Live Transcript On
+preparing / recording -> 180 × 48
+  top 24 -> CompactLiveTranscriptRow
+  bottom 24 -> existing controls + waveform
+
+processing / recovering / done / error
+-> existing Compact status, height 24, intrinsic width
+```
+
+实时文字不参与 capsule width。短文本从左侧开始；超过可视宽度后，通过 deterministic negative offset 实现 follow-tail，让最新 transcript 尾部持续可见。
+
+## 2. 核心工程原则
+
+1. 复用 `tf_showLiveTranscript`，不新增 Compact transcript preference。
+2. Compact 录音 width 继续固定 180pt。
+3. 现有 24pt Compact control lane 不改几何和 action。
+4. `TF.compactIndicatorHeight` 继续表示 24pt 基础高度，禁止直接改成 48。
+5. 48pt 只表示 Live Transcript 开启时的 Compact recording expanded height。
+6. transcript 直接读取 `state.transcriptionText`，不建立第二套 ASR state。
+7. follow-tail 只改变 text offset，不改变 capsule width。
+8. Compact 仍禁止 Transcript Popup。
+9. Processing / Recovering / Done / Error 继续现有 Compact renderer。
+10. Preview 继续复用真实 `FloatingBarView`。
+11. Panel 复用当前 `FloatingBarPanelLayout` 动态尺寸机制。
+12. 新尺寸、字体、fade 数值进入 `TF` token。
+
+## 3. 当前实现基线
+
+### 3.1 Presentation
+
+当前：
+
+```swift
+struct FloatingBarPresentation: Equatable {
+    var indicatorStyle: RecordingIndicatorStyle = .regular
+    var visualStyle: RecordingVisualStyle = .siri
+    var showsLiveTranscript: Bool = true
+    var enablesHoverTranscriptPreview: Bool = true
+    var showsTooltips: Bool = true
+    var showsCancelButton: Bool = true
+}
+```
+
+无需增加新字段。
+
+### 3.2 Live Transcript gate
+
+当前：
+
+```swift
+private var effectiveShowsLiveTranscript: Bool {
+    guard effectiveIndicatorStyle == .regular else { return false }
+    return presentationOverride?.showsLiveTranscript ?? showLiveTranscript
+}
+```
+
+这是 Compact 无法使用 live text 的主要 capability gate。
+
+### 3.3 Compact geometry
+
+当前：
+
+```swift
+private var capsuleHeight: CGFloat {
+    usesCompactPresentation ? TF.compactIndicatorHeight : TF.barHeight
+}
+```
+
+全部 Compact phase 都是 24pt。
+
+### 3.4 Compact recording content
+
+当前单行结构：
+
+```swift
+HStack(spacing: 0) {
+    compactRecordingButton(.finish)
+    CompactAudioIndicator(meter: state.audioLevel)
+    compactRecordingButton(.cancel)
+}
+.frame(width: TF.compactIndicatorWidth,
+       height: TF.compactIndicatorHeight)
+```
+
+这部分应抽成 bottom control lane，不重新设计。
+
+### 3.5 Settings
+
+当前 `AppearanceSettingsTab` 把：
+
+```text
+Recording Visual
+Live Transcript
+Hover Text Preview
+```
+
+一起放进 `if !isCompact`，所以 Compact 下无法控制 live transcript。
+
+### 3.6 Panel
+
+当前 `FloatingBarView` 已计算 `FloatingBarPanelLayout`，并通过 `onPanelLayoutChange` 把 capsule 和 overlay 尺寸传给 controller。24 ↔ 48 不需要新建固定 Panel 方案。
+
+## 4. Capability Resolution
+
+`Live Transcript` 改为 Regular / Compact 共用：
+
+```swift
+private var effectiveShowsLiveTranscript: Bool {
+    presentationOverride?.showsLiveTranscript ?? showLiveTranscript
+}
+```
+
+`Hover Text Preview` 继续 Regular-only：
+
+```swift
+private var effectiveHoverTranscriptPreview: Bool {
+    guard effectiveIndicatorStyle == .regular else { return false }
+    return presentationOverride?.enablesHoverTranscriptPreview ?? hoverTranscriptPreview
+}
+```
+
+能力矩阵：
+
+| Capability | Regular | Compact |
+|---|---:|---:|
+| Live Transcript | ✅ | ✅ |
+| Hover Transcript Popup | ✅ | ❌ |
+| Recording Visual | ✅ | ❌ |
+| Tooltips | ✅ | ✅ |
+| Cancel Button | ✅ | ✅ |
+
+`showTranscriptPopup` 已有 Compact guard，因此 inline transcript 不会误触发 Popup。
+
+## 5. Design Token
+
+保留现有：
+
+```swift
+TF.compactIndicatorWidth  // 180
+TF.compactIndicatorHeight // 24
+```
+
+禁止把 `compactIndicatorHeight` 改成 48，因为它同时用于 control row、status phase 和 `CompactAudioIndicator`。
+
+新增：
+
+```swift
+static let compactTranscriptLaneHeight: CGFloat = 24
+static let compactTranscriptExpandedHeight: CGFloat = 48
+static let compactTranscriptFontSize: CGFloat = 12
+static let compactTranscriptHorizontalInset: CGFloat = 8
+static let compactTranscriptLeadingFadeWidth: CGFloat = 10
+```
+
+继续复用：
+
+```swift
+TF.floatingBackground
+TF.floatingBorder
+TF.floatingText
+```
+
+不新增 raw color。
+
+## 6. Phase-aware Height
+
+新增：
+
+```swift
+private var usesCompactExpandedRecordingLayout: Bool {
+    usesCompactRecordingLayout && effectiveShowsLiveTranscript
+}
+```
+
+高度：
+
+```swift
+private var capsuleHeight: CGFloat {
+    guard usesCompactPresentation else { return TF.barHeight }
+    return usesCompactExpandedRecordingLayout
+        ? TF.compactTranscriptExpandedHeight
+        : TF.compactIndicatorHeight
+}
+```
+
+Contract：
+
+```text
+compact preparing + live on  -> 48
+compact recording + live on  -> 48
+compact preparing + live off -> 24
+compact recording + live off -> 24
+compact processing           -> 24
+compact recovering           -> 24
+compact done                 -> 24
+compact error                -> 24
+```
+
+`compactCapsuleWidth` 不修改：Preparing / Recording 始终 180pt。
+
+## 7. Compact Recording Content 重构
+
+建议把当前录音行抽成 `compactRecordingControls`：
+
+```swift
+private var compactRecordingControls: some View {
+    HStack(spacing: 0) {
+        compactRecordingButton(.finish)
+            .frame(width: 32, height: TF.compactIndicatorHeight)
+
+        CompactAudioIndicator(meter: state.audioLevel)
+            .frame(maxWidth: .infinity,
+                   maxHeight: TF.compactIndicatorHeight)
+
+        if effectiveShowsCancelButton {
+            compactRecordingButton(.cancel)
+                .frame(width: 32,
+                       height: TF.compactIndicatorHeight)
+        } else {
+            Spacer().frame(width: TF.recordingEdgeInset)
+        }
+    }
+    .frame(width: TF.compactIndicatorWidth,
+           height: TF.compactIndicatorHeight)
+}
+```
+
+然后组合：
+
+```swift
+@ViewBuilder
+private var compactRecordingContent: some View {
+    if effectiveShowsLiveTranscript {
+        VStack(spacing: 0) {
+            CompactLiveTranscriptRow(text: state.transcriptionText)
+            compactRecordingControls
+        }
+        .frame(width: TF.compactIndicatorWidth,
+               height: TF.compactTranscriptExpandedHeight)
+    } else {
+        compactRecordingControls
+    }
+}
+```
+
+不改 `CompactAudioIndicator` 和 recording action callback。
+
+## 8. CompactLiveTranscriptRow
+
+建议新增：
+
+```text
+Type4Me/UI/FloatingBar/CompactLiveTranscriptRow.swift
+```
+
+API：
+
+```swift
+struct CompactLiveTranscriptRow: View {
+    let text: String
+}
+```
+
+职责：
+
+- 12pt Medium 单行文本；
+- 固定 180pt row；
+- 左右 8pt inset；
+- follow-tail offset；
+- overflow leading fade；
+- accessibility 完整 transcript。
+
+不负责：
+
+- 组合 ASR segments；
+- preference；
+- phase；
+- Popup；
+- buttons；
+- Panel resize。
+
+## 9. Follow-tail 算法
+
+### 9.1 Viewport
+
+```swift
+let viewportWidth = TF.compactIndicatorWidth
+    - TF.compactTranscriptHorizontalInset * 2
+```
+
+即：
+
+```text
+180 - 8 - 8 = 164pt
+```
+
+### 9.2 Text measurement
+
+字体必须与实际渲染一致：
+
+```swift
+let compactTranscriptFont = NSFont.systemFont(
+    ofSize: TF.compactTranscriptFontSize,
+    weight: .medium
+)
+```
+
+测量：
+
+```swift
+ceil((text as NSString).size(
+    withAttributes: [.font: compactTranscriptFont]
+).width)
+```
+
+不要复用 Regular 14pt `floatingBarFont`。
+
+### 9.3 Offset helper
+
+建议抽成 internal pure helper：
+
+```swift
+func compactTranscriptOffset(
+    textWidth: CGFloat,
+    viewportWidth: CGFloat
+) -> CGFloat {
+    -max(0, textWidth - viewportWidth)
+}
+```
+
+例子：
+
+```text
+80 / 164  -> 0
+164 / 164 -> 0
+190 / 164 -> -26
+300 / 164 -> -136
+```
+
+这同时满足：
+
+- 短文本 leading aligned；
+- 到右边界前不移动；
+- overflow 后 tail 贴住右边界；
+- ASR correction 让文本变短时 offset 可以自然回到 0。
+
+### 9.4 View sketch
+
+```swift
+Text(text)
+    .font(.system(size: TF.compactTranscriptFontSize,
+                  weight: .medium))
+    .foregroundStyle(TF.floatingText)
+    .lineLimit(1)
+    .fixedSize(horizontal: true, vertical: false)
+    .offset(x: offset)
+    .frame(width: viewportWidth, alignment: .leading)
+    .clipped()
+```
+
+外层加 8pt horizontal padding，并固定 180 × 24。
+
+## 10. Overflow Mask
+
+只有 `textWidth > viewportWidth` 时启用 leading fade。
+
+建议：
+
+```text
+0...10pt: transparent -> opaque
+10pt...end: opaque
+```
+
+右侧始终 opaque，确保最新识别结果最清晰。
+
+短文本不应用 fade。
+
+## 11. ASR Partial / Correction
+
+数据源只有：
+
+```swift
+state.transcriptionText
+```
+
+它已由 `AppState.setLiveTranscript` 统一组合 confirmed segments + partial。
+
+Compact 不监听 segments 去改变 width，也不使用 `recordingPeakWidth`。
+
+行为：
+
+- append：重新测量，并在 overflow 后向左跟随；
+- correction/rewrite：立即以新的 `state.transcriptionText` 为准；
+- correction 后仍 overflow：重新计算最新 tail；
+- correction 后回到 viewport 内：offset = 0。
+
+### Animation
+
+可以对纯 append 的 offset 变化使用 80–120ms ease-out。
+
+可选优化：
+
+```swift
+newText.hasPrefix(oldText)
+```
+
+时才做动画；rewrite 直接跳到最新正确位置，避免“滚过已经被 ASR 修掉的旧文本”。
+
+第一版 correctness 不依赖该优化。
+
+## 12. Empty State
+
+当 `state.transcriptionText.isEmpty`：
+
+- row 仍占 24pt；
+- 内容为空；
+- 不显示 `Listening / 倾听中`；
+- 不显示 Revise placeholder。
+
+不要复用 Regular 的 `recordingDisplayText`。
+
+## 13. Settings 修改
+
+当前：
+
+```swift
+indicatorStyleRow
+if !isCompact {
+    visualStyleRow
+    liveTranscriptRow
+    hoverPreviewRow
+}
+showTooltipsRow
+showCancelButtonRow
+```
+
+改为：
+
+```swift
+indicatorStyleRow
+SettingsDivider()
+
+if !isCompact {
+    visualStyleRow
+    SettingsDivider()
+}
+
+liveTranscriptRow
+
+if !isCompact {
+    SettingsDivider()
+    hoverPreviewRow
+}
+
+SettingsDivider()
+showTooltipsRow
+SettingsDivider()
+showCancelButtonRow
+```
+
+Regular 保持：
+
+```text
+Indicator Style
+Recording Visual
+Live Transcript
+Hover Text Preview
+Show Tooltips
+Show Cancel Button
+```
+
+Compact 变为：
+
+```text
+Indicator Style
+Live Transcript
+Show Tooltips
+Show Cancel Button
+```
+
+不迁移 `showLiveTranscript` 值。
+
+## 14. Appearance Preview
+
+现有 `AppearancePreviewStage` 已使用长 sample transcript，并直接运行真实 `FloatingBarView`。
+
+理论上无需修改 Preview View 本身。
+
+必须验收：
+
+```text
+Compact + Live On + Recording -> 180 × 48 + follow-tail
+Compact + Live Off + Recording -> 180 × 24
+Compact + Processing -> intrinsic width × 24
+```
+
+Preview action isolation 保持不变。
+
+## 15. Panel Layout
+
+当前 panel layout 以：
+
+```swift
+let capsuleSize = NSSize(width: capsuleWidth,
+                         height: capsuleHeight)
+```
+
+为输入，有 overlay 时高度为：
+
+```text
+capsule height + overlay gap + overlay height
+```
+
+所以本功能只需要正确解析 `capsuleHeight`。
+
+手工验证：
+
+- 录音中切 Live Transcript 24 ↔ 48，bottom anchor 不漂移；
+- mode hint 位于 48pt capsule 上方；
+- action tooltip 仍对齐底部两个按钮；
+- Finish 后 48 -> 24 resize 无明显位置跳动。
+
+## 16. Tooltips / Cancel Button
+
+`recordingActionHorizontalOffset` 的 Compact path 只依赖 capsule width：
+
+```swift
+capsuleWidth / 2 - 16
+```
+
+width 仍为 180，因此无需修改水平对齐算法。
+
+`Show Cancel Button = Off` 只改变 bottom control lane；上方 transcript viewport 始终固定 164pt，不与 control chrome 耦合。
+
+Transcript lane 不增加 hover tracker，也不触发 Popup。
+
+## 17. Processing / Result 隔离
+
+现有 `compactPhaseContent` routing 保持不变：
+
+```text
+preparing / recording -> compactRecordingContent
+processing            -> compactStatusContent
+recovering            -> compactStatusContent
+done                  -> compactDoneContent
+error                 -> compactStatusContent
+```
+
+Expanded height 必须只由：
+
+```swift
+usesCompactRecordingLayout && effectiveShowsLiveTranscript
+```
+
+触发。
+
+禁止用：
+
+```swift
+usesCompactPresentation && effectiveShowsLiveTranscript
+```
+
+否则 Processing / Done 会错误保持 48pt。
+
+## 18. Regular Regression Isolation
+
+Regular 不应变化：
+
+- dynamic capsule width；
+- `recordingPeakWidth`；
+- 14pt live text；
+- Transcript Popup；
+- LiquidGlassText / Orb；
+- Hover Text Preview；
+- Recording Visual；
+- tooltip geometry。
+
+Regular 的 segment / width logic 已经有 `!usesCompactPresentation` guard，应继续保留。
+
+## 19. Accessibility
+
+`CompactLiveTranscriptRow`：
+
+- accessibility label = 完整 `text`；
+- 视觉 viewport 不影响完整内容读取；
+- 空 text 时可 `.accessibilityHidden(true)`；
+- 不声明 editable / button trait；
+- Finish / Cancel 保持现有 accessibility action 和 first-click。
+
+## 20. 文件规划
+
+预计修改：
+
+```text
+Type4Me/UI/DesignSystem.swift
+Type4Me/UI/FloatingBar/FloatingBarView.swift
+Type4Me/UI/Settings/AppearanceSettingsTab.swift
+Type4MeTests/AppearancePreviewTests.swift
+```
+
+预计新增：
+
+```text
+Type4Me/UI/FloatingBar/CompactLiveTranscriptRow.swift
+```
+
+大概率无需修改：
+
+```text
+Type4Me/UI/AppState.swift
+Type4Me/UI/FloatingBar/CompactAudioIndicator.swift
+Type4Me/UI/Settings/AppearancePreviewStage.swift
+```
+
+## 21. 单元测试
+
+### 21.1 Offset pure helper
+
+```swift
+XCTAssertEqual(
+    compactTranscriptOffset(textWidth: 80,
+                            viewportWidth: 164),
+    0
+)
+XCTAssertEqual(
+    compactTranscriptOffset(textWidth: 164,
+                            viewportWidth: 164),
+    0
+)
+XCTAssertEqual(
+    compactTranscriptOffset(textWidth: 190,
+                            viewportWidth: 164),
+    -26
+)
+```
+
+还应验证 textWidth = 0 时不会产生正 offset。
+
+### 21.2 Geometry contract
+
+```text
+compact base height = 24
+transcript lane = 24
+expanded recording height = 48
+recording width = 180
+font = 12
+horizontal inset = 8
+viewport = 164
+```
+
+### 21.3 Phase resolution
+
+覆盖：
+
+```text
+Compact + live on + recording -> 48
+Compact + live off + recording -> 24
+Compact + live on + processing -> 24
+Regular + live on -> existing 55pt behavior
+```
+
+如果 View property private，建议抽小型 pure resolution helper，不做 pixel snapshot。
+
+### 21.4 Capability
+
+覆盖：
+
+- Compact + `showsLiveTranscript=true` 不再被强制 false；
+- Compact + false 不显示 transcript lane；
+- Regular true/false 保持原行为；
+- Compact Hover Transcript Popup 仍禁用；
+- 没有新增 UserDefaults key。
+
+## 22. Manual QA
+
+### Settings
+
+- Compact 下出现 Live Transcript；
+- Compact 下仍不出现 Recording Visual / Hover Text Preview；
+- toggle 使用原 `tf_showLiveTranscript`；
+- 切回 Regular 值一致。
+
+### Short transcript
+
+口述：
+
+```text
+你好，这是测试
+```
+
+要求：leading aligned，offset 0，无滚动。
+
+### Long transcript
+
+持续口述超过 viewport：
+
+- 到右边界后才左移；
+- 最新字符始终可见；
+- capsule width 仍 180；
+- leading fade 仅 overflow 后出现。
+
+### English
+
+验证长单词、空格、标点时测量与实际 12pt Text 一致，不出现 trailing clipping。
+
+### ASR correction
+
+- 旧 partial 不残留；
+- correction 不 resize capsule；
+- 文本缩短后能回到 leading。
+
+### Cancel hidden
+
+- transcript viewport 不变；
+- bottom controls 保持当前行为；
+- Esc 仍可取消。
+
+### Tooltips
+
+- 48pt 时 mode hint 位置正确；
+- Finish / Cancel bubble 对齐正确；
+- tooltip 不遮 transcript；
+- Show Tooltips Off 时隐藏。
+
+### Finish transition
+
+```text
+180 × 48 recording
+→ intrinsic × 24 processing
+→ intrinsic × 24 done/error
+```
+
+全程不进入 Regular renderer。
+
+## 23. 性能
+
+ASR partial 更新频率远低于 `AudioLevelMeter` Canvas animation。
+
+允许每次 `state.transcriptionText` 改变做一次 12pt NSString width measurement。
+
+避免：
+
+- TimelineView 驱动文字；
+- 第二套高频 Observable transcript model；
+- 无限 marquee animation；
+- ScrollView 用户滚动状态与 ASR follow-tail 混用。
+
+如果 profiling 后测量成为热点，再考虑 width cache，第一版不提前复杂化。
+
+## 24. 为什么不优先使用 horizontal ScrollView
+
+`ScrollViewReader + scrollTo(end)` 看似简单，但在以下场景更难稳定：
+
+- 首次从未溢出切到溢出；
+- ASR partial correction；
+- 文本变短后需要回到 leading；
+- panel 录音中 resize；
+- 禁止用户手动把视口留在旧位置。
+
+本功能的目标不是“可浏览的横向文本”，而是 deterministic follow-tail，因此固定 viewport + text width + offset 更直接。
+
+## 25. 风险与缓解
+
+### 风险 1：直接改 `compactIndicatorHeight = 48`
+
+会误伤 status / waveform。
+
+缓解：保留 24，新增 expanded token。
+
+### 风险 2：复用 Regular `recordingPeakWidth`
+
+会把固定 width Compact 与动态 width Regular 混在一起。
+
+缓解：Compact 只计算 text offset。
+
+### 风险 3：partial 高频更新造成抖动
+
+缓解：viewport 内 offset 恒 0；overflow 后只移动必要距离，动画保持短小。
+
+### 风险 4：已有 Compact 用户默认变成 48pt
+
+这是复用既有 Live Transcript preference 的预期语义变化。
+
+用户关闭 Live Transcript 后立即恢复 180 × 24。
+
+### 风险 5：无 realtime partial 时上层为空
+
+第一版接受空白 lane，不伪造 placeholder，也不动态改变高度。
+
+### 风险 6：48 -> 24 transition 跳动
+
+复用当前动态 Panel layout 和现有 critically damped capsule resize，重点做 bottom-anchor QA。
+
+## 26. 实现顺序
+
+1. 增加 transcript geometry / typography token；
+2. 允许 Compact 解析 `effectiveShowsLiveTranscript`；
+3. 增加 expanded recording height resolution；
+4. 抽出 `compactRecordingControls`；
+5. 新增 `CompactLiveTranscriptRow`；
+6. 实现 text measurement + follow-tail offset；
+7. 增加 overflow leading fade；
+8. 调整 Settings Compact 项；
+9. 添加 offset / geometry / capability tests；
+10. 验证 Appearance Preview；
+11. 手工 QA 中英文、ASR correction、tooltips、Cancel hidden；
+12. `swift test`；
+13. `swift build`。
+
+## 27. 技术决策汇总
+
+| 项目 | 决策 |
+|---|---|
+| Preference | 复用 `tf_showLiveTranscript` |
+| New storage | 无 |
+| Live On recording | 180 × 48 |
+| Live Off recording | 180 × 24 |
+| Status phases | 继续 24pt Compact |
+| Base height token | 保持 24 |
+| Expanded height | 新增 48 |
+| Transcript component | `CompactLiveTranscriptRow` |
+| Font | 12pt Medium |
+| Color | `TF.floatingText` |
+| Insets | 8pt horizontal |
+| Viewport | 164pt |
+| Width | 固定 180 |
+| Follow-tail | deterministic negative offset |
+| Offset | `-max(0, textWidth - viewportWidth)` |
+| Left fade | overflow 时约 10pt |
+| Right fade | 无 |
+| ASR source | `state.transcriptionText` |
+| Correction | 跟随最新 source of truth |
+| Transcript Popup | Compact 禁用 |
+| Tooltips | 保持现状 |
+| Cancel hidden | 不影响 transcript viewport |
+| Panel | 复用 `FloatingBarPanelLayout` |
+| Preview | 复用真实 `FloatingBarView` |
+| Existing Compact docs | 不修改 |

--- a/docs/features/compact-live-transcript/product-design.md
+++ b/docs/features/compact-live-transcript/product-design.md
@@ -1,0 +1,492 @@
+# Type4Me Compact 实时识别文本产品设计
+
+> 分支：`feat/compact-live-transcript`
+> 文档类型：产品设计
+> 文档状态：设计中
+> 设计日期：2026-08-27
+> 基线：`main` @ `8c3f0c0`
+> 关联开发设计：`docs/features/compact-live-transcript/development-design.md`
+> 说明：本文档是独立功能设计，不修改或替代 `docs/features/compact-recording-indicator/` 下的既有文档。
+
+## 1. 背景
+
+Type4Me 已经提供 Regular / Compact 两套录音指示器外观。
+
+当前 Compact 的核心优势是占用空间小：录音阶段固定为 180 × 24 pt，底部一行包含 Finish、动态 Audio Indicator 和 Cancel；录音结束后的 Processing / Recovering / Done / Error 继续使用 24pt 高的 Compact 状态提示。
+
+当前 Compact 不展示实时识别文本，因此用户只能从声纹确认“正在录音”，无法在录音过程中快速确认 ASR 是否识别正确。
+
+本功能在不放弃 Compact 固定宽度和低占屏特性的前提下，为 Compact 增加可选的内嵌实时识别文本。
+
+## 2. 产品目标
+
+1. Compact 支持现有 `Live Transcript / 实时展示文本` 设置；
+2. Live Transcript 开启时，Compact 的 Preparing / Recording 录音态从 180 × 24 pt 扩展为 180 × 48 pt；
+3. 48pt 高度拆成上下两个 24pt 区域：上方实时文本，下方保持现有录音控制和声纹；
+4. 实时文本使用 12pt 单行文本，从左侧开始自然向右增长；
+5. 文本尚未填满可用宽度时保持左对齐，不发生滚动；
+6. 文本达到右边界后进入 follow-tail 行为：旧内容向左移动，最新识别内容持续保持可见；
+7. Compact 的宽度始终保持 180pt，不因为实时文本长度增长；
+8. Live Transcript 关闭时，Compact 继续保持现有 180 × 24 pt 录音态；
+9. Finish 后 Processing / Recovering / Done / Error 不继承 48pt 高度，继续使用现有 24pt Compact 状态提示；
+10. 不引入新的 ASR 数据源、录音状态或独立 transcript preference。
+
+## 3. 非目标
+
+本功能不包含：
+
+- 把 Compact 录音态宽度改成随文字变化；
+- 多行实时文本；
+- 垂直滚动 transcript；
+- 跑马灯式循环滚动；
+- Compact Transcript Popup；
+- 通过 hover 展开完整实时文字；
+- 改变现有 Compact Audio Indicator 的声纹规格；
+- 改变 Finish / Cancel 的交互语义；
+- 改变 Processing / Recovering / Done / Error 的宽度自适应策略；
+- 新增 Compact 专属的 Live Transcript UserDefaults key。
+
+## 4. 设置语义
+
+### 4.1 复用现有 Live Transcript
+
+继续复用：
+
+```text
+tf_showLiveTranscript
+```
+
+不新增 `tf_compactLiveTranscript`。
+
+`Live Transcript` 从“Regular-only 能力”调整为“Regular 与 Compact 共用能力”。
+
+### 4.2 Compact + Live Transcript On
+
+录音阶段显示：
+
+```text
+180 × 48 pt
+```
+
+上层为实时文字，下层为原有 Compact controls / waveform。
+
+### 4.3 Compact + Live Transcript Off
+
+录音阶段继续显示：
+
+```text
+180 × 24 pt
+```
+
+与当前 Compact 行为完全一致。
+
+### 4.4 Settings 页面
+
+当 Indicator Style = Compact 时：
+
+- `Live Transcript` 保持显示并可操作；
+- `Recording Visual` 仍然属于 Regular-only，不在 Compact 中显示；
+- `Hover Text Preview` 仍然属于 Regular-only，不在 Compact 中显示；
+- `Show Tooltips` 与 `Show Cancel Button` 行为不变。
+
+因此 Compact 设置项建议呈现为：
+
+```text
+Indicator Style     Compact
+Live Transcript     On / Off
+Show Tooltips       On / Off
+Show Cancel Button  On / Off
+```
+
+Regular 继续保留现有完整设置组合。
+
+## 5. 录音态总体布局
+
+### 5.1 Live Transcript 开启
+
+```text
+┌────────────────────────────────────┐
+│ 你好，这是一段录音，它将被 Type… │  ← 24pt transcript lane
+│ [■]   ▁▃▆▂▅▇▃▂▅▃▆▂▅          [×] │  ← 24pt control lane
+└────────────────────────────────────┘
+                 180 × 48 pt
+```
+
+上下两层属于同一个 Compact capsule，不增加内部边框或分隔线。
+
+### 5.2 Live Transcript 关闭
+
+```text
+┌────────────────────────────────────┐
+│ [■]   ▁▃▆▂▅▇▃▂▅▃▆▂▅          [×] │
+└────────────────────────────────────┘
+                 180 × 24 pt
+```
+
+### 5.3 尺寸原则
+
+- width：固定 180pt；
+- transcript lane：24pt；
+- control lane：24pt；
+- expanded height：48pt；
+- collapsed height：24pt；
+- 外轮廓继续使用当前 Compact 的深色 capsule 视觉语言；
+- 48pt 只适用于 Preparing / Recording 且 Live Transcript 开启的情况。
+
+> 本文使用 macOS 逻辑坐标 `pt`。Retina 屏幕的物理像素由系统缩放处理。
+
+## 6. 实时文本视觉规格
+
+### 6.1 字体
+
+```text
+font size: 12pt
+weight: medium
+line count: 1
+```
+
+颜色使用现有 Floating Bar 文本 Design Token，不在组件内写死 `.white`。
+
+### 6.2 文本区域
+
+建议：
+
+```text
+horizontal inset: 8pt
+viewport width: 180 - 8 - 8 = 164pt
+lane height: 24pt
+```
+
+文本在 24pt lane 内垂直居中。
+
+### 6.3 空内容
+
+Preparing 阶段和第一段 ASR partial 到达之前：
+
+- transcript lane 保持空白；
+- 不显示 `倾听中 / Listening` placeholder；
+- 下方声纹已经承担录音状态反馈，因此不额外重复状态文字。
+
+这样第一段识别文本出现时可以直接从左侧自然长出。
+
+## 7. Follow-tail 文本行为
+
+这是本功能的核心交互。
+
+### 7.1 未溢出
+
+当当前文本实际宽度小于等于 transcript viewport：
+
+```text
+你好，这是
+↑
+左侧起始位置固定
+```
+
+行为：
+
+- 左对齐；
+- 不滚动；
+- 不居中；
+- 不因为每个 partial update 横向抖动。
+
+### 7.2 到达右边界
+
+文本不断向右增长，直到触达可用区域右侧。
+
+在触达右边界之前，不移动已有内容。
+
+### 7.3 溢出后
+
+一旦文本宽度超过 viewport：
+
+- 整段文字向左移动；
+- 最新识别的文本尾部保持在右侧可视范围；
+- 新内容继续到达时，视口跟随 transcript 尾部；
+- 用户始终能看到最新识别结果。
+
+示意：
+
+```text
+初始：
+| 你好，这是一段录音               |
+
+接近边界：
+| 你好，这是一段录音，它将被 Type4 |
+
+溢出后：
+| 一段录音，它将被 Type4Me 转换为文字 |
+```
+
+### 7.4 不是 Marquee
+
+禁止实现成循环跑马灯：
+
+```text
+末尾 → 消失 → 从右侧重新进入
+```
+
+文本只跟随当前 transcript 尾部，不循环播放历史内容。
+
+### 7.5 左侧溢出提示
+
+当 transcript 已经发生左侧溢出时，可在左边缘使用约 10pt 的轻量 fade mask。
+
+目的：
+
+- 表达左侧仍有更早内容；
+- 避免文字在 capsule 边缘生硬裁切。
+
+右侧不增加 fade，因为右侧代表当前最新识别内容。
+
+## 8. ASR Partial 与修正行为
+
+实时 ASR 不一定只做 append，也可能修正上一段 partial。
+
+Compact transcript 始终渲染当前 `state.transcriptionText`，不自己缓存“用户已经看过的旧文本”。
+
+### Append
+
+当新文本是在现有文本尾部追加时：
+
+- 未溢出：继续向右增长；
+- 已溢出：平滑跟随新的尾部位置。
+
+### Correction / Rewrite
+
+当 ASR 回改已有 partial 时：
+
+- 立即以最新 `state.transcriptionText` 为准；
+- 不保留已被 ASR 替换的旧字符；
+- 如果修正后文本变短但仍溢出，继续显示最新尾部；
+- 如果修正后文本重新短于 viewport，恢复左对齐。
+
+不使用类似 Regular `recordingPeakWidth` 的 high-water mark，因为 Compact 宽度始终固定。
+
+## 9. Phase 行为
+
+### Preparing
+
+Live Transcript On：
+
+```text
+180 × 48
+上层空白 transcript lane
+下层 controls + idle waveform
+```
+
+Live Transcript Off：
+
+```text
+180 × 24
+controls + idle waveform
+```
+
+### Recording
+
+Live Transcript On：
+
+```text
+180 × 48
+上层实时识别文字
+下层 controls + dynamic waveform
+```
+
+Live Transcript Off：维持 180 × 24。
+
+### Processing / Recovering / Done / Error
+
+无论 Live Transcript On / Off：
+
+- 不显示 transcript lane；
+- 高度恢复为 24pt；
+- 宽度继续沿用当前 Compact status intrinsic-width 策略；
+- 不回退 Regular renderer。
+
+因此典型 transition 为：
+
+```text
+Recording  180 × 48
+    ↓ Finish
+Processing intrinsic(content) × 24
+    ↓
+Done       intrinsic(content) × 24
+```
+
+## 10. Tooltips 与按钮
+
+现有 Compact 模式提示和按钮悬停提示继续保留。
+
+Live Transcript 开启后：
+
+- mode hint 仍位于整个 48pt capsule 上方；
+- Finish / Cancel tooltip 仍然水平对齐底部两个 control 的中心；
+- tooltip 的 vertical positioning 以新的 capsule height 计算；
+- transcript lane 本身不响应 hover，不触发 Transcript Popup。
+
+## 11. Show Cancel Button
+
+当 `Show Cancel Button = Off`：
+
+- Compact width 仍然固定 180pt；
+- Live Transcript On 时仍为 180 × 48；
+- 上层 transcript viewport 不因为 Cancel 隐藏而改变宽度；
+- 下层继续使用当前单按钮 Compact 布局策略；
+- Esc 取消能力保持不变。
+
+## 12. 无实时 Partial 的 ASR 场景
+
+如果当前 ASR pipeline 在录音阶段不产生 realtime partial：
+
+- Live Transcript 设置仍保持启用状态；
+- 不伪造识别文本；
+- transcript lane 在录音期间可以保持空白；
+- 不使用 placeholder 代替 ASR 内容。
+
+第一版不因为 provider 能力动态隐藏 transcript lane，避免同一设置产生不可预测的高度变化。
+
+后续如需要，可单独设计 provider-capability-aware fallback。
+
+## 13. Appearance Preview
+
+Settings Preview 必须真实展示 Compact Live Transcript。
+
+### Compact + Live Transcript On
+
+Recording Preview：
+
+- 180 × 48；
+- 上方使用现有长 sample transcript；
+- sample 足够长，能够直观看到 follow-tail 溢出状态；
+- 下方 synthetic audio 持续驱动 waveform。
+
+### Compact + Live Transcript Off
+
+Recording Preview：180 × 24，不显示文本行。
+
+### Processing Preview
+
+继续显示现有 24pt Compact processing status，不保留 transcript lane。
+
+## 14. 可访问性
+
+实时文字 lane：
+
+- accessibility label 暴露完整的当前 transcript；
+- 视觉裁切或滚动不能影响辅助功能读取完整内容；
+- transcript lane 不声明 button / text field 等可交互 trait；
+- Finish / Cancel 继续保持现有 accessibility action。
+
+## 15. 兼容性
+
+### UserDefaults
+
+不增加新的持久化 key。
+
+继续使用：
+
+```text
+tf_recordingIndicatorStyle
+tf_showLiveTranscript
+tf_showTooltips
+tf_showCancelButton
+```
+
+### 用户行为变化
+
+此前 Compact 会忽略 `tf_showLiveTranscript`。
+
+本功能上线后，如果用户：
+
+```text
+Indicator Style = Compact
+Live Transcript = On
+```
+
+录音态将变为 180 × 48。
+
+这是有意的语义修正：既有 Live Transcript preference 开始同时控制 Regular 与 Compact。
+
+如果用户希望保持原来的最小 Compact，可关闭 Live Transcript，恢复 180 × 24。
+
+## 16. 验收场景
+
+### 16.1 Compact + Live Transcript Off
+
+- Preparing / Recording 始终 180 × 24；
+- 行为与当前 Compact 一致；
+- 无 transcript lane。
+
+### 16.2 Compact + Live Transcript On
+
+- Preparing / Recording 始终 180 × 48；
+- 下方 controls / waveform 几何不变；
+- 上方显示 12pt transcript；
+- 没有识别文字时上层为空白。
+
+### 16.3 短文本
+
+例如：
+
+```text
+你好，这是测试
+```
+
+- 从左边开始显示；
+- 不居中；
+- 不发生水平滚动。
+
+### 16.4 长文本
+
+当文字到达右边界：
+
+- 开始向左移动；
+- 最新文字保持在右侧可见；
+- 左侧可出现轻微 fade；
+- 整个 capsule width 始终 180pt。
+
+### 16.5 ASR 修正
+
+- partial 被修正时界面立即反映最新文本；
+- 被替换的旧文本不继续残留；
+- 文本缩短到 viewport 内时恢复左对齐。
+
+### 16.6 Phase Transition
+
+Finish 后：
+
+- 48pt transcript lane 消失；
+- Processing 高度变回 24pt；
+- Processing / Done / Error 继续使用 Compact；
+- 不出现 Regular 55pt UI。
+
+### 16.7 Settings / Preview
+
+- Compact 下可以直接开关 Live Transcript；
+- Recording Visual / Hover Text Preview 仍只属于 Regular；
+- Preview 与真实 Floating Bar 行为一致；
+- 开关 Live Transcript 后 Preview 高度立即从 24 ↔ 48 更新。
+
+## 17. 产品决策汇总
+
+| 项目 | 决策 |
+|---|---|
+| 功能 | Compact 内嵌 Live Transcript |
+| Preference | 复用现有 `tf_showLiveTranscript` |
+| Compact Live On | Preparing / Recording = 180 × 48 |
+| Compact Live Off | Preparing / Recording = 180 × 24 |
+| Transcript lane | 24pt 高 |
+| Controls lane | 24pt 高，保持现状 |
+| Transcript font | 12pt Medium |
+| Width | 固定 180pt，不随 transcript 变化 |
+| 初始文本 | leading aligned |
+| 未溢出 | 不滚动 |
+| 溢出后 | follow-tail，最新内容保持可见 |
+| 左侧 overflow | 可使用约 10pt fade mask |
+| 右侧 overflow | 不使用 fade |
+| Empty state | 空白，不显示 Listening placeholder |
+| Transcript Popup | Compact 不支持 |
+| Tooltips | 保持现有 Compact 行为 |
+| Processing / Result | 继续 24pt Compact status |
+| New storage key | 无 |
+| Existing Compact docs | 不修改，本文独立维护 |


### PR DESCRIPTION
## Overview
Implements embedded live transcript for the Compact recording indicator style in Type4Me, allowing users who prefer the compact indicator to view real-time ASR text streaming while preserving the 180pt width footprint.

<p align="center">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/f231b4a7-80da-473b-9326-1d270af9e8e7" />
</p>

## Changes
- **Design Tokens**: Added `compactTranscriptLaneHeight` (24pt), `compactTranscriptExpandedHeight` (48pt), `compactTranscriptFontSize` (12pt), `compactTranscriptCornerRadius` (10pt), `compactTranscriptHorizontalInset` (8pt), and `compactTranscriptLeadingFadeWidth` (10pt).
- **Component**: Created `CompactLiveTranscriptRow` rendering 12pt medium live text with pure-function `compactTranscriptOffset` for follow-tail alignment and subtle leading fade mask when overflowing.
- **Floating Bar Geometry**:
  - Compact recording capsule expands from 24pt to 48pt height when live transcript is enabled, adopting 10pt corner radius.
  - Automatically shrinks back to 24pt (pill shape) during processing, done, error, or when live transcript is toggled off.
- **Panel Fallback & Preview Fixes**:
  - Updated `FloatingBarPanelLayout.fallback(for:showsLiveTranscript:)` to match the 48pt height contract immediately on first show, preventing jump/clipping.
  - Fixed preview placeholder centering when live transcript is toggled off.
  - Fixed dynamic capsule width expansion when switching from Compact back to Regular style.
- **Settings UI**: Unlocked the Live Transcript toggle in Settings > Appearance for both Compact and Regular styles.

## Design Documents
- `docs/features/compact-live-transcript/product-design.md`
- `docs/features/compact-live-transcript/development-design.md`

## Verification
- Added comprehensive unit tests in `AppearancePreviewTests.swift` and `AppStateTests.swift`.
- All 862 automated tests passed (0 failures, 2 skipped).
- Verified on macOS in both Appearance preview and live recording.