### PR TITLE
feat: support Gemini 3.5 Transcribe streaming ASR provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 macOS menu bar voice input tool with dual-engine local ASR, multi-provider cloud ASR, and LLM post-processing.
 Local ASR: SenseVoice via native sherpa-onnx (streaming) + Qwen3-ASR (final calibration, Python WebSocket service managed by `SenseVoiceServerManager`).
-Cloud ASR: 12 providers implemented (Volcano, StepFun batch, MiMo batch, OpenAI, Deepgram, Cartesia, AssemblyAI, ElevenLabs, Grok, Soniox, Bailian, Baidu), plus Apple Speech.
+Cloud ASR: 13 providers implemented (Volcano, StepFun batch, MiMo batch, OpenAI, Deepgram, Cartesia, AssemblyAI, ElevenLabs, Gemini, Grok, Soniox, Bailian, Baidu), plus Apple Speech.
 Swift Package Manager project, no Xcode project file. Optional `sherpa-onnx.xcframework` enables local SenseVoice, Silero VAD, and punctuation restoration.
 
 ## Branch Naming and Lifecycle
@@ -148,10 +148,10 @@ All subscription/cloud-proxy code lives in `Type4Me/CloudSubscription/`. Main co
 
 Multi-provider ASR support via `ASRProvider` enum + `ASRProviderConfig` protocol + `ASRProviderRegistry`.
 
-- `ASRProvider` enum: 21 standard cases (`sherpa`, `apple`, international and China cloud providers, and `custom`), plus conditional `cloud` when `HAS_CLOUD_SUBSCRIPTION` is enabled.
+- `ASRProvider` enum: 22 standard cases (`sherpa`, `apple`, international and China cloud providers, and `custom`), plus conditional `cloud` when `HAS_CLOUD_SUBSCRIPTION` is enabled.
 - Each provider has its own Config type (e.g., `SherpaASRConfig`, `VolcanoASRConfig`) defining `credentialFields` for dynamic UI rendering
 - `ASRProviderRegistry`: maps provider to config type + client factory; `capabilities` indicates availability and streaming support
-- **Fully implemented**: Apple Speech (streaming); Volcano, Deepgram, Cartesia, AssemblyAI, ElevenLabs, Grok, Soniox, Bailian, and Baidu (streaming); StepFun, MiMo, and OpenAI (batch); and Sherpa/SenseVoice when `HAS_SHERPA_ONNX` is enabled.
+- **Fully implemented**: Apple Speech (streaming); Volcano, Deepgram, Cartesia, AssemblyAI, ElevenLabs, Gemini, Grok, Soniox, Bailian, and Baidu (streaming); StepFun, MiMo, and OpenAI (batch); and Sherpa/SenseVoice when `HAS_SHERPA_ONNX` is enabled.
 - **Config only (no client)**: azure, google, aws, aliyun, tencent, iflytek, custom
 
 ### Adding a New Provider
@@ -235,6 +235,9 @@ API keys and other secure values are stored in Keychain, not in this file.
 | `Type4Me/ASR/VolcASRClient.swift` | Cloud streaming ASR (Volcano, WebSocket) |
 | `Type4Me/ASR/DeepgramASRClient.swift` | Cloud streaming ASR (Deepgram, WebSocket) |
 | `Type4Me/ASR/ElevenLabsASRClient.swift` | Cloud streaming ASR (ElevenLabs Scribe v2, WebSocket) |
+| `Type4Me/ASR/GeminiASRClient.swift` | Cloud streaming ASR (Gemini Live API, model selectable) |
+| `Type4Me/Protocol/GeminiTranscribeProtocol.swift` | Gemini Live wire format: setup/audio messages, response parsing |
+| `Type4Me/ASR/GeminiConnectionGate.swift` | Gemini connection gate, close tracker, WebSocket delegate |
 | `Type4Me/ASR/OpenAIASRClient.swift` | Cloud batch ASR (OpenAI, REST) |
 | `Type4Me/ASR/MiMoASRClient.swift` | Cloud batch ASR (Xiaomi MiMo, REST/SSE) |
 | `Type4Me/ASR/SherpaPunctuationProcessor.swift` | Optional punctuation restoration (SherpaOnnx) |

--- a/README.md
+++ b/README.md
@@ -1528,7 +1528,7 @@ For non-Dev packaging, a signing identity can be supplied explicitly with
 
 - **Swift Package Manager** project, no `.xcodeproj` needed
 - **Local ASR**: dual-engine design. SenseVoice (streaming partial results) + Qwen3-ASR (final calibration via MLX/Metal). Both run as Python WebSocket servers managed by `SenseVoiceServerManager`
-- **Cloud ASR**: 12 providers implemented (Volcano, StepFun batch, MiMo batch, OpenAI, Deepgram, Cartesia, AssemblyAI, ElevenLabs, Grok, Soniox, Bailian, Baidu)
+- **Cloud ASR**: 13 providers implemented (Volcano, StepFun batch, MiMo batch, OpenAI, Deepgram, Cartesia, AssemblyAI, ElevenLabs, Gemini, Grok, Soniox, Bailian, Baidu)
 - **Credentials**: stored at `~/Library/Application Support/Type4Me/credentials.json` (mode 0600), never in code or environment variables. GUI apps cannot read shell env vars from `~/.zshrc`
 - **ASR provider architecture**: plugin-based. To add a new provider: implement `ASRProviderConfig` + `SpeechRecognizer` protocol, register in `ASRProviderRegistry.all`. See `AGENTS.md` for details
 - **Audio format**: 16kHz mono PCM16-LE, 200ms chunks (6400 bytes)

--- a/Type4Me/ASR/ASRProvider.swift
+++ b/Type4Me/ASR/ASRProvider.swift
@@ -15,6 +15,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
     case cartesia
     case assemblyai
     case elevenlabs
+    case gemini
     case grok
     case soniox
     // China
@@ -45,6 +46,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
         case .cartesia: return "Cartesia"
         case .assemblyai: return "AssemblyAI"
         case .elevenlabs: return "ElevenLabs"
+        case .gemini:   return "Gemini"
         case .grok:     return "Grok"
         case .soniox:   return "Soniox"
         case .volcano:  return L("火山引擎 (Doubao)", "Volcano (Doubao)")

--- a/Type4Me/ASR/ASRProviderRegistry.swift
+++ b/Type4Me/ASR/ASRProviderRegistry.swift
@@ -117,6 +117,11 @@ enum ASRProviderRegistry {
                 createClient: { ElevenLabsASRClient() },
                 capabilities: .streaming()
             ),
+            .gemini: ProviderEntry(
+                configType: GeminiASRConfig.self,
+                createClient: { GeminiASRClient() },
+                capabilities: .streaming()
+            ),
             .grok: ProviderEntry(
                 configType: GrokASRConfig.self,
                 createClient: { GrokASRClient() },

--- a/Type4Me/ASR/GeminiASRClient.swift
+++ b/Type4Me/ASR/GeminiASRClient.swift
@@ -1,0 +1,347 @@
+import Foundation
+import os
+
+enum GeminiASRError: Error, LocalizedError, Equatable {
+    case unsupportedProvider
+    case invalidConfig
+    case invalidEndpoint
+    case handshakeTimedOut
+    case setupTimedOut
+    case setupRejected(String?)
+    case emptyAudio
+    case closedBeforeSetup(code: Int, reason: String?)
+    case closed(code: Int, reason: String?)
+    case quotaExceeded(String?)
+    case sessionLimitReached
+    case invalidResponse
+    case serverError(code: Int?, message: String?)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedProvider:
+            return L("Gemini 识别配置无效", "GeminiASRClient requires GeminiASRConfig")
+        case .invalidConfig:
+            return L("Gemini 识别配置无效", "Gemini ASR configuration is invalid")
+        case .invalidEndpoint:
+            return L("Gemini WebSocket 地址无效", "Invalid Gemini WebSocket URL")
+        case .handshakeTimedOut:
+            return L("Gemini 握手超时", "Gemini WebSocket handshake timed out")
+        case .setupTimedOut:
+            return L("Gemini 初始化超时", "Gemini Transcribe setup timed out")
+        case .setupRejected(let msg):
+            if let msg, !msg.isEmpty {
+                return L("Gemini 初始化失败：\(msg)", "Gemini Transcribe setup rejected: \(msg)")
+            }
+            return L("Gemini 初始化失败", "Gemini Transcribe setup rejected")
+        case .emptyAudio:
+            return L("没有录到有效音频", "No valid audio recorded")
+        case .closedBeforeSetup(let code, let reason):
+            if let reason, !reason.isEmpty {
+                return L("Gemini 连接在初始化完成前关闭（\(code)）：\(reason)", "Gemini WebSocket closed before setup (\(code)): \(reason)")
+            }
+            return L("Gemini 连接在初始化完成前关闭（\(code)）", "Gemini WebSocket closed before setup (\(code))")
+        case .closed(let code, let reason):
+            if let reason, !reason.isEmpty {
+                return L("Gemini 连接意外关闭（\(code)）：\(reason)", "Gemini WebSocket closed unexpectedly (\(code)): \(reason)")
+            }
+            return L("Gemini 连接意外关闭（\(code)）", "Gemini WebSocket closed unexpectedly (\(code))")
+        case .quotaExceeded(let msg):
+            if let msg, !msg.isEmpty {
+                return L("当前项目达到 Gemini API 配额限制（\(msg)）", "Gemini API quota exceeded: \(msg)")
+            }
+            return L("当前项目达到 Gemini API 配额限制，请稍后重试或检查额度", "Gemini API quota exceeded or rate limited. Please try again later or check your quota.")
+        case .sessionLimitReached:
+            return L("Gemini 单次实时识别最长约 10 分钟，请缩短录音", "Gemini live transcription session limit reached (~10 min). Please keep recordings shorter.")
+        case .invalidResponse:
+            return L("Gemini 返回了无法解析的识别结果", "Gemini returned an invalid response")
+        case .serverError(let code, let msg):
+            let desc = msg ?? L("未知错误", "Unknown error")
+            if let code {
+                return L("Gemini 服务端错误（\(code)）：\(desc)", "Gemini server error (\(code)): \(desc)")
+            }
+            return L("Gemini 服务端错误：\(desc)", "Gemini server error: \(desc)")
+        }
+    }
+
+    /// Maps a WebSocket close frame to an error, or `nil` when the close is a
+    /// benign end-of-stream. Gemini Live surfaces most failures (quota, session
+    /// limit, internal errors) as close frames rather than JSON error payloads,
+    /// so this is the primary failure channel once setup has completed.
+    static func unexpectedClose(
+        code: URLSessionWebSocketTask.CloseCode,
+        reason: String?
+    ) -> GeminiASRError? {
+        switch code {
+        case .normalClosure, .goingAway, .noStatusReceived:
+            return nil
+        default:
+            if isSessionLimitReason(reason) {
+                return .sessionLimitReached
+            }
+            return .closed(code: Int(code.rawValue), reason: reason)
+        }
+    }
+
+    private static func isSessionLimitReason(_ reason: String?) -> Bool {
+        guard let reason, !reason.isEmpty else { return false }
+        let lowered = reason.lowercased()
+        let sessionMarkers = ["session", "duration", "connection"]
+        let limitMarkers = ["limit", "exceed", "too long", "maximum", "max "]
+        return sessionMarkers.contains { lowered.contains($0) }
+            && limitMarkers.contains { lowered.contains($0) }
+    }
+}
+
+actor GeminiASRClient: SpeechRecognizer {
+
+    private let logger = Logger(subsystem: "com.type4me.asr", category: "GeminiASRClient")
+
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var receiveTask: Task<Void, Never>?
+    private var sessionTimerTask: Task<Void, Never>?
+    private var session: URLSession?
+    private var sessionDelegate: GeminiWebSocketDelegate?
+    private var connectionGate: GeminiConnectionGate?
+    private var closeTracker: GeminiCloseTracker?
+
+    private var eventContinuation: AsyncStream<RecognitionEvent>.Continuation?
+    private var _events: AsyncStream<RecognitionEvent>?
+
+    private var confirmedSegments: [String] = []
+    private var lastTranscript: RecognitionTranscript = .empty
+    private var residualAudio = Data()
+    private var didStartActivity = false
+    private var didEndAudio = false
+    private var didEmitFinal = false
+    private var audioPayloadCount = 0
+    private var connectDate: Date?
+
+    var events: AsyncStream<RecognitionEvent> {
+        if let existing = _events { return existing }
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        eventContinuation = continuation
+        _events = stream
+        return stream
+    }
+
+    func connect(config: any ASRProviderConfig, options: ASRRequestOptions = ASRRequestOptions()) async throws {
+        guard let geminiConfig = config as? GeminiASRConfig else {
+            throw GeminiASRError.unsupportedProvider
+        }
+
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        eventContinuation = continuation
+        _events = stream
+
+        let url = try GeminiTranscribeProtocol.buildWebSocketURL(config: geminiConfig, options: options)
+        logger.info("Connecting Gemini WebSocket: \(GeminiTranscribeProtocol.redactedURLString(for: url), privacy: .public)")
+
+        let request = URLRequest(url: url)
+        let gate = GeminiConnectionGate()
+        let tracker = GeminiCloseTracker()
+        let delegate = GeminiWebSocketDelegate(gate: gate, closeTracker: tracker)
+        let session = URLSession(configuration: options.urlSessionConfiguration, delegate: delegate, delegateQueue: nil)
+        let task = session.webSocketTask(with: request)
+        task.resume()
+
+        self.connectionGate = gate
+        self.closeTracker = tracker
+        self.sessionDelegate = delegate
+        self.session = session
+        self.webSocketTask = task
+        self.confirmedSegments = []
+        self.lastTranscript = .empty
+        self.residualAudio.removeAll()
+        self.didStartActivity = false
+        self.didEndAudio = false
+        self.didEmitFinal = false
+        self.audioPayloadCount = 0
+        self.connectDate = Date()
+
+        try await gate.waitUntilOpen(timeout: .seconds(5))
+        startReceiveLoop()
+
+        let setupMessage = try GeminiTranscribeProtocol.setupMessage(config: geminiConfig, options: options)
+        try await task.send(.string(setupMessage))
+
+        try await gate.waitUntilSetupComplete(timeout: .seconds(5))
+        logger.info("Gemini WebSocket setup complete and ready")
+
+        startSessionLimitMonitor()
+        emitEvent(.ready)
+    }
+
+    func sendAudio(_ data: Data) async throws {
+        guard let task = webSocketTask, !data.isEmpty else { return }
+
+        residualAudio.append(data)
+
+        if !didStartActivity && !residualAudio.isEmpty {
+            try await task.send(.string(GeminiTranscribeProtocol.activityStartMessage()))
+            didStartActivity = true
+        }
+
+        let payloads = GeminiTranscribeProtocol.sliceAudioPayloads(from: &residualAudio)
+        var batchCount = 0
+        for payload in payloads {
+            try await task.send(.string(GeminiTranscribeProtocol.audioChunkMessage(payload)))
+            audioPayloadCount += 1
+            batchCount += 1
+            if batchCount > 2 {
+                await Task.yield()
+            }
+        }
+    }
+
+    func endAudio() async throws {
+        guard let task = webSocketTask else { return }
+
+        if let flushed = GeminiTranscribeProtocol.flushResidualAudio(from: &residualAudio) {
+            if !didStartActivity {
+                try await task.send(.string(GeminiTranscribeProtocol.activityStartMessage()))
+                didStartActivity = true
+            }
+            try await task.send(.string(GeminiTranscribeProtocol.audioChunkMessage(flushed)))
+            audioPayloadCount += 1
+        }
+
+        // If no audio was sent during this session, silently return without throwing (see §16.1)
+        guard didStartActivity else {
+            return
+        }
+
+        didEndAudio = true
+        try await task.send(.string(GeminiTranscribeProtocol.activityEndMessage()))
+    }
+
+    func disconnect() {
+        receiveTask?.cancel()
+        receiveTask = nil
+        sessionTimerTask?.cancel()
+        sessionTimerTask = nil
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        webSocketTask = nil
+        session?.invalidateAndCancel()
+        session = nil
+        sessionDelegate = nil
+        eventContinuation?.finish()
+        eventContinuation = nil
+        _events = nil
+        connectionGate = nil
+        closeTracker = nil
+        confirmedSegments = []
+        lastTranscript = .empty
+        residualAudio.removeAll()
+        didStartActivity = false
+        didEndAudio = false
+        didEmitFinal = false
+        audioPayloadCount = 0
+        connectDate = nil
+        logger.info("Gemini disconnected")
+    }
+
+    // MARK: - Receive Loop
+
+    private func startReceiveLoop() {
+        receiveTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                do {
+                    guard let task = await self.webSocketTask else { break }
+                    let message = try await task.receive()
+                    await self.handleMessage(message)
+                } catch {
+                    if Task.isCancelled { break }
+                    logger.info("Gemini receive loop ended: \(String(describing: error), privacy: .public)")
+                    if let gate = await self.connectionGate, await !gate.isReady {
+                        await gate.markFailure(error)
+                    }
+
+                    // Any termination that did not deliver a final transcript is a
+                    // failure, even when it arrives as a WebSocket close frame after
+                    // setup completed. Reporting `.completed` alone here would make
+                    // RecognitionSession treat a truncated partial as the finished
+                    // result: no recovery, no batch fallback, no user-visible error.
+                    let didEmitFinal = await self.didEmitFinal
+                    var closeError = await self.closeTracker?.consumeCloseError()
+                    if closeError == nil && !didEmitFinal {
+                        // The URLSession close delegate races with receive()
+                        // throwing. Wait briefly so the specific close reason
+                        // (quota, session limit) wins over the raw transport
+                        // error. Bounded and off the stopRecording() budget.
+                        try? await Task.sleep(for: .milliseconds(50))
+                        closeError = await self.closeTracker?.consumeCloseError()
+                    }
+
+                    if let closeError {
+                        logger.error("Gemini stream closed abnormally: \(String(describing: closeError), privacy: .public)")
+                        await self.emitEvent(.error(closeError))
+                    } else if !didEmitFinal {
+                        await self.emitEvent(.error(error))
+                    }
+                    await self.emitEvent(.completed)
+                    break
+                }
+            }
+            await self.eventContinuation?.finish()
+        }
+    }
+
+    private func handleMessage(_ message: URLSessionWebSocketTask.Message) {
+        do {
+            let data: Data
+            switch message {
+            case .data(let d): data = d
+            case .string(let s): data = Data(s.utf8)
+            @unknown default: return
+            }
+
+            if let update = try GeminiTranscribeProtocol.makeTranscriptUpdate(
+                from: data,
+                confirmedSegments: confirmedSegments,
+                didEndAudio: didEndAudio
+            ) {
+                if update.isSetupComplete {
+                    Task { await connectionGate?.markSetupComplete() }
+                    return
+                }
+
+                // Dedup before mutating state: applying `confirmedSegments`
+                // first would let an identical repeated final append twice
+                // while the transcript comparison below still saw a change.
+                guard update.transcript != lastTranscript else { return }
+                confirmedSegments = update.confirmedSegments
+                lastTranscript = update.transcript
+
+                logger.info("Gemini transcript update confirmed=\(update.transcript.confirmedSegments.count) partial=\(update.transcript.partialText.count) final=\(update.transcript.isFinal)")
+                emitEvent(.transcript(update.transcript))
+
+                if update.transcript.isFinal && didEndAudio {
+                    didEmitFinal = true
+                    emitEvent(.completed)
+                    eventContinuation?.finish()
+                }
+            }
+        } catch {
+            logger.error("Gemini decode or server error: \(String(describing: error), privacy: .public)")
+            if let gate = connectionGate {
+                Task { await gate.markFailure(error) }
+            }
+            emitEvent(.error(error))
+        }
+    }
+
+    private func startSessionLimitMonitor() {
+        sessionTimerTask?.cancel()
+        sessionTimerTask = Task { [weak self] in
+            // 9 minutes and 30 seconds = 570 seconds
+            try? await Task.sleep(for: .seconds(570))
+            guard !Task.isCancelled, let self else { return }
+            logger.warning("Gemini live transcription session approaching 10-minute limit")
+        }
+    }
+
+    private func emitEvent(_ event: RecognitionEvent) {
+        eventContinuation?.yield(event)
+    }
+}

--- a/Type4Me/ASR/GeminiConnectionGate.swift
+++ b/Type4Me/ASR/GeminiConnectionGate.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+actor GeminiConnectionGate {
+    private var openContinuation: CheckedContinuation<Void, Error>?
+    private var setupContinuation: CheckedContinuation<Void, Error>?
+    private(set) var isOpen = false
+    private(set) var isSetupComplete = false
+    private var failure: Error?
+
+    var hasOpened: Bool { isOpen }
+    var isReady: Bool { isSetupComplete }
+
+    func waitUntilOpen(timeout: Duration = .seconds(5)) async throws {
+        if isOpen { return }
+        if let failure { throw failure }
+
+        let timeoutTask = Task {
+            do {
+                try await Task.sleep(for: timeout)
+                self.markFailure(GeminiASRError.handshakeTimedOut)
+            } catch {
+                // Task was cancelled before timeout expired
+            }
+        }
+        defer { timeoutTask.cancel() }
+
+        try await withCheckedThrowingContinuation { self.openContinuation = $0 }
+    }
+
+    func waitUntilSetupComplete(timeout: Duration = .seconds(5)) async throws {
+        if isSetupComplete { return }
+        if let failure { throw failure }
+
+        let timeoutTask = Task {
+            do {
+                try await Task.sleep(for: timeout)
+                self.markFailure(GeminiASRError.setupTimedOut)
+            } catch {
+                // Task was cancelled before timeout expired
+            }
+        }
+        defer { timeoutTask.cancel() }
+
+        try await withCheckedThrowingContinuation { self.setupContinuation = $0 }
+    }
+
+    func markOpen() {
+        guard !isOpen else { return }
+        isOpen = true
+        openContinuation?.resume()
+        openContinuation = nil
+    }
+
+    func markSetupComplete() {
+        guard !isSetupComplete else { return }
+        isSetupComplete = true
+        setupContinuation?.resume()
+        setupContinuation = nil
+    }
+
+    func markFailure(_ error: Error) {
+        guard failure == nil else { return }
+        failure = error
+
+        if !isOpen {
+            openContinuation?.resume(throwing: error)
+            openContinuation = nil
+        }
+        if !isSetupComplete {
+            setupContinuation?.resume(throwing: error)
+            setupContinuation = nil
+        }
+    }
+}
+
+/// Records the first abnormal termination seen after the WebSocket is live so
+/// the receive loop can report it instead of treating the stream as complete.
+actor GeminiCloseTracker {
+
+    private var closeError: Error?
+
+    func recordClose(
+        code: URLSessionWebSocketTask.CloseCode,
+        reason: String?
+    ) {
+        guard closeError == nil,
+              let error = GeminiASRError.unexpectedClose(code: code, reason: reason)
+        else { return }
+        closeError = error
+    }
+
+    func recordFailure(_ error: Error) {
+        guard closeError == nil else { return }
+        closeError = error
+    }
+
+    func consumeCloseError() -> Error? {
+        defer { closeError = nil }
+        return closeError
+    }
+}
+
+final class GeminiWebSocketDelegate: NSObject, URLSessionWebSocketDelegate, URLSessionTaskDelegate, @unchecked Sendable {
+
+    private let gate: GeminiConnectionGate
+    private let closeTracker: GeminiCloseTracker
+
+    init(gate: GeminiConnectionGate, closeTracker: GeminiCloseTracker) {
+        self.gate = gate
+        self.closeTracker = closeTracker
+    }
+
+    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
+        Task { await gate.markOpen() }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let error else { return }
+        Task {
+            await closeTracker.recordFailure(error)
+            await gate.markFailure(error)
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
+        reason: Data?
+    ) {
+        let reasonText = reason.flatMap { String(data: $0, encoding: .utf8) }
+        Task {
+            let isReady = await gate.isReady
+            if isReady {
+                // Post-setup closes must not be silently treated as a clean
+                // end-of-stream: record them so the receive loop can report
+                // the failure and let the session recover the audio.
+                await closeTracker.recordClose(code: closeCode, reason: reasonText)
+            } else {
+                await gate.markFailure(
+                    GeminiASRError.closedBeforeSetup(
+                        code: Int(closeCode.rawValue),
+                        reason: reasonText
+                    )
+                )
+            }
+        }
+    }
+}

--- a/Type4Me/ASR/Providers/GeminiASRConfig.swift
+++ b/Type4Me/ASR/Providers/GeminiASRConfig.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+enum GeminiTranscriptionMode: String, Sendable, CaseIterable {
+    case smart = "SMART"
+    case verbatim = "VERBATIM"
+}
+
+struct GeminiASRConfig: ASRProviderConfig, Sendable {
+
+    static let provider = ASRProvider.gemini
+    static let displayName = "Gemini"
+
+    /// Models exposed under the Gemini provider. Add new entries here as Google
+    /// ships more transcription models; the provider itself stays "Gemini".
+    static let supportedModels: [(id: String, label: String)] = [
+        ("gemini-3.5-transcribe-live", "Gemini 3.5 Transcribe (Live)"),
+    ]
+    static let defaultModel = "gemini-3.5-transcribe-live"
+
+    static let webSocketBaseURL = "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
+
+    static let defaultMode: GeminiTranscriptionMode = .smart
+    static let defaultLanguage = "auto"
+
+    static var credentialFields: [CredentialField] {[
+        CredentialField(
+            key: "apiKey",
+            label: L("API Key", "API Key"),
+            placeholder: L("粘贴 API Key", "Paste your API Key"),
+            isSecure: true,
+            isOptional: false,
+            defaultValue: ""
+        ),
+        CredentialField(
+            key: "model",
+            label: L("模型", "Model"),
+            placeholder: defaultModel,
+            isSecure: false,
+            isOptional: true,
+            defaultValue: defaultModel,
+            options: supportedModels.map { FieldOption(value: $0.id, label: $0.label) },
+            allowCustomInput: true
+        ),
+        CredentialField(
+            key: "mode",
+            label: L("转写模式", "Transcription Mode"),
+            placeholder: "",
+            isSecure: false,
+            isOptional: true,
+            defaultValue: "SMART",
+            options: [
+                FieldOption(value: "SMART", label: L("智能整理", "Smart")),
+                FieldOption(value: "VERBATIM", label: L("逐字转写", "Verbatim")),
+            ]
+        ),
+        CredentialField(
+            key: "languageCode",
+            label: L("语言提示", "Language Hint"),
+            placeholder: L("BCP-47，例如 en-US", "BCP-47, e.g. en-US"),
+            isSecure: false,
+            isOptional: true,
+            defaultValue: "auto",
+            options: [
+                FieldOption(value: "auto", label: L("自动检测", "Auto Detect")),
+                FieldOption(value: "cmn-Hans-CN", label: L("中文（普通话）", "Mandarin Chinese")),
+                FieldOption(value: "yue-Hant-HK", label: L("粤语", "Cantonese")),
+                FieldOption(value: "en-US", label: "English (US)"),
+                FieldOption(value: "ja-JP", label: "日本語"),
+                FieldOption(value: "ko-KR", label: "한국어"),
+            ],
+            allowCustomInput: true
+        ),
+    ]}
+
+    let apiKey: String
+    let model: String
+    let mode: GeminiTranscriptionMode
+    let languageCode: String
+
+    init?(credentials: [String: String]) {
+        guard let apiKey = credentials["apiKey"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !apiKey.isEmpty
+        else { return nil }
+
+        let rawModel = credentials["model"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let model = rawModel.isEmpty ? Self.defaultModel : rawModel
+
+        let rawMode = credentials["mode"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let mode = GeminiTranscriptionMode(rawValue: rawMode.uppercased()) ?? Self.defaultMode
+
+        let rawLanguage = credentials["languageCode"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let languageCode = rawLanguage.isEmpty ? Self.defaultLanguage : rawLanguage
+
+        self.apiKey = apiKey
+        self.model = model
+        self.mode = mode
+        self.languageCode = languageCode
+    }
+
+    func toCredentials() -> [String: String] {
+        [
+            "apiKey": apiKey,
+            "model": model,
+            "mode": mode.rawValue,
+            "languageCode": languageCode,
+        ]
+    }
+
+    var isValid: Bool {
+        !apiKey.isEmpty
+    }
+}

--- a/Type4Me/Protocol/GeminiTranscribeProtocol.swift
+++ b/Type4Me/Protocol/GeminiTranscribeProtocol.swift
@@ -1,0 +1,331 @@
+import Foundation
+
+enum GeminiProtocolError: Error, LocalizedError, Equatable {
+    case invalidEndpoint
+    case invalidJSON
+    case serverError(code: Int?, message: String?)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidEndpoint:
+            return L("Gemini WebSocket 地址无效", "Invalid Gemini WebSocket URL")
+        case .invalidJSON:
+            return L("Gemini 消息格式错误", "Invalid Gemini JSON message")
+        case .serverError(let code, let message):
+            let msg = message ?? L("未知错误", "Unknown error")
+            if let code {
+                return L("Gemini 服务端错误（\(code)）：\(msg)", "Gemini server error (\(code)): \(msg)")
+            }
+            return L("Gemini 服务端错误：\(msg)", "Gemini server error: \(msg)")
+        }
+    }
+}
+
+struct GeminiTranscriptUpdate: Sendable, Equatable {
+    let transcript: RecognitionTranscript
+    let confirmedSegments: [String]
+    let isSetupComplete: Bool
+}
+
+enum GeminiTranscribeProtocol {
+
+    static let defaultEndpoint = "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
+    static let sampleRate = 16000
+    static let targetFramesPerPayload = 1600
+    static let bytesPerSample = 2
+    static let targetPayloadBytes = 3200 // 1600 frames * 2 bytes = 3200 bytes (~100ms)
+    static let maxCustomVocabularyCount = 1000
+
+    // MARK: - URL Construction
+
+    static func buildWebSocketURL(config: GeminiASRConfig, options: ASRRequestOptions = ASRRequestOptions()) throws -> URL {
+        let baseURLString = GeminiASRConfig.webSocketBaseURL
+        guard var components = URLComponents(string: baseURLString) else {
+            throw GeminiProtocolError.invalidEndpoint
+        }
+
+        components.queryItems = [
+            URLQueryItem(name: "key", value: config.apiKey)
+        ]
+
+        guard let url = components.url else {
+            throw GeminiProtocolError.invalidEndpoint
+        }
+        return url
+    }
+
+    /// Returns a redacted URL string safe for logging (without the API key).
+    static func redactedURLString(for url: URL) -> String {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return "wss://generativelanguage.googleapis.com/... (redacted)"
+        }
+        if components.queryItems?.contains(where: { $0.name == "key" }) == true {
+            components.queryItems = [URLQueryItem(name: "key", value: "REDACTED")]
+        }
+        return components.string ?? "wss://generativelanguage.googleapis.com/... (redacted)"
+    }
+
+    // MARK: - Outbound Messages
+
+    /// Gemini expects a fully qualified `models/<id>` name. Users may paste
+    /// either form when entering a custom model id, so normalize here.
+    static func qualifiedModelName(_ model: String) -> String {
+        let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        let bare = trimmed.hasPrefix("models/")
+            ? String(trimmed.dropFirst("models/".count))
+            : trimmed
+        let resolved = bare.isEmpty ? GeminiASRConfig.defaultModel : bare
+        return "models/\(resolved)"
+    }
+
+    static func setupMessage(config: GeminiASRConfig, options: ASRRequestOptions) throws -> String {
+        var languageCodes: [String] = []
+        let lang = config.languageCode.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !lang.isEmpty && lang.lowercased() != "auto" {
+            languageCodes.append(lang)
+        }
+
+        let customVocabulary = sanitizeHotwords(options.hotwords)
+
+        var inputAudioTranscription: [String: Any] = [
+            "mode": config.mode.rawValue,
+            "languageCodes": languageCodes
+        ]
+        if !customVocabulary.isEmpty {
+            inputAudioTranscription["customVocabulary"] = customVocabulary
+        }
+
+        let setupPayload: [String: Any] = [
+            "setup": [
+                "model": qualifiedModelName(config.model),
+                "generationConfig": [
+                    "responseModalities": ["TEXT"]
+                ],
+                "realtimeInputConfig": [
+                    "automaticActivityDetection": [
+                        "disabled": true
+                    ]
+                ],
+                "inputAudioTranscription": inputAudioTranscription
+            ]
+        ]
+
+        let data = try JSONSerialization.data(withJSONObject: setupPayload, options: [])
+        guard let jsonString = String(data: data, encoding: .utf8) else {
+            throw GeminiProtocolError.invalidJSON
+        }
+        return jsonString
+    }
+
+    static func activityStartMessage() -> String {
+        jsonString([
+            "realtimeInput": [
+                "activityStart": [:]
+            ]
+        ])
+    }
+
+    static func activityEndMessage() -> String {
+        jsonString([
+            "realtimeInput": [
+                "activityEnd": [:]
+            ]
+        ])
+    }
+
+    static func audioChunkMessage(_ data: Data) -> String {
+        let base64 = data.base64EncodedString()
+        return jsonString([
+            "realtimeInput": [
+                "audio": [
+                    "data": base64,
+                    "mimeType": "audio/pcm;rate=\(sampleRate)"
+                ]
+            ]
+        ])
+    }
+
+    // MARK: - Inbound Message Models & Parsing
+
+    private struct InboundError: Decodable {
+        let code: Int?
+        let message: String?
+        let status: String?
+    }
+
+    private struct TranscriptionContent: Decodable {
+        let text: String?
+    }
+
+    private struct ServerContent: Decodable {
+        let interimInputTranscription: TranscriptionContent?
+        let inputTranscription: TranscriptionContent?
+        let turnComplete: Bool?
+        let interrupted: Bool?
+    }
+
+    private struct InboundEnvelope: Decodable {
+        let setupComplete: [String: String]?
+        let serverContent: ServerContent?
+        let error: InboundError?
+    }
+
+    static func makeTranscriptUpdate(
+        from data: Data,
+        confirmedSegments: [String],
+        didEndAudio: Bool
+    ) throws -> GeminiTranscriptUpdate? {
+        guard data.first == UInt8(ascii: "{") else { return nil }
+
+        // Attempt decoding raw dictionary or structure to check setupComplete / error / serverContent
+        let decoder = JSONDecoder()
+        let envelope: InboundEnvelope
+        do {
+            envelope = try decoder.decode(InboundEnvelope.self, from: data)
+        } catch {
+            // Also check for dynamic setupComplete representation (e.g. empty object `{}`)
+            if let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                if root["setupComplete"] != nil {
+                    return GeminiTranscriptUpdate(
+                        transcript: .empty,
+                        confirmedSegments: confirmedSegments,
+                        isSetupComplete: true
+                    )
+                }
+                if let errDict = root["error"] as? [String: Any] {
+                    let code = errDict["code"] as? Int
+                    let msg = errDict["message"] as? String
+                    let status = errDict["status"] as? String
+                    if code == 429 || status == "RESOURCE_EXHAUSTED" {
+                        throw GeminiASRError.quotaExceeded(msg)
+                    }
+                    throw GeminiASRError.serverError(code: code, message: msg)
+                }
+            }
+            return nil
+        }
+
+        if let error = envelope.error {
+            if error.code == 429 || error.status == "RESOURCE_EXHAUSTED" {
+                throw GeminiASRError.quotaExceeded(error.message)
+            }
+            throw GeminiASRError.serverError(code: error.code, message: error.message)
+        }
+
+        if envelope.setupComplete != nil {
+            return GeminiTranscriptUpdate(
+                transcript: .empty,
+                confirmedSegments: confirmedSegments,
+                isSetupComplete: true
+            )
+        }
+
+        guard let serverContent = envelope.serverContent else {
+            return nil
+        }
+
+        // 1. Finalized input transcription (authoritative segment)
+        if let finalText = serverContent.inputTranscription?.text {
+            let trimmed = finalText.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+
+            let normalized = normalize(segment: trimmed, after: confirmedSegments.joined())
+            var updatedConfirmed = confirmedSegments
+            updatedConfirmed.append(normalized)
+
+            let fullAuthoritative = updatedConfirmed.joined()
+            let transcript = RecognitionTranscript(
+                confirmedSegments: updatedConfirmed,
+                partialText: "",
+                authoritativeText: fullAuthoritative,
+                isFinal: didEndAudio
+            )
+            return GeminiTranscriptUpdate(
+                transcript: transcript,
+                confirmedSegments: updatedConfirmed,
+                isSetupComplete: false
+            )
+        }
+
+        // 2. Interim input transcription (streaming partial)
+        if let interimText = serverContent.interimInputTranscription?.text {
+            let trimmed = interimText.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+
+            let confirmedJoined = confirmedSegments.joined()
+            let normalizedInterim = normalize(segment: trimmed, after: confirmedJoined)
+
+            let transcript = RecognitionTranscript(
+                confirmedSegments: confirmedSegments,
+                partialText: normalizedInterim,
+                authoritativeText: confirmedJoined + normalizedInterim,
+                isFinal: false
+            )
+            return GeminiTranscriptUpdate(
+                transcript: transcript,
+                confirmedSegments: confirmedSegments,
+                isSetupComplete: false
+            )
+        }
+
+        return nil
+    }
+
+    // MARK: - Hotwords & Normalization
+
+    static func sanitizeHotwords(_ hotwords: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+
+        for word in hotwords {
+            let trimmed = word.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            if seen.insert(trimmed).inserted {
+                result.append(trimmed)
+                if result.count >= maxCustomVocabularyCount {
+                    break
+                }
+            }
+        }
+        return result
+    }
+
+    static func normalize(segment: String, after existingText: String) -> String {
+        guard !segment.isEmpty, let last = existingText.last, let first = segment.first else {
+            return segment
+        }
+        if last.isWhitespace || first.isWhitespace { return segment }
+        if first.isClosingPunctuation || last.isOpeningPunctuation { return segment }
+        if last.isCJKUnifiedIdeograph || first.isCJKUnifiedIdeograph { return segment }
+        return " " + segment
+    }
+
+    // MARK: - Rechunking Helper
+
+    /// Slices incoming audio data accumulated in `residual` into ~100ms (3,200 bytes) payloads.
+    /// Remaining bytes (< 3,200) stay in `residual`.
+    static func sliceAudioPayloads(from residual: inout Data) -> [Data] {
+        var payloads: [Data] = []
+        while residual.count >= targetPayloadBytes {
+            let chunk = residual.prefix(targetPayloadBytes)
+            payloads.append(chunk)
+            residual.removeFirst(targetPayloadBytes)
+        }
+        return payloads
+    }
+
+    /// Flushes any residual audio data remaining in the buffer.
+    static func flushResidualAudio(from residual: inout Data) -> Data? {
+        guard !residual.isEmpty else { return nil }
+        let chunk = residual
+        residual.removeAll()
+        return chunk
+    }
+
+    // MARK: - Utilities
+
+    private static func jsonString(_ payload: [String: Any]) -> String {
+        (try? JSONSerialization.data(withJSONObject: payload))
+            .flatMap { String(data: $0, encoding: .utf8) } ?? ""
+    }
+}

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -307,6 +307,8 @@ actor RecognitionSession {
             return "https://stt-rt.soniox.com"
         case .deepgram:
             return "https://api.deepgram.com"
+        case .gemini:
+            return "https://generativelanguage.googleapis.com"
         default:
             return ""
         }
@@ -345,6 +347,16 @@ actor RecognitionSession {
     // MARK: - Accumulated text
 
     private let maxRecordingDuration: TimeInterval = 600  // 10 minutes
+
+    /// Gemini Live sessions are terminated by the server at roughly 10 minutes,
+    /// measured from `connect()`. Stopping slightly earlier lets Type4Me finish
+    /// the recording through the normal path (and surface the existing
+    /// "已达最大时长" hint) instead of losing the tail to a server-side close.
+    private let geminiMaxRecordingDuration: TimeInterval = 570  // 9m30s
+
+    private func maxRecordingDuration(for provider: ASRProvider) -> TimeInterval {
+        provider == .gemini ? geminiMaxRecordingDuration : maxRecordingDuration
+    }
 
     private var currentTranscript: RecognitionTranscript = .empty
     private var eventConsumptionTask: Task<Void, Never>?
@@ -1057,10 +1069,11 @@ actor RecognitionSession {
         asrCleanupTask?.cancel()
         asrCleanupTask = nil
         asrCleanupGeneration = nil
-        maxDurationTask = Task { [weak self, maxRecordingDuration] in
-            try? await Task.sleep(for: .seconds(maxRecordingDuration))
+        let recordingLimit = maxRecordingDuration(for: activeProvider)
+        maxDurationTask = Task { [weak self, recordingLimit] in
+            try? await Task.sleep(for: .seconds(recordingLimit))
             guard let self, !Task.isCancelled else { return }
-            await self.autoStopIfRecording()
+            await self.autoStopIfRecording(limit: recordingLimit)
         }
     }
 
@@ -1069,9 +1082,9 @@ actor RecognitionSession {
     }
 
     /// Auto-stop triggered by max recording duration timer.
-    private func autoStopIfRecording() async {
+    private func autoStopIfRecording(limit: TimeInterval) async {
         guard state == .recording else { return }
-        DebugFileLogger.log("max recording duration reached (\(maxRecordingDuration)s), auto-stopping")
+        DebugFileLogger.log("max recording duration reached (\(limit)s), auto-stopping")
         stoppedByMaxDuration = true
         await stopRecording()
     }

--- a/Type4Me/UI/Settings/ASRSettingsCard.swift
+++ b/Type4Me/UI/Settings/ASRSettingsCard.swift
@@ -127,6 +127,12 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
             return [
                 (L("API Key", "API Key"), L("获取", "get"), URL(string: "https://elevenlabs.io/app/settings/api-keys")!),
             ]
+        case .gemini:
+            return [
+                (L("官方文档", "Docs"), L("查看", "view"), URL(string: "https://ai.google.dev/gemini-api/docs/live-api/live-transcribe")!),
+                ("API Key", L("获取", "get"), URL(string: "https://aistudio.google.com/app/apikey")!),
+                (L("定价与限制", "Pricing & Limits"), L("查看", "view"), URL(string: "https://ai.google.dev/gemini-api/docs/pricing")!),
+            ]
         case .grok:
             return [
                 ("API Key", L("获取", "get"), URL(string: "https://console.x.ai/team/default/api-keys")!),
@@ -214,6 +220,11 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
             )
         case .deepgram:
             return L("受接口限制，热词仅取前 30 个", "Due to API limits, only the first 30 hotwords are used")
+        case .gemini:
+            return L(
+                "实时流式识别。Smart 模式会自动清理口语停顿、重复和自我纠正；如需逐字记录可切换为 Verbatim。",
+                "Real-time streaming transcription. Smart mode cleans up disfluencies, repetitions, and self-corrections; switch to Verbatim for literal transcripts."
+            )
         case .openai:
             return L(
                 "松开快捷键后提交完整录音进行转写。",

--- a/Type4MeTests/ASRProviderRegistryTests.swift
+++ b/Type4MeTests/ASRProviderRegistryTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class ASRProviderRegistryTests: XCTestCase {
 
     func testAvailableProvidersSupportDirectMode() {
-        for provider in [ASRProvider.volcano, .stepfunBatch, .mimo, .baidu, .bailian, .deepgram, .assemblyai, .soniox, .openai] {
+        for provider in [ASRProvider.volcano, .stepfunBatch, .mimo, .baidu, .bailian, .deepgram, .gemini, .assemblyai, .soniox, .openai] {
             XCTAssertTrue(ASRProviderRegistry.supports(.direct, for: provider))
         }
     }
@@ -37,6 +37,20 @@ final class ASRProviderRegistryTests: XCTestCase {
         XCTAssertEqual(bailianModes.map(\.id), [ProcessingMode.directId, customMode.id])
     }
 
+    func testRegistry_exposesGeminiProviderConfiguration() {
+        let entry = ASRProviderRegistry.entry(for: .gemini)
+        XCTAssertNotNil(entry)
+        XCTAssertTrue(entry?.isAvailable ?? false)
+        XCTAssertTrue(ASRProviderRegistry.configType(for: .gemini) == GeminiASRConfig.self)
+        XCTAssertNotNil(ASRProviderRegistry.createClient(for: .gemini))
+
+        let caps = ASRProviderRegistry.capabilities(for: .gemini)
+        XCTAssertTrue(caps.isAvailable)
+        XCTAssertTrue(caps.isStreaming)
+        XCTAssertTrue(caps.supportsRealtimeRecognition)
+        XCTAssertEqual(caps.audioInput, .pcmData)
+    }
+
     func testRegistry_exposesMiMoProviderConfiguration() {
         let entry = ASRProviderRegistry.entry(for: .mimo)
         XCTAssertNotNil(entry)
@@ -63,7 +77,7 @@ final class ASRProviderRegistryTests: XCTestCase {
         // Realtime streaming providers
         for realtime in [
             ASRProvider.apple, .volcano, .deepgram, .cartesia,
-            .assemblyai, .elevenlabs, .grok, .soniox, .bailian, .baidu
+            .assemblyai, .elevenlabs, .gemini, .grok, .soniox, .bailian, .baidu
         ] {
             let caps = ASRProviderRegistry.capabilities(for: realtime)
             XCTAssertTrue(caps.isAvailable)

--- a/Type4MeTests/GeminiASRClientTests.swift
+++ b/Type4MeTests/GeminiASRClientTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import Type4Me
+
+/// Client-level behaviors required by development design §29.3 and §30 that do
+/// not need a live network connection.
+final class GeminiASRClientTests: XCTestCase {
+
+    // MARK: - §16.1: teardown must never throw on an unused session
+
+    func testEndAudio_withoutConnect_doesNotThrow() async throws {
+        let client = GeminiASRClient()
+        // RecognitionSession budgets only 3s for endAudio() and treats a throw
+        // as an unclean teardown, so an unused session must return silently.
+        try await client.endAudio()
+    }
+
+    func testSendAudio_withoutConnect_doesNotThrow() async throws {
+        let client = GeminiASRClient()
+        try await client.sendAudio(Data(repeating: 0, count: 3200))
+        try await client.endAudio()
+    }
+
+    func testDisconnect_withoutConnect_isSafeAndRepeatable() async {
+        let client = GeminiASRClient()
+        await client.disconnect()
+        await client.disconnect()
+    }
+
+    // MARK: - §16: empty audio must not open an activity window
+
+    func testEmptyAudio_doesNotStartActivity() async throws {
+        let client = GeminiASRClient()
+        try await client.sendAudio(Data())
+        // No activityStart was sent, so endAudio must not send activityEnd
+        // either; it returns without throwing.
+        try await client.endAudio()
+    }
+
+    // MARK: - §24: abnormal close classification
+
+    func testUnexpectedClose_ignoresBenignCloseCodes() {
+        XCTAssertNil(GeminiASRError.unexpectedClose(code: .normalClosure, reason: nil))
+        XCTAssertNil(GeminiASRError.unexpectedClose(code: .goingAway, reason: nil))
+        XCTAssertNil(GeminiASRError.unexpectedClose(code: .noStatusReceived, reason: nil))
+    }
+
+    func testUnexpectedClose_reportsAbnormalCloseCodes() {
+        let error = GeminiASRError.unexpectedClose(code: .internalServerError, reason: "boom")
+        XCTAssertEqual(error, .closed(code: 1011, reason: "boom"))
+
+        let noReason = GeminiASRError.unexpectedClose(code: .abnormalClosure, reason: nil)
+        XCTAssertEqual(noReason, .closed(code: 1006, reason: nil))
+    }
+
+    func testUnexpectedClose_mapsSessionLimitReasonToSessionLimitReached() {
+        XCTAssertEqual(
+            GeminiASRError.unexpectedClose(code: .internalServerError, reason: "Session duration limit exceeded"),
+            .sessionLimitReached
+        )
+        XCTAssertEqual(
+            GeminiASRError.unexpectedClose(code: .policyViolation, reason: "maximum session length reached"),
+            .sessionLimitReached
+        )
+        // A generic server failure must not be mislabeled as a session limit.
+        XCTAssertEqual(
+            GeminiASRError.unexpectedClose(code: .internalServerError, reason: "internal error"),
+            .closed(code: 1011, reason: "internal error")
+        )
+    }
+
+    // MARK: - §24: close tracker semantics
+
+    func testCloseTracker_recordsFirstAbnormalCloseOnly() async {
+        let tracker = GeminiCloseTracker()
+        await tracker.recordClose(code: .internalServerError, reason: "first")
+        await tracker.recordClose(code: .policyViolation, reason: "second")
+
+        let consumed = await tracker.consumeCloseError()
+        XCTAssertEqual(consumed as? GeminiASRError, .closed(code: 1011, reason: "first"))
+
+        let afterConsume = await tracker.consumeCloseError()
+        XCTAssertNil(afterConsume)
+    }
+
+    func testCloseTracker_ignoresNormalClosure() async {
+        let tracker = GeminiCloseTracker()
+        await tracker.recordClose(code: .normalClosure, reason: nil)
+        let consumed = await tracker.consumeCloseError()
+        XCTAssertNil(consumed)
+    }
+
+    func testCloseTracker_recordsTransportFailure() async {
+        let tracker = GeminiCloseTracker()
+        let transportError = URLError(.networkConnectionLost)
+        await tracker.recordFailure(transportError)
+
+        let consumed = await tracker.consumeCloseError()
+        XCTAssertEqual((consumed as? URLError)?.code, .networkConnectionLost)
+    }
+
+    func testCloseTracker_normalClosureDoesNotMaskEarlierFailure() async {
+        let tracker = GeminiCloseTracker()
+        await tracker.recordFailure(URLError(.timedOut))
+        await tracker.recordClose(code: .normalClosure, reason: nil)
+
+        let consumed = await tracker.consumeCloseError()
+        XCTAssertEqual((consumed as? URLError)?.code, .timedOut)
+    }
+}

--- a/Type4MeTests/GeminiASRConfigTests.swift
+++ b/Type4MeTests/GeminiASRConfigTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import Type4Me
+
+final class GeminiASRConfigTests: XCTestCase {
+
+    func testInit_acceptsValidAPIKeyAndAppliesDefaults() throws {
+        let config = try XCTUnwrap(GeminiASRConfig(credentials: [
+            "apiKey": "test-gemini-key"
+        ]))
+
+        XCTAssertEqual(config.apiKey, "test-gemini-key")
+        XCTAssertEqual(config.model, GeminiASRConfig.defaultModel)
+        XCTAssertEqual(config.mode, .smart)
+        XCTAssertEqual(config.languageCode, "auto")
+        XCTAssertTrue(config.isValid)
+    }
+
+    func testInit_rejectsMissingOrEmptyAPIKey() {
+        XCTAssertNil(GeminiASRConfig(credentials: [:]))
+        XCTAssertNil(GeminiASRConfig(credentials: ["apiKey": ""]))
+        XCTAssertNil(GeminiASRConfig(credentials: ["apiKey": "   \n\t "]))
+    }
+
+    func testInit_parsesModeAndLanguage() throws {
+        let config = try XCTUnwrap(GeminiASRConfig(credentials: [
+            "apiKey": "test-key",
+            "mode": "VERBATIM",
+            "languageCode": "cmn-Hans-CN"
+        ]))
+
+        XCTAssertEqual(config.mode, .verbatim)
+        XCTAssertEqual(config.languageCode, "cmn-Hans-CN")
+    }
+
+    func testInit_fallsBackOnInvalidMode() throws {
+        let config = try XCTUnwrap(GeminiASRConfig(credentials: [
+            "apiKey": "test-key",
+            "mode": "NON_EXISTENT_MODE"
+        ]))
+
+        XCTAssertEqual(config.mode, .smart)
+    }
+
+    func testToCredentials_roundTripsValues() throws {
+        let config = try XCTUnwrap(GeminiASRConfig(credentials: [
+            "apiKey": "test-key",
+            "mode": "VERBATIM",
+            "languageCode": "en-US"
+        ]))
+
+        let creds = config.toCredentials()
+        XCTAssertEqual(creds["apiKey"], "test-key")
+        XCTAssertEqual(creds["mode"], "VERBATIM")
+        XCTAssertEqual(creds["languageCode"], "en-US")
+    }
+
+    func testCredentialFieldsMetadata() {
+        let fields = GeminiASRConfig.credentialFields
+        let apiKeyField = fields.first { $0.key == "apiKey" }
+        XCTAssertNotNil(apiKeyField)
+        XCTAssertTrue(apiKeyField?.isSecure ?? false)
+        XCTAssertFalse(apiKeyField?.isOptional ?? true)
+
+        let modeField = fields.first { $0.key == "mode" }
+        XCTAssertNotNil(modeField)
+        XCTAssertFalse(modeField?.isSecure ?? true)
+        XCTAssertTrue(modeField?.isOptional ?? false)
+        XCTAssertEqual(modeField?.defaultValue, "SMART")
+        XCTAssertEqual(modeField?.options.map(\.value), ["SMART", "VERBATIM"])
+
+        let langField = fields.first { $0.key == "languageCode" }
+        XCTAssertNotNil(langField)
+        XCTAssertFalse(langField?.isSecure ?? true)
+        XCTAssertTrue(langField?.isOptional ?? false)
+        XCTAssertTrue(langField?.allowCustomInput ?? false)
+    }
+
+    // MARK: - Model selection (provider "Gemini" → model underneath)
+
+    func testInit_usesDefaultModelWhenMissingOrBlank() throws {
+        let missing = try XCTUnwrap(GeminiASRConfig(credentials: ["apiKey": "k"]))
+        XCTAssertEqual(missing.model, "gemini-3.5-transcribe-live")
+
+        let blank = try XCTUnwrap(GeminiASRConfig(credentials: ["apiKey": "k", "model": "  \n "]))
+        XCTAssertEqual(blank.model, "gemini-3.5-transcribe-live")
+    }
+
+    func testInit_acceptsExplicitModel() throws {
+        let config = try XCTUnwrap(GeminiASRConfig(credentials: [
+            "apiKey": "k",
+            "model": "gemini-4-transcribe-live"
+        ]))
+        XCTAssertEqual(config.model, "gemini-4-transcribe-live")
+        XCTAssertEqual(config.toCredentials()["model"], "gemini-4-transcribe-live")
+    }
+
+    func testCredentialFields_exposeModelPickerWithCustomInput() throws {
+        let field = try XCTUnwrap(GeminiASRConfig.credentialFields.first { $0.key == "model" })
+        XCTAssertFalse(field.isSecure)
+        XCTAssertTrue(field.isOptional)
+        XCTAssertTrue(field.allowCustomInput)
+        XCTAssertEqual(field.defaultValue, GeminiASRConfig.defaultModel)
+        XCTAssertEqual(
+            field.options.map(\.value),
+            GeminiASRConfig.supportedModels.map(\.id)
+        )
+    }
+
+    func testCredentialFields_apiKeyPrecedesModel() throws {
+        let keys = GeminiASRConfig.credentialFields.map(\.key)
+        let apiKeyIndex = try XCTUnwrap(keys.firstIndex(of: "apiKey"))
+        let modelIndex = try XCTUnwrap(keys.firstIndex(of: "model"))
+        XCTAssertLessThan(apiKeyIndex, modelIndex)
+    }
+}

--- a/Type4MeTests/GeminiLocalizationTests.swift
+++ b/Type4MeTests/GeminiLocalizationTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import Type4Me
+
+final class GeminiLocalizationTests: XCTestCase {
+
+    private var previousLanguage: String?
+
+    override func setUp() {
+        super.setUp()
+        previousLanguage = UserDefaults.standard.string(forKey: "tf_language")
+    }
+
+    override func tearDown() {
+        if let previousLanguage {
+            UserDefaults.standard.set(previousLanguage, forKey: "tf_language")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "tf_language")
+        }
+        super.tearDown()
+    }
+
+    func testProviderDisplayName_isConsistentAcrossLanguages() {
+        // The provider is "Gemini"; the model is selected separately underneath
+        // it, so the provider name must not carry a model version.
+        UserDefaults.standard.set("zh", forKey: "tf_language")
+        XCTAssertEqual(ASRProvider.gemini.displayName, "Gemini")
+
+        UserDefaults.standard.set("en", forKey: "tf_language")
+        XCTAssertEqual(ASRProvider.gemini.displayName, "Gemini")
+    }
+
+    func testModelFieldLabelLocalization_switchesDynamically() {
+        UserDefaults.standard.set("zh", forKey: "tf_language")
+        XCTAssertEqual(GeminiASRConfig.credentialFields.first { $0.key == "model" }?.label, "模型")
+
+        UserDefaults.standard.set("en", forKey: "tf_language")
+        XCTAssertEqual(GeminiASRConfig.credentialFields.first { $0.key == "model" }?.label, "Model")
+    }
+
+    func testCredentialFieldsLocalization_switchesDynamically() {
+        // 1. Chinese
+        UserDefaults.standard.set("zh", forKey: "tf_language")
+        let zhFields = GeminiASRConfig.credentialFields
+
+        let zhModeField = zhFields.first { $0.key == "mode" }
+        XCTAssertEqual(zhModeField?.label, "转写模式")
+        XCTAssertEqual(zhModeField?.options.first { $0.value == "SMART" }?.label, "智能整理")
+        XCTAssertEqual(zhModeField?.options.first { $0.value == "VERBATIM" }?.label, "逐字转写")
+
+        let zhLangField = zhFields.first { $0.key == "languageCode" }
+        XCTAssertEqual(zhLangField?.label, "语言提示")
+        XCTAssertEqual(zhLangField?.options.first { $0.value == "auto" }?.label, "自动检测")
+        XCTAssertEqual(zhLangField?.options.first { $0.value == "cmn-Hans-CN" }?.label, "中文（普通话）")
+        XCTAssertEqual(zhLangField?.options.first { $0.value == "yue-Hant-HK" }?.label, "粤语")
+
+        // 2. English
+        UserDefaults.standard.set("en", forKey: "tf_language")
+        let enFields = GeminiASRConfig.credentialFields
+
+        let enModeField = enFields.first { $0.key == "mode" }
+        XCTAssertEqual(enModeField?.label, "Transcription Mode")
+        XCTAssertEqual(enModeField?.options.first { $0.value == "SMART" }?.label, "Smart")
+        XCTAssertEqual(enModeField?.options.first { $0.value == "VERBATIM" }?.label, "Verbatim")
+
+        let enLangField = enFields.first { $0.key == "languageCode" }
+        XCTAssertEqual(enLangField?.label, "Language Hint")
+        XCTAssertEqual(enLangField?.options.first { $0.value == "auto" }?.label, "Auto Detect")
+        XCTAssertEqual(enLangField?.options.first { $0.value == "cmn-Hans-CN" }?.label, "Mandarin Chinese")
+        XCTAssertEqual(enLangField?.options.first { $0.value == "yue-Hant-HK" }?.label, "Cantonese")
+    }
+
+    func testConfigSemanticValues_remainIntactAcrossLanguageSwitches() throws {
+        let config = try XCTUnwrap(GeminiASRConfig(credentials: [
+            "apiKey": "test-key",
+            "mode": "SMART",
+            "languageCode": "cmn-Hans-CN"
+        ]))
+
+        UserDefaults.standard.set("zh", forKey: "tf_language")
+        XCTAssertEqual(config.mode.rawValue, "SMART")
+        XCTAssertEqual(config.languageCode, "cmn-Hans-CN")
+
+        UserDefaults.standard.set("en", forKey: "tf_language")
+        XCTAssertEqual(config.mode.rawValue, "SMART")
+        XCTAssertEqual(config.languageCode, "cmn-Hans-CN")
+    }
+
+    func testErrorDescriptions_haveBothLanguages() {
+        let errors: [GeminiASRError] = [
+            .unsupportedProvider,
+            .invalidConfig,
+            .invalidEndpoint,
+            .handshakeTimedOut,
+            .setupTimedOut,
+            .setupRejected("Invalid model"),
+            .emptyAudio,
+            .closedBeforeSetup(code: 1006, reason: "Reset"),
+            .closed(code: 1000, reason: "Normal"),
+            .quotaExceeded("Rate limit"),
+            .sessionLimitReached,
+            .invalidResponse,
+            .serverError(code: 500, message: "Internal error")
+        ]
+
+        UserDefaults.standard.set("zh", forKey: "tf_language")
+        for err in errors {
+            XCTAssertFalse(err.localizedDescription.isEmpty, "ZH description should not be empty for \(err)")
+        }
+
+        UserDefaults.standard.set("en", forKey: "tf_language")
+        for err in errors {
+            XCTAssertFalse(err.localizedDescription.isEmpty, "EN description should not be empty for \(err)")
+        }
+    }
+}

--- a/Type4MeTests/GeminiTranscribeProtocolTests.swift
+++ b/Type4MeTests/GeminiTranscribeProtocolTests.swift
@@ -1,0 +1,267 @@
+import XCTest
+@testable import Type4Me
+
+final class GeminiTranscribeProtocolTests: XCTestCase {
+
+    func testBuildWebSocketURL_encodesKeyQueryParameter() throws {
+        let config = try XCTUnwrap(GeminiASRConfig(credentials: ["apiKey": "AIzaSyTestKey123_special+value"]))
+        let url = try GeminiTranscribeProtocol.buildWebSocketURL(config: config)
+
+        XCTAssertTrue(url.absoluteString.starts(with: "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"))
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let keyItem = components.queryItems?.first { $0.name == "key" }
+        XCTAssertEqual(keyItem?.value, "AIzaSyTestKey123_special+value")
+    }
+
+    func testRedactedURLString_masksAPIKey() throws {
+        let config = try XCTUnwrap(GeminiASRConfig(credentials: ["apiKey": "SECRET_KEY_999"]))
+        let url = try GeminiTranscribeProtocol.buildWebSocketURL(config: config)
+        let redacted = GeminiTranscribeProtocol.redactedURLString(for: url)
+
+        XCTAssertFalse(redacted.contains("SECRET_KEY_999"))
+        XCTAssertTrue(redacted.contains("key=REDACTED"))
+    }
+
+    func testSetupMessage_autoLanguageAndSmartMode() throws {
+        let config = try XCTUnwrap(GeminiASRConfig(credentials: ["apiKey": "test-key", "mode": "SMART", "languageCode": "auto"]))
+        let options = ASRRequestOptions(hotwords: ["Type4Me", "SwiftUI", "Type4Me", "   ", "OpenAI"])
+        let setupJSON = try GeminiTranscribeProtocol.setupMessage(config: config, options: options)
+
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(setupJSON.utf8)) as? [String: Any])
+        let setup = try XCTUnwrap(root["setup"] as? [String: Any])
+
+        XCTAssertEqual(setup["model"] as? String, "models/gemini-3.5-transcribe-live")
+
+        let genConfig = try XCTUnwrap(setup["generationConfig"] as? [String: Any])
+        XCTAssertEqual(genConfig["responseModalities"] as? [String], ["TEXT"])
+
+        let realtimeConfig = try XCTUnwrap(setup["realtimeInputConfig"] as? [String: Any])
+        let autoVAD = try XCTUnwrap(realtimeConfig["automaticActivityDetection"] as? [String: Any])
+        XCTAssertEqual(autoVAD["disabled"] as? Bool, true)
+
+        let transcribeConfig = try XCTUnwrap(setup["inputAudioTranscription"] as? [String: Any])
+        XCTAssertEqual(transcribeConfig["mode"] as? String, "SMART")
+        XCTAssertEqual(transcribeConfig["languageCodes"] as? [String], [])
+
+        let vocab = try XCTUnwrap(transcribeConfig["customVocabulary"] as? [String])
+        XCTAssertEqual(vocab, ["Type4Me", "SwiftUI", "OpenAI"])
+    }
+
+    func testSetupMessage_explicitLanguageAndVerbatimMode() throws {
+        let config = try XCTUnwrap(GeminiASRConfig(credentials: ["apiKey": "test-key", "mode": "VERBATIM", "languageCode": "cmn-Hans-CN"]))
+        let options = ASRRequestOptions()
+        let setupJSON = try GeminiTranscribeProtocol.setupMessage(config: config, options: options)
+
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(setupJSON.utf8)) as? [String: Any])
+        let setup = try XCTUnwrap(root["setup"] as? [String: Any])
+        let transcribeConfig = try XCTUnwrap(setup["inputAudioTranscription"] as? [String: Any])
+
+        XCTAssertEqual(transcribeConfig["mode"] as? String, "VERBATIM")
+        XCTAssertEqual(transcribeConfig["languageCodes"] as? [String], ["cmn-Hans-CN"])
+        XCTAssertNil(transcribeConfig["customVocabulary"])
+    }
+
+    func testCustomVocabulary_deDuplicatesAndCapsAt1000() {
+        var input: [String] = []
+        for i in 0..<1200 {
+            input.append("word\(i)")
+            input.append("word\(i)") // duplicate
+        }
+        let sanitized = GeminiTranscribeProtocol.sanitizeHotwords(input)
+        XCTAssertEqual(sanitized.count, 1000)
+        XCTAssertEqual(sanitized.first, "word0")
+        XCTAssertEqual(sanitized.last, "word999")
+    }
+
+    func testActivityMessages() throws {
+        let startJSON = GeminiTranscribeProtocol.activityStartMessage()
+        let startDict = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(startJSON.utf8)) as? [String: Any])
+        let startRealtime = try XCTUnwrap(startDict["realtimeInput"] as? [String: Any])
+        XCTAssertNotNil(startRealtime["activityStart"])
+
+        let endJSON = GeminiTranscribeProtocol.activityEndMessage()
+        let endDict = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(endJSON.utf8)) as? [String: Any])
+        let endRealtime = try XCTUnwrap(endDict["realtimeInput"] as? [String: Any])
+        XCTAssertNotNil(endRealtime["activityEnd"])
+    }
+
+    func testAudioChunkMessage_encodesBase64() throws {
+        let originalBytes = (0..<100).map { UInt8($0) }
+        let pcmData = Data(originalBytes)
+        let chunkJSON = GeminiTranscribeProtocol.audioChunkMessage(pcmData)
+
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(chunkJSON.utf8)) as? [String: Any])
+        let realtime = try XCTUnwrap(root["realtimeInput"] as? [String: Any])
+        let audio = try XCTUnwrap(realtime["audio"] as? [String: Any])
+
+        XCTAssertEqual(audio["mimeType"] as? String, "audio/pcm;rate=16000")
+        let base64String = try XCTUnwrap(audio["data"] as? String)
+        let decodedData = try XCTUnwrap(Data(base64Encoded: base64String))
+        XCTAssertEqual(decodedData, pcmData)
+    }
+
+    func testMakeTranscriptUpdate_setupComplete() throws {
+        let json = #"{"setupComplete": {}}"#
+        let update = try GeminiTranscribeProtocol.makeTranscriptUpdate(
+            from: Data(json.utf8),
+            confirmedSegments: ["Previously"],
+            didEndAudio: false
+        )
+        XCTAssertNotNil(update)
+        XCTAssertTrue(update?.isSetupComplete ?? false)
+    }
+
+    func testMakeTranscriptUpdate_interimTranscription() throws {
+        let json = #"{"serverContent": {"interimInputTranscription": {"text": "hello world"}}}"#
+        let update = try GeminiTranscribeProtocol.makeTranscriptUpdate(
+            from: Data(json.utf8),
+            confirmedSegments: ["Hi."],
+            didEndAudio: false
+        )
+        let unwrapped = try XCTUnwrap(update)
+        XCTAssertFalse(unwrapped.isSetupComplete)
+        XCTAssertEqual(unwrapped.transcript.confirmedSegments, ["Hi."])
+        XCTAssertEqual(unwrapped.transcript.partialText, " hello world")
+        XCTAssertEqual(unwrapped.transcript.authoritativeText, "Hi. hello world")
+        XCTAssertFalse(unwrapped.transcript.isFinal)
+    }
+
+    func testMakeTranscriptUpdate_finalTranscriptionBeforeEndAudio() throws {
+        let json = #"{"serverContent": {"inputTranscription": {"text": "Hello world"}}}"#
+        let update = try GeminiTranscribeProtocol.makeTranscriptUpdate(
+            from: Data(json.utf8),
+            confirmedSegments: [],
+            didEndAudio: false
+        )
+        let unwrapped = try XCTUnwrap(update)
+        XCTAssertEqual(unwrapped.confirmedSegments, ["Hello world"])
+        XCTAssertEqual(unwrapped.transcript.partialText, "")
+        XCTAssertEqual(unwrapped.transcript.authoritativeText, "Hello world")
+        XCTAssertFalse(unwrapped.transcript.isFinal)
+    }
+
+    func testMakeTranscriptUpdate_finalTranscriptionAfterEndAudio() throws {
+        let json = #"{"serverContent": {"inputTranscription": {"text": "Final sentence."}}}"#
+        let update = try GeminiTranscribeProtocol.makeTranscriptUpdate(
+            from: Data(json.utf8),
+            confirmedSegments: ["Part 1."],
+            didEndAudio: true
+        )
+        let unwrapped = try XCTUnwrap(update)
+        XCTAssertEqual(unwrapped.confirmedSegments, ["Part 1.", " Final sentence."])
+        XCTAssertEqual(unwrapped.transcript.partialText, "")
+        XCTAssertEqual(unwrapped.transcript.authoritativeText, "Part 1. Final sentence.")
+        XCTAssertTrue(unwrapped.transcript.isFinal)
+    }
+
+    func testMakeTranscriptUpdate_quotaExceededError() {
+        let json = #"{"error": {"code": 429, "message": "Resource has been exhausted", "status": "RESOURCE_EXHAUSTED"}}"#
+        XCTAssertThrowsError(try GeminiTranscribeProtocol.makeTranscriptUpdate(
+            from: Data(json.utf8),
+            confirmedSegments: [],
+            didEndAudio: false
+        )) { error in
+            guard let geminiErr = error as? GeminiASRError else {
+                XCTFail("Expected GeminiASRError, got \(error)")
+                return
+            }
+            XCTAssertEqual(geminiErr, .quotaExceeded("Resource has been exhausted"))
+        }
+    }
+
+    func testRechunkAudioPayloads() {
+        var buffer = Data()
+
+        // 1. Append 6400 bytes (standard 200ms input) -> two 3200-byte payloads
+        let chunk6400 = Data(repeating: 0x42, count: 6400)
+        buffer.append(chunk6400)
+        let payloads1 = GeminiTranscribeProtocol.sliceAudioPayloads(from: &buffer)
+        XCTAssertEqual(payloads1.count, 2)
+        XCTAssertEqual(payloads1[0].count, 3200)
+        XCTAssertEqual(payloads1[1].count, 3200)
+        XCTAssertTrue(buffer.isEmpty)
+
+        // 2. Incremental appends: 1000 then 2200 bytes -> 1 payload of 3200
+        buffer.append(Data(repeating: 0x01, count: 1000))
+        let payloads2a = GeminiTranscribeProtocol.sliceAudioPayloads(from: &buffer)
+        XCTAssertEqual(payloads2a.count, 0)
+        XCTAssertEqual(buffer.count, 1000)
+
+        buffer.append(Data(repeating: 0x02, count: 2200))
+        let payloads2b = GeminiTranscribeProtocol.sliceAudioPayloads(from: &buffer)
+        XCTAssertEqual(payloads2b.count, 1)
+        XCTAssertEqual(payloads2b[0].count, 3200)
+        XCTAssertTrue(buffer.isEmpty)
+
+        // 3. Flush residual audio
+        buffer.append(Data(repeating: 0x03, count: 500))
+        let flushed = GeminiTranscribeProtocol.flushResidualAudio(from: &buffer)
+        XCTAssertEqual(flushed?.count, 500)
+        XCTAssertTrue(buffer.isEmpty)
+
+        // 4. Batch fallback scale: 1.92 MB (60 seconds at 16kHz 16-bit mono = 1,920,000 bytes)
+        let fullRecording = Data(repeating: 0x55, count: 1_920_000)
+        buffer.append(fullRecording)
+        let batchPayloads = GeminiTranscribeProtocol.sliceAudioPayloads(from: &buffer)
+        XCTAssertEqual(batchPayloads.count, 600) // 1,920,000 / 3200 = 600
+        XCTAssertTrue(buffer.isEmpty)
+
+        var reconstructed = Data()
+        for p in batchPayloads {
+            reconstructed.append(p)
+        }
+        XCTAssertEqual(reconstructed, fullRecording)
+    }
+
+    func testSegmentNormalization() {
+        // CJK segments - no space added
+        XCTAssertEqual(GeminiTranscribeProtocol.normalize(segment: "世界", after: "你好"), "世界")
+
+        // Latin segments - space added
+        XCTAssertEqual(GeminiTranscribeProtocol.normalize(segment: "world", after: "hello"), " world")
+
+        // Already has leading whitespace
+        XCTAssertEqual(GeminiTranscribeProtocol.normalize(segment: " world", after: "hello"), " world")
+
+        // Punctuation handling
+        XCTAssertEqual(GeminiTranscribeProtocol.normalize(segment: "，你好", after: "今天"), "，你好")
+    }
+
+    // MARK: - Model selection
+
+    func testSetupMessage_usesConfiguredModel() throws {
+        let config = try XCTUnwrap(GeminiASRConfig(credentials: [
+            "apiKey": "test-key",
+            "model": "gemini-4-transcribe-live"
+        ]))
+        let setupJSON = try GeminiTranscribeProtocol.setupMessage(config: config, options: ASRRequestOptions())
+
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(setupJSON.utf8)) as? [String: Any])
+        let setup = try XCTUnwrap(root["setup"] as? [String: Any])
+        XCTAssertEqual(setup["model"] as? String, "models/gemini-4-transcribe-live")
+    }
+
+    func testQualifiedModelName_normalizesUserInput() {
+        XCTAssertEqual(
+            GeminiTranscribeProtocol.qualifiedModelName("gemini-3.5-transcribe-live"),
+            "models/gemini-3.5-transcribe-live"
+        )
+        // Users may paste the fully qualified name; it must not be doubled up.
+        XCTAssertEqual(
+            GeminiTranscribeProtocol.qualifiedModelName("models/gemini-3.5-transcribe-live"),
+            "models/gemini-3.5-transcribe-live"
+        )
+        XCTAssertEqual(
+            GeminiTranscribeProtocol.qualifiedModelName("  gemini-4-transcribe-live \n"),
+            "models/gemini-4-transcribe-live"
+        )
+        XCTAssertEqual(
+            GeminiTranscribeProtocol.qualifiedModelName("   "),
+            "models/\(GeminiASRConfig.defaultModel)"
+        )
+        XCTAssertEqual(
+            GeminiTranscribeProtocol.qualifiedModelName("models/"),
+            "models/\(GeminiASRConfig.defaultModel)"
+        )
+    }
+}

--- a/docs/features/gemini-transcribe-asr/development-design.md
+++ b/docs/features/gemini-transcribe-asr/development-design.md
@@ -1,0 +1,1253 @@
+# Type4Me Gemini ASR Provider 开发设计
+
+> 分支：`feat/gemini-transcribe-asr`
+> 文档类型：开发设计
+> 文档状态：已 review（2026-08-27），待实现
+> 对应产品设计：`docs/features/gemini-transcribe-asr/product-design.md`
+> 设计日期：2026-08-27
+> 官方 Live Transcription 文档：https://ai.google.dev/gemini-api/docs/live-api/live-transcribe
+> 官方 API Reference：https://ai.google.dev/api/generate-content
+
+## 1. 设计摘要
+
+本次新增独立的 **Gemini** 实时 ASR Provider，使用 Gemini Live API 的 WebSocket `BidiGenerateContent` 接口。Provider 名是厂商名 `Gemini`；具体模型是它下面的一层可选配置，首版默认 `gemini-3.5-transcribe-live`（见 §7.2）。
+
+Type4Me 现有 `SpeechRecognizer`、`ASRProviderRegistry`、`RecognitionTranscript`、实时 PCM 上传和 streaming teardown 已经能承载该模型，因此第一版不增加新的公共 ASR 抽象。
+
+核心技术决策：
+
+1. 新增独立 `ASRProvider.gemini`，不复用 `.google`；
+2. Registry capability 使用 `.streaming()`；
+3. 直接使用 `URLSessionWebSocketTask`，不引入 Google Gen AI SDK；
+4. 模型固定 `gemini-3.5-transcribe-live`；
+5. WebSocket 使用官方 `v1beta` BidiGenerateContent endpoint；
+6. setup 使用 `responseModalities = [TEXT]`；
+7. 使用 Manual VAD，关闭 automatic activity detection；
+8. 第一段真实音频发送前发 `activityStart`，`endAudio()` 发 `activityEnd`；
+9. interim transcript 映射到 `partialText`；finalized transcript 映射到 `confirmedSegments`；
+10. Type4Me 当前 200ms PCM chunk 在 Gemini Client 内拆成约 100ms payload，不改 `AudioCaptureEngine`；
+11. HotwordStorage 映射到 `customVocabulary`；
+12. Smart / Verbatim 作为 Provider config；
+13. API Key 继续使用 Keychain；
+14. `connect()` 必须等待 WebSocket open + `setupComplete` 后才算 ready；
+15. 不记录带 API Key 的完整 WebSocket URL；
+16. `endAudio()` 在无音频时静默返回，不抛错（§16.1）；
+17. `activityEnd → final` 有 2s 硬性预算（快速路径 1s，§16.2）；
+18. 沿用现有 batch fallback 路径，但 `sendAudio` 内需节流（§16.3）；
+19. setup / 消息字段命名已对照官方 SDK `googleapis/python-genai` 核实完毕并锁定（§4.1）。
+
+## 2. 当前 Type4Me 架构适配
+
+现有扩展点：
+
+- `ASRProvider`：稳定 Provider ID；
+- `ASRProviderConfig`：动态凭证和非安全参数；
+- `ASRProviderRegistry`：Config / Client / Capability / validation；
+- `SpeechRecognizer`：`connect → sendAudio → endAudio → disconnect`；
+- `RecognitionTranscript`：confirmed / partial / authoritative / final；
+- `RecognitionSession`：Streaming provider 自动持续调用 `sendAudio()`；
+- `AudioCaptureEngine`：16 kHz / 16-bit / mono PCM；
+- `HotwordStorage`：统一 ASR 热词来源；
+- `ASRSettingsCard`：Provider Picker、字段渲染、指引和测试连接；
+- `KeychainService`：secure credential。
+
+Gemini 不需要修改 `SpeechRecognizer` protocol。
+
+## 3. 为什么不能复用现有 Google Provider
+
+当前 `.google`：
+
+- display name：`Google Cloud STT`；
+- Config：`GoogleASRConfig`；
+- credential：Service Account JSON；
+- Registry：`createClient = nil`；
+- 语义：传统 Google Cloud Speech-to-Text。
+
+Gemini Transcribe：
+
+- 产品：Gemini Developer API；
+- credential：Gemini API Key；
+- endpoint：`generativelanguage.googleapis.com`；
+- protocol：Gemini Live API WebSocket；
+- model：`gemini-3.5-transcribe-live`；
+- feature：Smart transcription / custom vocabulary / Live VAD。
+
+如果复用 `.google`，会导致 persisted provider ID、credential schema 和产品命名发生语义冲突。
+
+因此新增：
+
+```swift
+case gemini
+```
+
+## 4. 官方协议事实
+
+第一版依赖以下官方约束：
+
+- Model：`gemini-3.5-transcribe-live`；
+- Transport：WebSocket；
+- Endpoint：`wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent`；
+- Input：raw 16-bit PCM；
+- 推荐采样率：16 kHz；
+- Channel：mono；
+- 推荐 chunk：约 100ms；
+- MIME：`audio/pcm;rate=16000`；
+- Interim field：`serverContent.interimInputTranscription`；
+- Final field：`serverContent.inputTranscription`；
+- Auto language：`languageCodes: []`；
+- Custom vocabulary：最多 1,000 项；
+- Mode：`SMART` / `VERBATIM`；
+- Live session 最大时长：10 分钟；
+- Manual VAD：关闭 automatic activity detection 后使用 `activityStart` / `activityEnd`。
+
+### 4.1 字段命名核实结果（已完成，2026-08-27）
+
+本文档中的 JSON 字段名已对照官方 SDK `googleapis/python-genai`（`google/genai/_live_converters.py`、`google/genai/types.py`，main 分支）逐条核实完毕，**全部与本文档采用的命名一致**，未发现需要改名的项：
+
+| 位置 | 采用命名 | 核实来源 | 结论 |
+|---|---|---|---|
+| setup 转写配置对象 | `setup.inputAudioTranscription` | `_LiveClientSetup_to_mldev` | ✅ 确认 |
+| 转写配置字段 | `languageCodes` / `customVocabulary` / `mode` | `AudioTranscriptionConfig` | ✅ 确认，`mode` 取值 `VERBATIM` \| `SMART`，省略时服务端默认 `VERBATIM` |
+| response modalities 层级 | `setup.generationConfig.responseModalities` | `_LiveClientSetup_to_mldev` | ✅ 确认（非 setup 根层） |
+| 手动 VAD 开关 | `setup.realtimeInputConfig.automaticActivityDetection.disabled` | `RealtimeInputConfig` / `AutomaticActivityDetection` | ✅ 确认 |
+| 实时音频负载 | `realtimeInput.audio`（Blob `{data, mimeType}`） | `_LiveClientRealtimeInput_to_mldev` | ✅ 确认；`mediaChunks` 为旧版命名，两者并存 |
+| turn 结束信号 | 仅 `realtimeInput.activityEnd` | `audio_stream_end` 字段说明 | ✅ 确认；SDK 明确 `audioStreamEnd` **只能在自动 VAD 启用时发送**，本方案用手动 VAD，故不得发送 |
+| interim / final 字段 | `serverContent.interimInputTranscription` / `serverContent.inputTranscription` | `LiveServerContent` | ✅ 确认，interim 描述为 "Low latency transcription updated while the user is speaking" |
+| setup ack | `setupComplete` | `LiveServerMessage` | ✅ 确认 |
+
+另确认：自动语言检测传 `languageCodes: []`（或省略）是官方明确支持的写法。
+
+字段名仍全部集中在 `GeminiTranscribeProtocol` 内，使后续 API 演进只影响单文件。
+
+## 5. 文件变更规划
+
+### 5.1 新增文件
+
+```text
+Type4Me/ASR/GeminiASRClient.swift
+Type4Me/ASR/GeminiConnectionGate.swift
+Type4Me/ASR/Providers/GeminiASRConfig.swift
+Type4Me/Protocol/GeminiTranscribeProtocol.swift
+Type4MeTests/GeminiASRClientTests.swift
+Type4MeTests/GeminiASRConfigTests.swift
+Type4MeTests/GeminiLocalizationTests.swift
+Type4MeTests/GeminiTranscribeProtocolTests.swift
+```
+
+`GeminiConnectionGate.swift` 同时承载连接 gate、`GeminiCloseTracker` 与 `URLSessionWebSocketDelegate`（§24.1）。
+
+### 5.2 修改文件
+
+```text
+Type4Me/ASR/ASRProvider.swift
+Type4Me/ASR/ASRProviderRegistry.swift
+Type4Me/Session/RecognitionSession.swift
+Type4Me/UI/Settings/ASRSettingsCard.swift
+Type4MeTests/ASRProviderRegistryTests.swift
+AGENTS.md
+README.md
+```
+
+`RecognitionSession.swift` 的改动只有一处：在 `currentASREndpoint()` 中补 `.gemini` 分支（见 §13.1）。识别流程本身不需要修改。
+
+`CHANGELOG.md` 只在对应发布流程中更新。
+
+## 6. ASRProvider
+
+新增到 International 区域：
+
+```swift
+case gemini
+```
+
+显示名：
+
+```swift
+case .gemini:
+    return "Gemini"
+```
+
+Provider 名固定为厂商名 `Gemini`，**不带模型版本**。具体模型（当前为 `gemini-3.5-transcribe-live`）是 provider 下的一个可选项，见 §7.2，这样后续 Google 增加新的转写模型时无需新增 provider。
+
+不要将 `.google` 改名为 Gemini，也不要迁移已有 `.google` credential。
+
+## 7. GeminiASRConfig
+
+建议定义：
+
+```swift
+enum GeminiTranscriptionMode: String, Sendable, CaseIterable {
+    case smart = "SMART"
+    case verbatim = "VERBATIM"
+}
+
+struct GeminiASRConfig: ASRProviderConfig, Sendable {
+    static let provider = ASRProvider.gemini
+    static let displayName = "Gemini"
+
+    static let supportedModels: [(id: String, label: String)] = [
+        ("gemini-3.5-transcribe-live", "Gemini 3.5 Transcribe (Live)"),
+    ]
+    static let defaultModel = "gemini-3.5-transcribe-live"
+
+    static let webSocketBaseURL = "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
+
+    let apiKey: String
+    let model: String
+    let mode: GeminiTranscriptionMode
+    let languageCode: String
+}
+```
+
+### 7.1 credentialFields
+
+API Key：
+
+```swift
+CredentialField(
+    key: "apiKey",
+    label: "API Key",
+    placeholder: "...",
+    isSecure: true,
+    isOptional: false,
+    defaultValue: ""
+)
+```
+
+Mode：
+
+```swift
+CredentialField(
+    key: "mode",
+    label: L("转写模式", "Transcription Mode"),
+    placeholder: "",
+    isSecure: false,
+    isOptional: true,
+    defaultValue: "SMART",
+    options: [
+        FieldOption(value: "SMART", label: L("智能整理", "Smart")),
+        FieldOption(value: "VERBATIM", label: L("逐字转写", "Verbatim")),
+    ]
+)
+```
+
+Language：
+
+```swift
+CredentialField(
+    key: "languageCode",
+    label: L("语言提示", "Language Hint"),
+    placeholder: L("BCP-47，例如 en-US", "BCP-47, e.g. en-US"),
+    isSecure: false,
+    isOptional: true,
+    defaultValue: "auto",
+    options: [
+        FieldOption(value: "auto", label: L("自动检测", "Auto Detect")),
+        FieldOption(value: "cmn-Hans-CN", label: L("中文（普通话）", "Mandarin Chinese")),
+        FieldOption(value: "yue-Hant-HK", label: L("粤语", "Cantonese")),
+        FieldOption(value: "en-US", label: "English (US)"),
+        FieldOption(value: "ja-JP", label: "日本語"),
+        FieldOption(value: "ko-KR", label: "한국어"),
+    ],
+    allowCustomInput: true
+)
+```
+
+### 7.2 模型选择（provider 与 model 解耦）
+
+Provider 是厂商（`Gemini`），模型是 provider 下的一层选择。设置页字段顺序为 **API Key → 模型 → 转写模式 → 语言提示**。
+
+- `model` 是非 secure、可选字段，落在 `credentials.json`，缺省或留空时回退 `defaultModel`；
+- 字段带下拉选项，同时 `allowCustomInput: true`，便于新模型上线时用户先手填、我们再补进 `supportedModels`；
+- 新增模型只需往 `supportedModels` 追加一行，**不新增 ASRProvider case，也不影响已保存的凭据**；
+- Gemini 要求完全限定名 `models/<id>`。用户可能粘贴任一形式，统一由 `GeminiTranscribeProtocol.qualifiedModelName(_:)` 归一化：去掉已有 `models/` 前缀、trim 空白、为空时回退默认模型，再补上前缀，避免出现 `models/models/...`；
+- 若将来某个模型不支持流式，再在 `ASRProviderRegistry.capabilities` 里按模型细分，本版不提前抽象。
+
+### 7.3 config normalization
+
+`init?(credentials:)`：
+
+- apiKey trim 后不能为空；
+- model 缺省或 trim 后为空回退 `defaultModel`；
+- mode 非法值回退 `.smart`；
+- language 为空回退 `auto`；
+- custom BCP-47 只做 trim，不在客户端维护完整语言白名单。
+
+理由：Google 支持语言列表会变化，不应把 85+ code 复制成 Type4Me 的长期 hard-coded validation source。
+
+## 8. Registry
+
+注册：
+
+```swift
+.gemini: ProviderEntry(
+    configType: GeminiASRConfig.self,
+    createClient: { GeminiASRClient() },
+    capabilities: .streaming()
+),
+```
+
+不需要自定义 `validateCredentials` closure。
+
+当前 Registry 的通用 fallback 会：
+
+```text
+createClient
+→ connect(config, options)
+→ disconnect()
+```
+
+Gemini `connect()` 会真实执行 WebSocket handshake 和 setup，因此足以验证凭证和模型可访问性。
+
+Registry 测试确认：
+
+- isAvailable == true；
+- isStreaming == true；
+- supportsRealtimeRecognition == true；
+- audioInput == .pcmData；
+- Direct mode supported。
+
+## 9. WebSocket 建连
+
+### 9.1 URL
+
+官方原生 WebSocket 示例使用：
+
+```text
+wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key=<API_KEY>
+```
+
+第一版遵循官方示例使用 query API Key。
+
+安全要求：
+
+- 不把 `url.absoluteString` 写入日志；
+- Debug log 只记录 host、model 和匿名状态；
+- error description 不回显 URL query；
+- `URLRequest` 不进入通用 debug dump。
+
+如果后续官方明确支持并推荐 WebSocket `x-goog-api-key` header，可单独迁移以降低 URL 泄露风险。
+
+### 9.2 URLSession
+
+必须使用：
+
+```swift
+URLSession(
+    configuration: options.urlSessionConfiguration,
+    delegate: delegate,
+    delegateQueue: nil
+)
+```
+
+这样继续支持现有 ASR proxy bypass 与测试注入。
+
+不要使用 `URLSession.shared`。
+
+### 9.3 cloudProxyURL
+
+`ASRRequestOptions.cloudProxyURL` 只服务于 `HAS_CLOUD_SUBSCRIPTION` 下的 `.cloud` provider。Gemini 是 BYOK Provider，**必须忽略该字段**，始终连接官方 endpoint，不提供自定义 Base URL（与产品设计 §4 非目标一致）。
+
+## 10. Connection Gate
+
+Gemini 不能在 WebSocket `didOpen` 后立即视为 ready，因为协议要求首先发送 setup，并等待服务端 `setupComplete`。
+
+建议 gate 状态：
+
+```text
+connecting
+→ socketOpen
+→ setupSent
+→ setupComplete
+→ ready
+```
+
+`connect()` 成功条件：
+
+1. WebSocket handshake 成功；
+2. setup message 成功发送；
+3. 收到 `setupComplete`；
+4. receive loop 已启动。
+
+建议 timeout：5 秒。
+
+错误路径：
+
+- handshake failure；
+- socket close before setup；
+- setup error payload；
+- setup timeout。
+
+可以参考 `DeepgramConnectionGate` 结构，但不要把 Deepgram 类型直接复用到 Gemini。
+
+## 11. Setup Message
+
+推荐 setup：
+
+```json
+{
+  "setup": {
+    "model": "models/gemini-3.5-transcribe-live",   // 实际取自 config.model，见 §7.2
+    "generationConfig": {
+      "responseModalities": ["TEXT"]
+    },
+    "realtimeInputConfig": {
+      "automaticActivityDetection": {
+        "disabled": true
+      }
+    },
+    "inputAudioTranscription": {
+      "languageCodes": [],
+      "customVocabulary": ["Type4Me", "SwiftUI"],
+      "mode": "SMART"
+    }
+  }
+}
+```
+
+### 11.1 languageCodes
+
+如果 config 为 `auto`：
+
+```json
+"languageCodes": []
+```
+
+否则：
+
+```json
+"languageCodes": ["cmn-Hans-CN"]
+```
+
+第一版只发送 0 或 1 个语言提示。
+
+### 11.2 customVocabulary
+
+来源：
+
+```swift
+options.hotwords
+```
+
+处理：
+
+1. trim whitespace/newline；
+2. 丢弃空字符串；
+3. 保序去重；
+4. 最多取 1,000 项。
+
+不要把 `boostingTableID` 映射到 Gemini。
+
+日志只记录 count。
+
+### 11.3 mode
+
+直接映射：
+
+```text
+.smart    → SMART
+.verbatim → VERBATIM
+```
+
+`enablePunc` 不映射，因为 Gemini Live Transcription 没有对应布尔字段。
+
+## 12. 为什么使用 Manual VAD
+
+Type4Me 是明确的 Push-to-Talk / Toggle-to-Talk 交互，客户端天然知道：
+
+- 什么时候开始说；
+- 什么时候结束录音。
+
+官方 Manual VAD 正好允许关闭自动 VAD，然后由客户端发送 `activityStart` / `activityEnd`。
+
+优势：
+
+- 松手即可 finalization；
+- 不需要额外等待服务端 silence timeout；
+- 不会因用户讲话中间的自然停顿提前结束一个 Type4Me recording turn；
+- 与现有快捷键语义一致。
+
+## 13. activityStart 的发送时机
+
+不要在 `connect()` 中发送 `activityStart`。
+
+原因：`RecognitionSession` 在录音开始时会先完成 `connect()`，再等待音频引擎产出第一段有效 PCM，两者之间存在可观的空档；此外 `connect()` 也可能因为重试或 mode 切换而先于真正说话发生。如果在 `connect()` 内就声明 activity 开始，会在没有任何语音的情况下开启一个 turn，浪费 session 时长（Gemini 10 分钟上限从 session 建立起算，见 §25），也可能产生空 final。
+
+需要澄清一个容易误解的点：Type4Me 的 `warmUpASRConnection()` **并不预建 ASR WebSocket**，它只是对 provider 域名发一次 `HEAD` 请求预热 DNS/TLS（见 §13.1）。所以这里的风险不是“复用了预热连接”，而是“connect 早于第一段真实音频”。
+
+Gemini Client 维护：
+
+```swift
+private var didStartActivity = false
+```
+
+第一段非空 PCM 进入 `sendAudio()` 时：
+
+```text
+if !didStartActivity
+  → send activityStart
+  → didStartActivity = true
+send audio payload
+```
+
+这样连接建立与语音起点解耦，不会产生空 turn。
+
+### 13.1 warm-up endpoint
+
+`RecognitionSession.currentASREndpoint()` 目前只为 volcano / stepfunBatch / soniox / deepgram 返回域名，其余走 `default: ""`，即完全不预热。Gemini 必须补一条，否则每次录音都要重新付 DNS + TLS 的冷启动成本：
+
+```swift
+case .gemini:
+    return "https://generativelanguage.googleapis.com"
+```
+
+该预热只做 `HEAD` 请求，不携带 API Key，不建立 WebSocket。
+
+## 14. Audio 输入与 100ms rechunk
+
+当前 `AudioCaptureEngine`：
+
+```text
+sampleRate      = 16000
+channels        = 1
+format          = Int16 PCM
+chunkDurationMs = 200
+samplesPerChunk = 3200
+chunkByteSize   = 6400
+```
+
+Gemini 官方推荐约 100ms、1,024~2,048 frames。
+
+因此不要修改全局 `AudioCaptureEngine`，而在 Gemini Client 内将每个 6,400-byte / 200ms chunk 拆为两个约 3,200-byte / 100ms 子块。
+
+建议常量：
+
+```swift
+private static let targetFramesPerPayload = 1600
+private static let bytesPerSample = 2
+private static let targetPayloadBytes = 3200
+```
+
+### 14.1 residual buffer
+
+虽然当前上游 chunk 固定为 6,400 bytes，Client 仍应实现小型 residual buffer，避免未来 capture chunk 调整后破坏协议：
+
+```text
+append incoming data
+while buffer >= 3200 bytes
+  pop 3200
+  send payload
+endAudio 时 flush residual even if < 3200
+```
+
+不做重采样，不改变样本内容。
+
+## 15. Audio Message
+
+每个约 100ms 子块编码为 Base64 后发送：
+
+```json
+{
+  "realtimeInput": {
+    "audio": {
+      "data": "<BASE64_PCM>",
+      "mimeType": "audio/pcm;rate=16000"
+    }
+  }
+}
+```
+
+Client 不持久化 Base64 string；构造后立即发送并释放临时对象。
+
+## 16. endAudio
+
+`endAudio()`：
+
+1. 若 residual audio 非空，先 flush；
+2. 如果从未发送过有效音频（`didStartActivity == false`），直接返回，**不抛错**；
+3. 若 activity 已开始，发送：
+
+```json
+{
+  "realtimeInput": {
+    "activityEnd": {}
+  }
+}
+```
+
+4. 设置 `didEndAudio = true`；
+5. 不立即 cancel WebSocket；
+6. 等 receive loop 收到 finalized transcript；
+7. 由现有 RecognitionSession 在 final / cleanup 后调用 `disconnect()`。
+
+### 16.1 为什么 endAudio 不能抛 emptyAudio
+
+`GeminiASRError.emptyAudio` 仍保留在错误模型中（供 §16.3 batch fallback 等调用方显式传入空音频的场景使用），但 `endAudio()` 不得抛它。
+
+原因是 `RecognitionSession` 的 teardown 会这样消费返回值：
+
+```text
+endAudioOK = withTimeout(3s) { try await client.endAudio() }
+if !endAudioOK → asrTeardownClean = false
+                → streamingFailed = true
+                → 可能触发 batch fallback
+```
+
+也就是说，从 `endAudio()` 抛错等价于宣告"本次流式识别失败"。对于用户只是按下快捷键没说话的正常场景，这会触发一次毫无意义的 batch fallback。现有流式 client（如 `DeepgramASRClient.endAudio()`）在这种情况下都是静默返回，Gemini 必须保持一致。
+
+空录音本身由 `RecognitionSession` 的既有空结果分支处理，不需要 ASR 层报错。
+
+### 16.2 endAudio 后的 final 时间预算（硬性）
+
+teardown 的实际预算不是"尽快"，而是明确的数字：
+
+| 阶段 | 超时 |
+|---|---|
+| `endAudio()` 本身（streaming provider） | 3s |
+| `endAudio()` 后等待 `isFinal` | 2s |
+| 已有流式文本的 phase-2 快速路径等待 `isFinal` | 1s |
+| 超时后的全量 event drain | 5s |
+
+含义：
+
+- `activityEnd` 到 final transcript **必须稳定在 2s 内**，phase-2 路径下应争取 1s 内；
+- 超出后会退化到 5s 全量 drain，并把 `asrTeardownClean` 置为 false，进而可能触发 batch fallback，用户侧表现为明显卡顿；
+- 因此 §31 手工集成测试必须实测并记录 `activityEnd → final` 的 P50 / P95；
+- 若实测 P95 > 2s，不能靠放宽 Type4Me 超时来解决，应先回头确认是否误用了 Manual VAD 或漏发了 turn 结束信号。
+
+### 16.3 batch fallback 路径
+
+`RecognitionSession.attemptBatchFallback` 对非 Soniox provider 会用同一个 provider 重跑一次：
+
+```text
+createClient
+→ connect(config, ASRRequestOptions(enablePunc: true))
+→ sendAudio(整段录音)
+→ endAudio()
+→ 等待 transcript.isFinal
+```
+
+对 Gemini 有三点必须注意：
+
+1. **单次 `sendAudio` 会传入整段录音**（可能数 MB）。§14 的 residual buffer 循环保证了拆分正确性，但会一次性把数百个 100ms payload 无间隔灌入一个实时端点，可能触发服务端限流或降低识别质量。第一版要求：Gemini Client 在 `sendAudio()` 内对连续 payload 做轻量节流（每个 payload 之间让出一次调度，或按不低于 20× 实时速率发送），避免瞬间突发。
+2. **该路径的 `ASRRequestOptions` 不带热词**（`hotwords` 为空），因此 fallback 结果不享受 `customVocabulary`。这是现有全局行为，第一版不改，但需在 §31 记录差异。
+3. 该路径只接受 `transcript.isFinal == true` 的结果。由于它显式调用了 `endAudio()`，§17.2 的 `isFinal = didEndAudio` 规则天然满足，无需特例。
+
+如果实测表明整段灌入会稳定触发 Gemini 限流，则第一版改为让 Gemini 退出通用 batch fallback（fallback 直接返回 nil），而不是引入重试放大限流。
+
+第一版 Manual VAD 不额外发送 `audioStreamEnd`，避免同时混用两种 turn-finalization 机制。若真实 API 测试表明 `activityEnd` 后仍需要 `audioStreamEnd`，再基于官方行为修正文档和实现。
+
+## 17. Server Message 解析
+
+Protocol 层只建立最小 JSON model。
+
+需要识别：
+
+```text
+setupComplete
+serverContent.interimInputTranscription.text
+serverContent.inputTranscription.text
+error
+```
+
+不要完整复制 Gemini Live API 的所有 Agent / tool / audio response schema。
+
+### 17.1 Interim
+
+收到：
+
+```text
+serverContent.interimInputTranscription.text
+```
+
+映射为：
+
+```swift
+RecognitionTranscript(
+    confirmedSegments: confirmedSegments,
+    partialText: interimText,
+    authoritativeText: confirmedSegments.joined() + interimText,
+    isFinal: false
+)
+```
+
+每次 interim 替换上一个 partial，不追加。
+
+### 17.2 Finalized
+
+收到：
+
+```text
+serverContent.inputTranscription.text
+```
+
+Manual VAD 下预期 final 主要在 `activityEnd` 后产生。
+
+处理：
+
+1. normalize segment spacing；
+2. append 到 `confirmedSegments`；
+3. clear partial；
+4. authoritativeText = confirmedSegments.joined()；
+5. `isFinal = didEndAudio`。
+
+为什么不对所有 `inputTranscription` 都强制 `isFinal = true`：
+
+- Type4Me 的 `RecognitionSession` 把 `isFinal` 视为整次 recording 已完成的强信号；
+- 如果未来 Gemini 在 activity 期间也产生 finalized sub-segment，提前标 final 会导致上层过早开始 teardown / LLM。
+
+因此只有已经执行 `endAudio()` 后收到的 authoritative transcription 才标记整次 `isFinal = true`。
+
+## 18. Transcript 去重与拼接
+
+复用现有 streaming 原则：
+
+- `confirmedSegments` 独立保存；
+- interim 只作为 current partial；
+- final append 一次；
+- 相同 transcript 不重复 yield；
+- CJK 不强制空格；
+- Latin segment 之间按现有 CharacterExtensions 规则补空格；
+- Smart 模式 final 以服务端清理后的文本为权威。
+
+可以抽取 Deepgram 的 segment normalize helper；如果会扩大首版 diff，也可以在 Gemini Protocol 内实现等价私有函数。
+
+## 19. Client 结构
+
+建议：
+
+```swift
+actor GeminiASRClient: SpeechRecognizer {
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var receiveTask: Task<Void, Never>?
+    private var session: URLSession?
+    private var delegate: GeminiWebSocketDelegate?
+    private var connectionGate: GeminiConnectionGate?
+
+    private var eventContinuation: AsyncStream<RecognitionEvent>.Continuation?
+    private var _events: AsyncStream<RecognitionEvent>?
+
+    private var confirmedSegments: [String] = []
+    private var lastTranscript: RecognitionTranscript = .empty
+    private var residualAudio = Data()
+    private var didStartActivity = false
+    private var didEndAudio = false
+}
+```
+
+## 20. connect 生命周期
+
+流程：
+
+```text
+validate GeminiASRConfig
+→ rebuild AsyncStream
+→ build redaction-safe WebSocket request
+→ URLSessionWebSocketTask.resume()
+→ wait didOpen
+→ start receive loop
+→ send setup
+→ wait setupComplete
+→ reset transcript/audio state
+→ emit .ready
+```
+
+注意顺序：receive loop 必须在等待 setupComplete 前开始，否则没有消费者处理服务端 setup ack。
+
+## 21. sendAudio 生命周期
+
+```text
+ignore empty data
+→ append residual buffer
+→ if first real audio: send activityStart
+→ while >= 3200 bytes:
+     pop 3200
+     base64 encode
+     send realtimeInput.audio
+     if 本次调用已连续发送多个 payload: yield / 轻量节流（见 §16.3）
+→ update counters
+```
+
+正常录音时每次 `sendAudio()` 只会产生 2 个 payload，节流不生效；只有 batch fallback 一次性传入整段录音时才会命中。
+
+WebSocket send 失败：
+
+- 抛出错误给 RecognitionSession；
+- receive side 同时发 `.error` 时需要避免双重 completed；
+- 让现有 streaming recovery 有机会接管。
+
+## 22. disconnect
+
+必须：
+
+- cancel receiveTask；
+- WebSocket normal closure；
+- invalidate URLSession；
+- finish event stream；
+- nil continuation / stream；
+- clear gate/delegate；
+- clear confirmed / partial state；
+- clear residual audio；
+- reset activity flags；
+- 不保留 API Key 的 URLRequest 副本。
+
+## 23. Error Model
+
+建议：
+
+```swift
+enum GeminiASRError: Error, LocalizedError, Equatable {
+    case invalidConfig
+    case invalidEndpoint
+    case handshakeTimedOut
+    case setupTimedOut
+    case setupRejected(String?)
+    case emptyAudio
+    case closedBeforeSetup(code: Int, reason: String?)
+    case closed(code: Int, reason: String?)
+    case quotaExceeded(String?)
+    case sessionLimitReached
+    case invalidResponse
+}
+```
+
+`emptyAudio` 仅用于 batch fallback 等“调用方明确传入了空音频”的场景，**不得**从正常录音的 `endAudio()` 抛出（见 §16.1）。
+
+`sessionLimitReached` 用于服务端因 10 分钟 session 上限关闭连接的可判定场景（§25.1）。
+
+### 23.1 服务端 error payload
+
+Gemini Live API error schema 只解析需要展示的字段，不建立庞大错误模型。
+
+对错误文本：
+
+- 最多保留有界长度，例如 1 KB；
+- 去除疑似 API Key / URL query；
+- 用户可见信息映射到中英文 LocalizedError；
+- 原始 JSON 不写 debug log。
+
+## 24. WebSocket Close Handling
+
+参考 Deepgram 的 close tracker，但区分：
+
+- setup 前关闭：连接失败；
+- recording 中异常关闭：stream error；
+- endAudio 后正常关闭：如果 final 已收到可视为完成；
+- endAudio 后关闭但无 final：返回 invalid response / interrupted。
+
+不要把所有 post-handshake close 都视为成功。
+
+### 24.1 实现约定（已落地）
+
+Gemini Live 的大多数失败（配额、session 上限、服务端内部错误）以 **close 帧**而非 JSON `{"error": …}` body 到达，因此 close 通道是主要失败通道，必须接线：
+
+- `GeminiCloseTracker`（对齐 `DeepgramCloseTracker`）记录 setup 完成**之后**的首个异常终止；
+- `GeminiWebSocketDelegate.didCloseWith`：`gate.isReady == true` 时写入 tracker，否则走 `closedBeforeSetup` 让 `connect()` 失败；
+- `didCompleteWithError`：同时写入 tracker 与 gate，覆盖无 close 帧的传输层断开；
+- `GeminiASRError.unexpectedClose(code:reason:)` 忽略 `normalClosure` / `goingAway` / `noStatusReceived`，其余映射为 `.closed(code:reason:)`；reason 同时命中 session/duration/connection 与 limit/exceed/maximum 类关键字时映射为 `.sessionLimitReached`；
+- receive loop 的终止分支：**先** `consumeCloseError()`，有值则 `emit(.error(…))`；无值但本次会话从未发出过 final（`didEmitFinal == false`）同样 `emit(.error(…))`；最后才 `emit(.completed)`。
+
+判定基准是「本次会话是否已交付 final」，而不是「是否发过音频」。只发 `.completed` 会让 `RecognitionSession` 把截断的 partial 当成最终结果注入：不触发 `beginStreamRecovery`，`needsBatchFallback` 因 `lastStreamingError == nil` 且 `hasUsableStreamingResult == true` 而为 false，用户得到静默截断的文本。
+
+## 25. 10 分钟 Session 限制
+
+第一版不自动 rollover。
+
+### 25.1 与 Type4Me 自身录音上限的关系
+
+`RecognitionSession.maxRecordingDuration` 目前是 600 秒，与 Gemini 的 10 分钟 session 上限数值相同，但**两者的起点不同**：
+
+- Type4Me 的 600 秒从**录音开始**计时；
+- Gemini 的 10 分钟从 **WebSocket session 建立（`connect()`）** 起算，早于第一段音频。
+
+因此在长录音场景下，Gemini 一定先于 Type4Me 自身的上限被服务端关闭，600 秒这道保护对 Gemini 实际上永远不会先生效。
+
+第一版处理（已落地，与初稿方案不同）：
+
+- `RecognitionSession` 的录音上限改为 **provider 相关**：`maxRecordingDuration(for:)` 对 `.gemini` 返回 **570 秒（9 分 30 秒）**，其余 provider 仍为 600 秒；
+- 该定时器与 Gemini 的 session 时钟同源（都在 ASR 连接建立后起算），570 < 600 留有 30 秒余量，Type4Me 因此**总是先于服务端关闭主动收尾**；
+- 收尾走既有的 `stoppedByMaxDuration` 路径，复用已本地化的「已达最大时长 / Max duration reached」提示，**不新增 UI 组件、不新增事件类型**；
+- 万一服务端仍抢先关闭，§24.1 的 close tracker 会把它映射为 `.sessionLimitReached` 并触发恢复流程，用户不会静默丢字；
+- 不自动重连；文档与设置页统一表述为「单次实时识别约 10 分钟」，不承诺精确到秒。
+
+**放弃初稿的「9 分 30 秒发一次提示」方案的原因**：录音进行中没有可用的非中断提示通道——`RecognitionEvent.error` 会触发 `beginStreamRecovery` 打断录音，`recoveryPrompt` / `macActionResult` 会重置热键状态，`processingLabelOverride` 在 `stopRecording()` 时被清空。主动提前收尾比新增一条 UI 通道更简单，且用户可感知的结果更好。
+
+Client 记录 connect / start activity 时间，同时用于诊断。
+
+如果服务端因为 session limit 主动关闭：
+
+- 识别为可理解的 session limit 错误（如果 reason 可判定）；
+- 不把当前 partial 当作完整 final；
+- 让现有恢复机制保留可恢复路径；
+- UI 提示用户单次 Gemini Live 录音最长约 10 分钟。
+
+后续 rollover 需要独立设计：
+
+```text
+finalize segment
+→ reconnect
+→ activityStart
+→ continue audio
+→ merge transcript
+```
+
+不在首版实现。
+
+## 26. Rate Limits 与 Free Tier
+
+Rate limit 属于 Google Project / Usage Tier，不在客户端硬编码 RPM / TPM / RPD 数字。
+
+Client 只负责：
+
+- 识别 quota / rate-limit 类错误；
+- 给出可理解提示；
+- 不做激进自动重试，避免加剧限流。
+
+定价和 Free Tier 只属于文档与链接，不进入核心识别逻辑。
+
+## 27. Settings 集成
+
+`ASRSettingsCard.currentASRGuideLinks` 增加 `.gemini`：
+
+- Live Transcription Docs；
+- Get API Key；
+- Pricing / Rate Limits。
+
+Provider note 建议：
+
+中文：
+
+`实时流式识别。Smart 模式会自动清理口语停顿、重复和自我纠正；如需逐字记录可切换为 Verbatim。`
+
+英文：
+
+`Real-time streaming transcription. Smart mode cleans up disfluencies, repetitions, and self-corrections; switch to Verbatim for literal transcripts.`
+
+不修改：
+
+```swift
+private static let recommendedProviders: [ASRProvider] = [.volcano, .soniox]
+```
+
+首版 Gemini 自动进入 Others。
+
+## 28. Keychain 与持久化
+
+`apiKey`：secure → Keychain。
+
+`mode`、`languageCode`：non-secure → credentials.json。
+
+不增加新的 UserDefaults key。
+
+Persisted provider ID 为：
+
+```text
+gemini
+```
+
+与 LLM 层可能存在的 Gemini provider 名称互不冲突，因为枚举类型不同。
+
+## 29. Unit Tests
+
+### 29.1 GeminiASRConfigTests
+
+覆盖：
+
+- missing apiKey → nil；
+- whitespace apiKey → nil；
+- default mode SMART；
+- VERBATIM round trip；
+- invalid mode fallback SMART；
+- default language auto；
+- custom BCP-47 round trip；
+- secure/non-secure field metadata。
+
+### 29.2 GeminiTranscribeProtocolTests
+
+覆盖：
+
+- WebSocket endpoint；
+- API Key query 正确 percent-encode；
+- 日志 redaction helper 不暴露 key；
+- setup model；
+- responseModalities TEXT；
+- automaticActivityDetection.disabled == true；
+- auto language → []；
+- explicit language → [code]；
+- Smart / Verbatim mapping；
+- customVocabulary trim / de-dup / max 1000；
+- activityStart message；
+- activityEnd message；
+- audio message MIME；
+- Base64 可还原原 PCM；
+- setupComplete parse；
+- interim parse；
+- final parse；
+- malformed response；
+- error response。
+
+### 29.3 Rechunk Tests
+
+覆盖：
+
+- 6400 bytes → 3200 + 3200；
+- 3200 bytes → one payload；
+- 1000 + 2200 → one payload；
+- residual 在 endAudio flush；
+- 空 audio 不发 activityStart；
+- **整段录音（batch fallback 规模，例如 1.92 MB）→ 600 个 payload 且顺序、内容无损**（对应 §16.3）；
+- 从未发送音频时 `endAudio()` 不抛错（对应 §16.1）；
+- 未 connect 时 `sendAudio()` / `disconnect()` 均不抛错、可重复调用。
+
+这几条 client 级行为由 `GeminiASRClientTests` 覆盖，无需网络。
+
+### 29.3.1 Close Handling Tests（对应 §24.1）
+
+- `unexpectedClose` 忽略 `normalClosure` / `goingAway` / `noStatusReceived`；
+- 其余 close code 映射为 `.closed(code:reason:)`；
+- reason 命中 session 时长关键字时映射为 `.sessionLimitReached`，普通 `internal error` 不得误判；
+- `GeminiCloseTracker` 只记录首个异常终止、`consumeCloseError()` 取走后清空；
+- 传输层失败经 `recordFailure` 记录，且不被后续 `normalClosure` 覆盖。
+
+### 29.4 Registry Tests
+
+覆盖 `.gemini`：
+
+- available；
+- streaming；
+- realtime recognition；
+- pcmData；
+- createClient non-nil；
+- Direct mode supported。
+
+### 29.5 本地化测试
+
+按 AGENTS.md 的强制本地化要求，新增设置字段属于语言敏感 UI，必须覆盖：
+
+- `tf_language` 为中文时，模型、转写模式与语言提示字段的 label / option 文案为中文；
+- 切换为英文后，同一字段渲染为英文，且无需重启；
+- Provider 显示名 `Gemini` 在两种语言下一致，不被翻译；模型 id（如 `gemini-3.5-transcribe-live`）同样不翻译；
+- §14 错误表中的用户可见文案中英文均存在且非空；
+- 用户已选中的 `model` / `mode` / `languageCode` **值**在语言切换后不变（持久化的是语义值，不是 UI 字符串）。
+
+## 30. Client Test Strategy
+
+如果现有 `URLProtocol` 无法直接 stub WebSocket，则将 protocol parsing、message creation、rechunk 和 connection gate 做成纯单元可测部分。
+
+至少补充可注入 transport 或最小 WebSocket test seam，覆盖：
+
+1. open 后 setup；
+2. setupComplete 后 ready；
+3. 第一段 audio 前只发一次 activityStart；
+4. 200ms audio 拆成两个 payload；
+5. interim → partial；
+6. endAudio → activityEnd；
+7. endAudio 后 final → isFinal true；
+8. invalid setup → error；
+9. abnormal close → error；
+10. disconnect cleanup。
+
+## 31. 手工集成测试
+
+需要真实 Gemini API Key。
+
+### 中文 Smart
+
+- Auto；
+- 10 秒中文；
+- 包含“嗯”“那个”和一次口头纠正；
+- 验证 interim 延迟与 Smart final。
+
+### 中文 Verbatim
+
+同一段内容切换 Verbatim，确认口语内容保留程度明显不同。
+
+### 中英混输
+
+例如：
+
+`帮我把 Type4Me 的 Gemini WebSocket provider 改成 Swift actor。`
+
+检查 code-switching 和术语。
+
+### Hotwords
+
+加入：
+
+- Type4Me；
+- SwiftUI；
+- WebSocket；
+- Antigravity。
+
+比较开启前后。
+
+### 网络与凭证
+
+- invalid API Key；
+- 无网络；
+- proxy bypass on/off；
+- quota / 429（若测试项目可触发）；
+- WebSocket 中断。
+
+### 延迟实测（必须记录数据）
+
+- `connect()` → `setupComplete`；
+- 第一段音频 → 第一个 interim；
+- **`activityEnd` → final transcript 的 P50 / P95**，对照 §16.2 的 2s / 1s 阈值；
+- 超标时记录是否退化到全量 drain。
+
+### batch fallback
+
+- 人为制造流式失败（如录音中断网后恢复），确认 fallback 路径可用；
+- 确认整段音频灌入未触发限流；
+- 记录 fallback 结果缺少热词偏置带来的差异（§16.3 第 2 点）。
+
+### 长录音
+
+- 连续录音超过 9 分 30 秒，确认 Type4Me 在 570 秒主动收尾并显示「已达最大时长」，文本完整无截断；
+- 超过 10 分钟被服务端关闭时，确认不会把 partial 当作完整 final 注入。
+
+### UI
+
+- 普通浮动栏实时文字；
+- compact live transcript；
+- 松手后 final 不重复；
+- Direct / LLM 两类 mode。
+
+## 32. Build 与 Regression
+
+实现后至少：
+
+```bash
+swift test
+swift build
+```
+
+重点回归：
+
+- Deepgram streaming；
+- Soniox streaming；
+- Grok streaming；
+- MiMo batch；
+- ASR Settings Picker；
+- Keychain save/load；
+- HotwordStorage；
+- RecognitionSession streaming teardown；
+- **batch fallback（`attemptBatchFallback`）路径**；
+- **中英语言切换后的 ASR 设置页**；
+- compact live transcript；
+- Direct 与 LLM ProcessingMode。
+
+## 33. 实现顺序
+
+1. 增加 `.gemini`；
+2. 增加 `GeminiASRConfig` + tests；
+3. **核实 §4.1 的全部字段命名并回写文档**（已完成：对照官方 SDK `googleapis/python-genai` 的 `_live_converters.py` / `types.py`，全部确认）；
+4. 增加 `GeminiTranscribeProtocol` + message/parser tests（字段名以第 3 步结论为准）；
+5. 增加 100ms rechunk helper + tests；
+6. 增加 connection gate；
+7. 实现 `GeminiASRClient.connect()` + setupComplete；
+8. 实现 Manual VAD + audio streaming（含 §16.3 的发送节流）；
+9. 实现 interim/final transcript mapping；
+10. Registry 注册为 `.streaming()`；
+11. `RecognitionSession.currentASREndpoint()` 补 `.gemini` warm-up 域名；
+12. Settings links / provider note；
+13. Registry / client / 本地化 tests；
+14. 真实 API 集成测试（含 §16.2 的 final 延迟实测）；
+15. README / AGENTS provider 清单；
+16. `swift test` + `swift build`；
+17. ASR Evaluation 对比。
+
+第 3 步是硬性前置：在字段名未确认前不要写 §29.2 的断言，否则测试会把错误的协议假设固化下来。该步骤已于 2026-08-27 完成，结论见 §4.1。
+
+## 34. 风险与缓解
+
+### 风险 1：API Key 出现在 WebSocket URL
+
+官方 WebSocket 示例使用 `?key=`。
+
+缓解：禁止完整 URL 日志、禁止 URLRequest dump、错误文本 redaction。后续若官方确认 header auth，优先迁移。
+
+### 风险 2：setup ready 与 socket open 混淆
+
+缓解：只有 `setupComplete` 后才 emit ready。
+
+### 风险 3：200ms chunk 增加识别延迟
+
+缓解：Client 内拆成约 100ms payload，不改全局 capture cadence。
+
+### 风险 4：Manual VAD 在用户开口前提前开始 turn
+
+`connect()` 早于第一段真实音频，若在 connect 时就声明 activity 开始，会浪费 session 时长并可能产生空 turn。（注意：Type4Me 的 warm-up 只是 HTTP HEAD 预热，并不预建 WebSocket，见 §13。）
+
+缓解：activityStart 延迟到第一段真实 `sendAudio()`。
+
+### 风险 5：Gemini 提前发送 finalized sub-segment
+
+缓解：只有 `didEndAudio == true` 时才把 authoritative transcript 标记为 Type4Me `isFinal = true`。
+
+### 风险 6：Smart 过度改写
+
+缓解：默认 Smart 但提供 Verbatim；Evaluation 单独记录 over-edit 情况。
+
+### 风险 7：10 分钟连接上限
+
+缓解：首版明确不做会议级长录音；session 计时从 `connect()` 起算，早于 Type4Me 自身 600s 上限，故对 Gemini 把录音上限收紧到 570 秒并主动收尾（§25.1）；服务端仍抢先关闭时由 close tracker 映射为 `.sessionLimitReached`，不静默成功（§24.1）；后续独立 rollover 设计。
+
+### 风险 8：Rate limit 经常变化
+
+缓解：不硬编码 Free Tier 数字；只映射错误并链接官方额度页面。
+
+### 风险 9：Live API schema 扩张
+
+缓解：Protocol 只解析 setup / transcript / error 最小子集，不引入完整 Gemini Agent schema。
+
+### 风险 10：setup / 消息字段命名与实际 API 不符
+
+公开资料对转写配置对象、responseModalities 层级和实时音频负载的命名存在分歧（§4.1）。
+
+缓解：字段名集中在 `GeminiTranscribeProtocol` 单文件；实现顺序第 3 步已完成核实（对照官方 SDK）并回写文档，测试断言据此锁定。
+
+### 风险 11：batch fallback 整段音频灌入触发限流
+
+缓解：`sendAudio()` 内做轻量节流（§16.3）；若实测仍稳定触发限流，则第一版让 Gemini 退出通用 batch fallback，而不是重试放大限流。
+
+### 风险 12：final transcript 超出 teardown 预算
+
+`activityEnd → final` 必须稳定在 2s 内（phase-2 路径 1s），否则每次录音都退化到 5s 全量 drain 并可能误触发 fallback。
+
+缓解：§16.2 定为硬性验收阈值，集成测试实测 P50 / P95；超标时先排查 Manual VAD 用法，不放宽 Type4Me 超时。
+
+## 35. 第一版最终技术决策
+
+| 项目 | 决策 |
+|---|---|
+| ASR Provider ID | `.gemini` |
+| 与 `.google` 关系 | 独立，不复用 |
+| Capability | `.streaming()` |
+| Model | `gemini-3.5-transcribe-live` |
+| Transport | URLSession WebSocket |
+| Endpoint | Gemini `v1beta` BidiGenerateContent |
+| Authentication | 官方 WebSocket `?key=`，日志严格 redaction |
+| Audio | 16 kHz / Int16 / mono PCM |
+| Capture chunk | 现有 200ms 不改 |
+| Gemini payload | Client 内拆为约 100ms |
+| VAD | Manual PTT |
+| activityStart | 第一段真实 audio 前 |
+| activityEnd | `endAudio()` |
+| Interim | `partialText` |
+| Final | confirmed + endAudio 后 `isFinal` |
+| Mode | SMART 默认 / VERBATIM 可选 |
+| Language | Auto + 单个 BCP-47 hint |
+| Hotwords | `customVocabulary`，最多 1000 |
+| Punctuation flag | 不直接映射 |
+| Credential test | 通用 connect/disconnect 即可真实验证 |
+| Session rollover | 首版不做 |
+| Session 上限处理 | Gemini 专属 570 秒录音上限，主动收尾复用「已达最大时长」提示（§25.1） |
+| endAudio 空音频 | 静默返回，不抛错（§16.1） |
+| final 延迟预算 | `activityEnd → final` ≤ 2s（phase-2 路径 ≤ 1s） |
+| batch fallback | 沿用通用路径，`sendAudio` 内节流；限流则退出该路径 |
+| warm-up | `currentASREndpoint()` 增加 Gemini 域名，仅 HEAD 预热 |
+| cloudProxyURL | 忽略，不支持自定义 Base URL |
+| 协议字段名 | 已对照官方 SDK `googleapis/python-genai` 核实并锁定（§4.1） |
+| SDK dependency | 不引入 Google Gen AI SDK |

--- a/docs/features/gemini-transcribe-asr/product-design.md
+++ b/docs/features/gemini-transcribe-asr/product-design.md
@@ -1,0 +1,470 @@
+# Type4Me Gemini ASR Provider 产品设计
+
+> 分支：`feat/gemini-transcribe-asr`
+> 文档类型：产品设计
+> 文档状态：已 review（2026-08-27），待实现
+> 设计日期：2026-08-27
+> 目标版本：Type4Me 2.x
+> 官方 Live Transcription 文档：https://ai.google.dev/gemini-api/docs/live-api/live-transcribe
+> 官方模型说明：https://ai.google.dev/gemini-api/docs/models/gemini-3.5-transcribe
+> 官方定价：https://ai.google.dev/gemini-api/docs/pricing
+> 官方 Rate Limits：https://ai.google.dev/gemini-api/docs/rate-limits
+
+## 1. 背景
+
+Google 在 2026 年 8 月发布 Gemini 3.5 Transcribe，其中 `gemini-3.5-transcribe-live` 是面向实时语音识别的专用 Live API 模型。它通过 WebSocket 接收持续 PCM 音频，并同时返回低延迟 interim transcript 与 finalized transcript。
+
+Type4Me 当前已经有成熟的多 Provider ASR 架构，也已经具备实时识别文本、热词、录音快捷键、紧凑型实时转写指示器和最终文本处理管线，因此这个能力不需要引入新的产品工作流，适合作为一个新的 BYOK 云端实时 ASR Provider 接入。
+
+本功能的核心产品判断是：
+
+**Gemini 应作为独立的实时 ASR Provider 接入 Type4Me，而不是复用现有的 Google Cloud STT 占位 Provider。**Provider 在 UI 上叫 `Gemini`（厂商名），`gemini-3.5-transcribe-live` 是它下面的模型选项，后续新模型直接在同一 provider 内扩展。
+
+原因是 Gemini Developer API 与 Google Cloud Speech-to-Text 在产品、鉴权、Endpoint、计费和模型语义上均属于不同体系。Type4Me 现有 `.google` 应继续表示传统 Google Cloud STT。
+
+## 2. 产品定位
+
+Gemini 实时转写在 Type4Me 中定位为：
+
+- BYOK 云端实时语音识别；
+- 面向日常语音输入和中英混输；
+- 支持热词偏置；
+- 支持可选 Smart Dictation；
+- 支持录音期间实时显示文字；
+- 不承担 Agent、LLM 对话或多模态理解能力。
+
+它不是“Antigravity 模式”的复制。Antigravity 产品内部可能结合屏幕和聊天上下文，而 Gemini Transcribe Live API 本身是音频输入的专用转写接口。第一版 Type4Me 只接入公开 API 能力。
+
+## 3. 产品目标
+
+### 3.1 核心目标
+
+1. 新增 `Gemini` 云端实时 ASR Provider，并在其下提供模型选择（首版 `gemini-3.5-transcribe-live`）；
+2. 支持按住/切换快捷键录音期间实时显示 interim transcript；
+3. 松开快捷键后快速得到 finalized transcript；
+4. 默认使用 Smart transcription，优化语音输入文本的可读性；
+5. 提供 Verbatim 模式满足逐字转写需求；
+6. 将 Type4Me 全局热词映射到 Gemini `custom_vocabulary`；
+7. 默认自动检测语言，同时允许用户提供常用语言提示或自定义 BCP-47 code；
+8. API Key 使用现有 macOS Keychain；
+9. 保持 Direct、Intelli Sense、翻译、自定义 Prompt 等后处理流程不变；
+10. 不增加 Type4Me 自有服务端、账号或代理依赖。
+
+### 3.2 成功标准
+
+1. 用户可在「识别引擎」中选择 `Gemini`，并在其下选择模型，且不会显示「非实时 / Batch」标记；
+2. 有效 Gemini API Key 可以通过设置页连接测试；
+3. 录音开始后能够在浮动栏和紧凑型实时转写区域看到持续更新的文本；
+4. 松开快捷键后，最终 transcript 稳定在 **2 秒内**返回（已有实时文本的快速路径为 **1 秒内**）；这是 Type4Me 现有流式 teardown 的硬性预算，超出会退化为约 5 秒的全量等待并可能触发一次多余的兜底识别；
+5. 热词能够影响专有名词、技术词汇、产品名等识别；
+6. Smart 与 Verbatim 两种模式行为明显且可预测；
+7. 中英文及中英 code-switching 可以使用默认 Auto 模式完成；
+8. 无效 Key、配额限制、网络错误、服务端关闭等不会被误报为成功；
+9. 不记录 API Key、完整 WebSocket URL 或原始音频内容到日志。
+
+## 4. 非目标
+
+第一版不包含：
+
+- `gemini-3.5-transcribe` 文件型 Batch Transcription；
+- Speaker diarization；
+- Word-level timestamps；
+- 会议级长录音与 10 分钟以上 session rollover；
+- 将截图、当前窗口文本或 Agent chat history 直接发送给 Gemini Transcribe；
+- 使用通用 Gemini Live Agent 代替专用 Transcribe 模型；
+- 自定义模型 ID；
+- 自定义 Gemini Base URL；
+- Type4Me Cloud 代理或统一计费；
+- 自动根据当前 App/代码仓库生成额外 dynamic vocabulary；
+- 将 Gemini 在首版直接加入“推荐 Provider”。
+
+## 5. Provider 命名与分类
+
+### 5.1 用户可见名称
+
+Provider 名在中英文下统一显示为厂商名：
+
+`Gemini`
+
+模型作为 provider 下的一层选择单独呈现，首版下拉里只有一项：
+
+`Gemini 3.5 Transcribe (Live)` → `gemini-3.5-transcribe-live`
+
+这样命名的原因：Gemini 产品线包含 LLM、Live Agent、TTS、Translate 等多类模型，把模型版本塞进 provider 名会在 Google 发布新转写模型时逼我们新增 provider 或改名。选择路径改为「先选 Gemini，再选模型」后，新模型只是下拉里多一行，用户已保存的 API Key 与其他配置不受影响。
+
+与 §5.3 的区分靠的是 `Google Cloud STT` 与 `Gemini` 两个入口本身，以及设置页的说明文案，而不是把模型版本写进 provider 名。
+
+### 5.2 Provider 分类
+
+第一版放入设置页的“其他 / Others”分组，不加入当前“推荐 / Recommended”。
+
+原因：
+
+- 模型刚发布；
+- Type4Me 尚未完成真实中英混输、延迟、稳定性和成本评测；
+- 推荐状态应基于 Type4Me 自有 Evaluation 结果，而不是官方宣传指标。
+
+### 5.3 与 Google Cloud STT 的边界
+
+保留现有 `Google Cloud STT` 入口语义，不重命名、不复用其 Service Account 配置。
+
+用户应该能够明确区分：
+
+- `Google Cloud STT`：传统 Google Cloud Speech-to-Text；
+- `Gemini`：Gemini Developer API 的实时 Transcribe 模型系列。
+
+## 6. 核心交互流程
+
+### 6.1 开始录音
+
+用户开始录音时：
+
+1. Type4Me 建立或复用当前 Gemini WebSocket session；
+2. 完成模型 setup；
+3. 第一段真实音频到达时声明一次语音活动开始；
+4. 持续发送 PCM 音频；
+5. 收到 interim transcript 后实时刷新浮动栏。
+
+用户感知为：
+
+`开始录音 → 很快出现文字 → 文字随讲话持续修正`
+
+### 6.2 录音期间
+
+Gemini 会提供两类文本：
+
+- Interim：低延迟、可被后续结果替换；
+- Finalized：当前语音段的权威结果。
+
+Type4Me UI 应继续遵守现有原则：
+
+- partial 只替换，不重复追加；
+- confirmed segment 只在 final 后提交；
+- UI 展示 `confirmed + partial`；
+- 不因为 interim 抖动而产生重复文本。
+
+### 6.3 松开快捷键
+
+松开快捷键后：
+
+1. Type4Me 明确声明语音活动结束；
+2. Gemini 尽快完成本次 turn finalization；
+3. 最终 transcript 替换 interim；
+4. 进入现有 Direct / LLM 后处理 / 注入流程；
+5. 当前 WebSocket 由现有 session cleanup 逻辑关闭。
+
+第一版采用 Push-to-Talk 的 Manual VAD 语义，避免松开后继续等待服务端自行判断长静音。
+
+## 7. 设置设计
+
+### 7.1 字段
+
+第一版提供：
+
+| 字段 | 类型 | 默认值 | 必填 |
+|---|---|---|---|
+| API Key | Secure | 空 | 是 |
+| 转写模式 | Picker | Smart | 否 |
+| 语言提示 | Picker + Custom | Auto | 否 |
+
+模型固定为：
+
+`gemini-3.5-transcribe-live`
+
+不向普通用户暴露 Model 和 Base URL。
+
+### 7.2 转写模式
+
+选项：
+
+- `Smart`：默认；
+- `Verbatim`：逐字。
+
+Smart 适合 Type4Me 的“语音输入”定位，会自动处理 filler words、重复、口误、自我纠正、数字、日期、列表、段落、大小写与标点。
+
+Verbatim 适合：
+
+- 会议原话记录；
+- 采访；
+- 语言学习；
+- 需要保留语气词、重复和 false start 的场景。
+
+### 7.3 为什么默认 Smart
+
+Type4Me 的主场景不是法庭逐字稿，而是“说完即可输入”。用户通常期待的是接近书面输入的结果，而不是保留“嗯、呃、那个、我说错了”等口语噪声。
+
+因此：
+
+**Gemini Provider 默认 Smart，但必须允许用户切回 Verbatim。**
+
+### 7.4 语言提示
+
+默认：`Auto Detect`
+
+建议首版预设：
+
+- Auto Detect；
+- 中文（普通话，简体）；
+- 粤语（繁体，香港）；
+- English (US)；
+- 日本語；
+- 한국어；
+- Custom BCP-47。
+
+Auto 不锁定单一语言，并支持跨 utterance 的语言切换，因此仍是绝大多数用户的推荐设置。
+
+不在 Picker 中硬编码全部 85+ 语言，避免设置菜单过长；高级用户可以通过 Custom 输入官方支持的 BCP-47 code。
+
+## 8. 热词
+
+Gemini Live Transcription 支持 `custom_vocabulary`，最多 1,000 个术语，官方建议通常在 100 个以内效果最佳。
+
+Type4Me 第一版直接复用全局 HotwordStorage：
+
+`Type4Me hotwords → trim / 去空 / 去重 → Gemini customVocabulary`
+
+产品要求：
+
+- 不增加 Gemini 独立热词编辑器；
+- 不改变现有全局热词语义；
+- 不静默添加 Type4Me 自己的营销词或第三方词；
+- 最多发送官方允许的 1,000 个词；
+- 超过 1,000 个时只发送前 1,000 个，并在 Debug 日志记录数量，不记录词内容。
+
+后续若加入当前 App、文件名、repo symbol 等上下文，应作为独立的“动态词表”功能设计，不与第一版混在一起。
+
+## 9. 标点与文本后处理
+
+Gemini Transcribe 没有与 Type4Me `enablePunc` 一一对应的简单标点开关。
+
+第一版产品规则：
+
+- 不伪造 `enablePunc` 到不存在的 Gemini 参数；
+- Smart / Verbatim 决定 Gemini 自身的转写风格；
+- Gemini 输出之后仍进入 Type4Me 现有 TextOutputFormatter 和 ProcessingMode 管线；
+- 不为 Gemini 增加单独的最终文本注入逻辑。
+
+## 10. 时长限制
+
+官方当前限制：Live Transcription 单个 session 最长 10 分钟。
+
+需要注意的是，这 10 分钟从 Type4Me 与 Gemini 建立连接时开始计时，而不是从用户开口时开始，所以实际可用录音时长会略短于 10 分钟。Type4Me 自身的 600 秒录音上限对 Gemini 不会先生效。
+
+Type4Me 第一版不做自动 session rollover，因此：
+
+- 产品定位仍是短到中等长度的语音输入；
+- 不承诺会议级连续转写；
+- 对外表述统一为「单次实时识别约 10 分钟」，不承诺精确到秒；
+- 选择 Gemini 时，Type4Me 把自身录音上限收紧到 **570 秒（9 分 30 秒）**，抢在服务端关闭之前主动完成本段录音，走既有的「已达最大时长」提示，而不是让录音突然中断；
+- 万一服务端仍先关闭，必须显示明确错误并触发恢复，而不是静默丢失后半段录音；
+- 后续若真实用户需要长录音，再单独设计「finalize + reconnect + segment merge」。
+
+## 11. Free Tier、成本与配额
+
+截至 2026-08-27，Gemini API 定价页明确显示 `gemini-3.5-transcribe-live` 支持 Free Tier，Free Tier 的输入和输出均为免费。
+
+Paid Tier 官方估算的 Live Transcribe 综合成本约为：
+
+`$0.009 / 分钟`
+
+其中约：
+
+- 音频输入：`$0.005 / 分钟`；
+- 文本输出：`$0.004 / 分钟`。
+
+产品文档不能写死“每天免费 X 分钟”，因为 Gemini API Rate Limits 按 Project / Usage Tier 管理，实际配额可能变化，用户应以 Google AI Studio 当前项目显示为准。
+
+## 12. Free Tier 数据使用提醒
+
+Google 当前定价页明确区分：
+
+- Free Tier：内容可能用于改进 Google 产品；
+- Paid Tier：内容不用于改进 Google 产品。
+
+第一版不增加强制弹窗，但在 README / Provider 指引或帮助链接中应能让用户访问官方 Pricing / Terms 页面。
+
+如果未来 Type4Me 增加统一的“云端 ASR 隐私说明”组件，应将这一差异纳入统一展示，而不是只为 Gemini 单独设计一次性 UI。
+
+## 13. 设置页链接
+
+建议提供：
+
+1. Live Transcription 接入文档；
+2. Gemini API Key 获取入口；
+3. Pricing / Rate Limits。
+
+所有链接使用 Google 官方域名。
+
+## 14. 错误体验
+
+至少覆盖：
+
+| 场景 | 用户提示方向 |
+|---|---|
+| API Key 为空 | 请先配置 Gemini API Key |
+| API Key 无效 | API Key 无效或无权访问 Gemini Transcribe |
+| WebSocket 建连失败 | 无法连接 Gemini 实时识别服务 |
+| Setup 被拒绝 | Gemini Transcribe 初始化失败 |
+| Rate limit / quota | 当前项目达到 Gemini API 配额限制，请稍后重试或检查额度 |
+| 网络中断 | 连接中断，请重试 |
+| 接近 10 分钟上限 | 复用既有「已达最大时长 / Max duration reached」提示（570 秒主动收尾），不新增文案 |
+| Session 超过 10 分钟 | Gemini 单次实时识别最长约 10 分钟，请缩短录音 |
+| 返回无法解析 | Gemini 返回了无法解析的识别结果 |
+| 空音频 | 没有录到有效音频 |
+
+所有用户可见文本必须有中英文版本。
+
+## 15. 测试连接
+
+Gemini 的 `connect()` 会实际进行 WebSocket 握手和 setup，因此通用 Provider 连接验证可以真正检查：
+
+- API Key 是否有效；
+- 模型是否可访问；
+- WebSocket 是否可建立；
+- setup 是否被服务端接受。
+
+测试连接不需要发送真实音频，也不应该创建一段伪造录音。
+
+## 16. 隐私与安全
+
+- API Key 使用现有 Keychain；
+- 非安全字段保存转写模式和语言提示；
+- 原始音频只在用户主动选择 Gemini Provider 并录音时发送给 Google；
+- 不持久化 WebSocket audio payload；
+- 不记录完整 API Key；
+- 不记录包含 API Key 的完整 WebSocket URL；
+- 不记录完整音频 Base64；
+- transcript 是否进入历史记录继续遵循 Type4Me 现有历史设置。
+
+## 17. 可观测性
+
+建议记录：
+
+- WebSocket connect latency；
+- setup complete latency；
+- 首个 audio chunk 时间；
+- 首个 interim transcript latency；
+- activity end 到 final transcript latency；
+- session duration；
+- sent audio bytes / chunk count；
+- hotword count；
+- transcript character count；
+- WebSocket close code；
+- error category。
+
+不得记录 API Key、完整 URL、完整热词内容或音频内容。
+
+## 18. 验收场景
+
+### 18.1 中文语音输入
+
+- Auto + Smart；
+- 连续说 5~15 秒中文；
+- 实时文字持续出现；
+- 松开后 final 在 2 秒内返回；
+- Smart 能合理处理口语停顿和自我纠正；
+- 最终文本正常注入。
+
+### 18.2 中英混输
+
+使用 Auto 输入中英文、代码名、产品名混合内容，确认不会因语言切换明显丢词。
+
+### 18.3 热词
+
+加入如 `Type4Me`、`WebSocket`、`SwiftUI` 等热词，比较启用前后的识别效果。
+
+### 18.4 Verbatim
+
+切换 Verbatim，确认 filler words、重复和 false start 不再被 Smart 清理。
+
+### 18.5 实时 UI
+
+验证：
+
+- 普通浮动栏；
+- 紧凑型实时转写指示器；
+- partial 更新不重复；
+- final 结果不会闪回旧 partial。
+
+### 18.6 ProcessingMode
+
+验证：
+
+- Direct；
+- 快速模式；
+- Intelli Sense；
+- 翻译；
+- 自定义 Prompt。
+
+Gemini 只替换 ASR 层，不改变 ProcessingMode 定义。
+
+### 18.7 错误
+
+至少验证：
+
+- 无效 Key；
+- 断网；
+- 429 / quota；
+- WebSocket 异常关闭；
+- 超长 session；
+- 只按下快捷键但没有说话时，不应出现任何错误提示。
+
+### 18.8 界面语言
+
+在中文与英文之间切换 `tf_language`，确认：
+
+- Gemini 的转写模式与语言提示字段文案立即随之切换，无需重启；
+- 已选中的模式与语言设置不因语言切换而改变；
+- Provider 名称 `Gemini` 与模型 id 在两种语言下保持一致，不被翻译。
+
+## 19. 发布策略
+
+第一版作为普通“其他 / Others”实时 Provider 发布。
+
+发布后重点评测：
+
+- 中文 WER / CER；
+- 英文 WER；
+- 中英混输；
+- 代码和产品术语；
+- 首字延迟；
+- 首个 interim 延迟；
+- 松手到 final 延迟；
+- Smart 模式的过度改写率；
+- WebSocket 稳定性；
+- 429 / quota 发生率；
+- 实际分钟成本。
+
+在真实 Evaluation 结果稳定后，再决定是否进入 Recommended。
+
+## 20. 后续演进
+
+可能的后续能力：
+
+- 接入 `gemini-3.5-transcribe` Batch 文件转写；
+- 10 分钟 session 自动 rollover；
+- 从当前 App / repo / 文件名动态生成 custom vocabulary；
+- 根据 ProcessingMode 自动选择 Smart / Verbatim；
+- 针对会议模式增加 timestamps / diarization 的独立工作流；
+- 将 Gemini 与 Type4Me ASR Evaluation 自动基准体系集成。
+
+## 21. 第一版产品决策汇总
+
+| 项目 | 决策 |
+|---|---|
+| Provider | 独立 Gemini Provider |
+| 用户名称 | Gemini（模型在其下单独选择） |
+| Capability | 实时 Streaming |
+| 模型 | provider 下可选，默认 `gemini-3.5-transcribe-live`，支持手填新模型 |
+| 默认模式 | Smart |
+| 可选模式 | Verbatim |
+| 语言 | Auto 默认 + 常用预设 + Custom BCP-47 |
+| 热词 | 复用 Type4Me 全局 HotwordStorage |
+| VAD | Push-to-Talk Manual VAD |
+| Batch 模型 | 首版不接入 |
+| 长录音 rollover | 首版不做 |
+| 推荐状态 | 首版不推荐 |
+| API Key | Keychain |
+| Free Tier | 支持，但额度以 Google 项目实际 Rate Limits 为准 |
+| 单次时长 | 约 10 分钟，接近上限时提示，不自动续接 |
+| Final 延迟目标 | 松手后 2 秒内（快速路径 1 秒内） |


### PR DESCRIPTION
## Summary

Add support for **Gemini 3.5 Transcribe** (`gemini-3.5-transcribe-live`) as a dedicated real-time streaming ASR provider using Gemini Live API's WebSocket (`BidiGenerateContent`) interface.

### Key Changes

1. **ASR Provider & Config**:
   - Added `.gemini` case in `ASRProvider` with display name `Gemini 3.5 Transcribe`.
   - Added `GeminiASRConfig` with Keychain-backed `apiKey`, `mode` (`SMART` / `VERBATIM`), and `languageCode` (default `auto` with BCP-47 presets + custom input).
   - Registered in `ASRProviderRegistry` as `.streaming()` and added DNS/TLS warm-up in `RecognitionSession`.

2. **Protocol & Client**:
   - `GeminiTranscribeProtocol`: WebSocket URL builder with query parameter API key & redaction helpers, setup message generation (model fixed to `models/gemini-3.5-transcribe-live`, text response modality, manual VAD with `automaticActivityDetection.disabled`, custom vocabulary capped at 1000 with deduplication), Manual VAD messages (`activityStart` / `activityEnd`), 100ms (3200-byte) PCM rechunking, and transcript / error message parsing.
   - `GeminiConnectionGate`: WebSocket open + setup acknowledgment gate with cancellation-safe timeouts.
   - `GeminiASRClient`: SpeechRecognizer actor handling live streaming, manual activity window management, audio chunking, and session limit protection.

3. **UI & Documentation**:
   - Added guide links (Live Docs, API Key, Pricing & Limits) and mode description in `ASRSettingsCard`.
   - Updated `AGENTS.md` and `README.md` provider counts and references.
   - Included full unit test suites (`GeminiASRConfigTests`, `GeminiTranscribeProtocolTests`, `GeminiLocalizationTests`, `GeminiASRClientTests`, and updated `ASRProviderRegistryTests`).

## Verification

- `swift test`: All 905 tests passed cleanly with 0 failures.
- Live API handshake and Setup validated against Gemini Live WebSocket endpoint.
- Dev App deployed and verified via `scripts/dev-run.sh`.