### PR TITLE
Add developer mode and transcription quality feedback

### DIFF
--- a/Type4Me/Database/HistoryStore.swift
+++ b/Type4Me/Database/HistoryStore.swift
@@ -71,6 +71,16 @@ actor HistoryStore {
             );
             """
             sqlite3_exec(db, feedbackTableSQL, nil, nil, nil)
+            // A previous development build created this table before scores
+            // were introduced. Add the column for those existing databases;
+            // the ALTER is a no-op (an expected error) when it already exists.
+            sqlite3_exec(
+                db,
+                "ALTER TABLE recognition_feedback ADD COLUMN quality_score INTEGER NOT NULL DEFAULT 0;",
+                nil,
+                nil,
+                nil
+            )
             sqlite3_exec(db, "CREATE INDEX IF NOT EXISTS idx_feedback_record_id ON recognition_feedback(record_id);", nil, nil, nil)
 
             let revisionTableSQL = """

--- a/Type4Me/Database/HistoryStore.swift
+++ b/Type4Me/Database/HistoryStore.swift
@@ -4,6 +4,7 @@ import Type4MeReviseCore
 
 extension Notification.Name {
     static let historyStoreDidChange = Notification.Name("Type4Me.historyStoreDidChange")
+    static let historyFeedbackDidChange = Notification.Name("Type4Me.historyFeedbackDidChange")
 }
 actor HistoryStore {
 
@@ -466,7 +467,7 @@ actor HistoryStore {
         sqlite3_bind_int(stmt, 2, Int32(clamping: score))
         bind(stmt, 3, ISO8601DateFormatter().string(from: Date()))
         guard sqlite3_step(stmt) == SQLITE_DONE else { return false }
-        postDidChangeNotification()
+        postFeedbackDidChangeNotification()
         return true
     }
 
@@ -1062,6 +1063,12 @@ actor HistoryStore {
     private func postDidChangeNotification() {
         Task { @MainActor in
             NotificationCenter.default.post(name: .historyStoreDidChange, object: nil)
+        }
+    }
+
+    private func postFeedbackDidChangeNotification() {
+        Task { @MainActor in
+            NotificationCenter.default.post(name: .historyFeedbackDidChange, object: nil)
         }
     }
 }

--- a/Type4Me/Database/HistoryStore.swift
+++ b/Type4Me/Database/HistoryStore.swift
@@ -72,16 +72,30 @@ actor HistoryStore {
             );
             """
             sqlite3_exec(db, feedbackTableSQL, nil, nil, nil)
-            // A previous development build created this table before scores
-            // were introduced. Add the column for those existing databases;
-            // the ALTER is a no-op (an expected error) when it already exists.
-            sqlite3_exec(
-                db,
-                "ALTER TABLE recognition_feedback ADD COLUMN quality_score INTEGER NOT NULL DEFAULT 0;",
-                nil,
-                nil,
-                nil
-            )
+            // A previous development build used row existence itself to mean
+            // bad feedback. Migrate that legacy schema explicitly so those
+            // rows retain their meaning instead of becoming neutral scores.
+            var feedbackHasQualityScore = false
+            var feedbackColumns: OpaquePointer?
+            if sqlite3_prepare_v2(db, "PRAGMA table_info(recognition_feedback);", -1, &feedbackColumns, nil) == SQLITE_OK {
+                while sqlite3_step(feedbackColumns) == SQLITE_ROW {
+                    if let name = sqlite3_column_text(feedbackColumns, 1), String(cString: name) == "quality_score" {
+                        feedbackHasQualityScore = true
+                        break
+                    }
+                }
+                sqlite3_finalize(feedbackColumns)
+            }
+            if !feedbackHasQualityScore,
+               sqlite3_exec(
+                   db,
+                   "ALTER TABLE recognition_feedback ADD COLUMN quality_score INTEGER NOT NULL DEFAULT 0;",
+                   nil,
+                   nil,
+                   nil
+               ) == SQLITE_OK {
+                sqlite3_exec(db, "UPDATE recognition_feedback SET quality_score = -1;", nil, nil, nil)
+            }
             sqlite3_exec(db, "CREATE INDEX IF NOT EXISTS idx_feedback_record_id ON recognition_feedback(record_id);", nil, nil, nil)
 
             let revisionTableSQL = """

--- a/Type4Me/Database/HistoryStore.swift
+++ b/Type4Me/Database/HistoryStore.swift
@@ -58,6 +58,21 @@ actor HistoryStore {
             """
             sqlite3_exec(db, sql, nil, nil, nil)
 
+            // Keep quality feedback separate from recognition_history so
+            // marking a transcription bad does not change the history schema.
+            let feedbackTableSQL = """
+            CREATE TABLE IF NOT EXISTS recognition_feedback (
+                record_id TEXT PRIMARY KEY,
+                quality_score INTEGER NOT NULL DEFAULT 0,
+                marked_at TEXT NOT NULL,
+                FOREIGN KEY(record_id)
+                    REFERENCES recognition_history(id)
+                    ON DELETE CASCADE
+            );
+            """
+            sqlite3_exec(db, feedbackTableSQL, nil, nil, nil)
+            sqlite3_exec(db, "CREATE INDEX IF NOT EXISTS idx_feedback_record_id ON recognition_feedback(record_id);", nil, nil, nil)
+
             let revisionTableSQL = """
             CREATE TABLE IF NOT EXISTS recognition_revisions (
                 id TEXT PRIMARY KEY,
@@ -417,6 +432,34 @@ actor HistoryStore {
         }
     }
 
+    func fetchQualityScores() -> [String: Int] {
+        let sql = "SELECT record_id, quality_score FROM recognition_feedback;"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return [:] }
+        defer { sqlite3_finalize(stmt) }
+
+        var scores: [String: Int] = [:]
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            scores[column(stmt, 0)] = Int(sqlite3_column_int(stmt, 1))
+        }
+        return scores
+    }
+
+    @discardableResult
+    func setRecordQualityScore(recordID: String, score: Int) -> Bool {
+        let sql = "INSERT OR REPLACE INTO recognition_feedback (record_id, quality_score, marked_at) VALUES (?, ?, ?);"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return false }
+        defer { sqlite3_finalize(stmt) }
+
+        bind(stmt, 1, recordID)
+        sqlite3_bind_int(stmt, 2, Int32(clamping: score))
+        bind(stmt, 3, ISO8601DateFormatter().string(from: Date()))
+        guard sqlite3_step(stmt) == SQLITE_DONE else { return false }
+        postDidChangeNotification()
+        return true
+    }
+
     @discardableResult
     func updateUserEditObservation(
         recordID: String,
@@ -576,6 +619,12 @@ actor HistoryStore {
         let last30DaysDuration: Double
         let allTimeDuration: Double
         let recordCount: Int
+        let badCount: Int
+
+        var badPercentage: Double {
+            guard recordCount > 0 else { return 0 }
+            return Double(badCount) / Double(recordCount)
+        }
 
         var id: String { modelName }
     }
@@ -677,8 +726,11 @@ actor HistoryStore {
             COALESCE(SUM(CASE WHEN created_at >= ? THEN duration_seconds ELSE 0 END), 0),
             COALESCE(SUM(CASE WHEN created_at >= ? THEN duration_seconds ELSE 0 END), 0),
             COALESCE(SUM(duration_seconds), 0),
-            COUNT(*)
+            COUNT(*),
+            COALESCE(SUM(CASE WHEN COALESCE(feedback.quality_score, 0) < 0 THEN 1 ELSE 0 END), 0)
         FROM recognition_history
+        LEFT JOIN recognition_feedback AS feedback
+            ON feedback.record_id = recognition_history.id
         WHERE \(Self.activeStatusSQLCondition)
         GROUP BY 1
         ORDER BY CASE WHEN model_name = ? THEN 1 ELSE 0 END,
@@ -704,7 +756,8 @@ actor HistoryStore {
                 last7DaysDuration: sqlite3_column_double(stmt, 2),
                 last30DaysDuration: sqlite3_column_double(stmt, 3),
                 allTimeDuration: sqlite3_column_double(stmt, 4),
-                recordCount: Int(sqlite3_column_int(stmt, 5))
+                recordCount: Int(sqlite3_column_int(stmt, 5)),
+                badCount: Int(sqlite3_column_int(stmt, 6))
             ))
         }
         return rows

--- a/Type4Me/UI/Settings/DebugSettingsTab.swift
+++ b/Type4Me/UI/Settings/DebugSettingsTab.swift
@@ -2,16 +2,6 @@ import AppKit
 import SwiftUI
 
 enum DebugSettingsAvailability {
-    static let defaultsKey = "tf_debug_panel"
-
-    static var defaultEnabled: Bool {
-        #if TYPE4ME_DEV_BUILD
-        true
-        #else
-        false
-        #endif
-    }
-
     static var buildLabel: String {
         #if TYPE4ME_DEV_BUILD
         return "DEV"
@@ -21,7 +11,7 @@ enum DebugSettingsAvailability {
     }
 }
 
-/// Developer diagnostics exposed through the Developer Mode setting.
+/// Developer diagnostics exposed only by DEV builds.
 struct DebugSettingsTab: View, SettingsCardHelpers {
     @State private var recentLog = ""
     @State private var refreshedAt = Date()

--- a/Type4Me/UI/Settings/DebugSettingsTab.swift
+++ b/Type4Me/UI/Settings/DebugSettingsTab.swift
@@ -4,13 +4,7 @@ import SwiftUI
 enum DebugSettingsAvailability {
     static let defaultsKey = "tf_debug_panel"
 
-    static var defaultEnabled: Bool {
-        #if TYPE4ME_DEV_BUILD
-        true
-        #else
-        false
-        #endif
-    }
+    static let defaultEnabled = false
 
     static var buildLabel: String {
         #if TYPE4ME_DEV_BUILD
@@ -21,8 +15,7 @@ enum DebugSettingsAvailability {
     }
 }
 
-/// Developer diagnostics enabled by default in builds produced by
-/// `scripts/dev-run.sh`. DEV users can hide the entry from Advanced settings.
+/// Developer diagnostics exposed through the Developer Mode setting.
 struct DebugSettingsTab: View, SettingsCardHelpers {
     @State private var recentLog = ""
     @State private var refreshedAt = Date()
@@ -35,8 +28,8 @@ struct DebugSettingsTab: View, SettingsCardHelpers {
             label: "DEBUG",
             title: L("调试与诊断", "Debug & Diagnostics"),
             description: L(
-                "查看当前构建、运行环境、系统权限与实时日志，快速定位开发版本中的问题。",
-                "Inspect the current build, runtime, permissions, and recent logs while diagnosing development builds."
+                "查看当前构建、运行环境、系统权限与实时日志，快速定位 Type4Me 的问题。",
+                "Inspect the current build, runtime, permissions, and recent logs while diagnosing Type4Me."
             )
         )
 

--- a/Type4Me/UI/Settings/DebugSettingsTab.swift
+++ b/Type4Me/UI/Settings/DebugSettingsTab.swift
@@ -4,7 +4,13 @@ import SwiftUI
 enum DebugSettingsAvailability {
     static let defaultsKey = "tf_debug_panel"
 
-    static let defaultEnabled = false
+    static var defaultEnabled: Bool {
+        #if TYPE4ME_DEV_BUILD
+        true
+        #else
+        false
+        #endif
+    }
 
     static var buildLabel: String {
         #if TYPE4ME_DEV_BUILD

--- a/Type4Me/UI/Settings/DebugSettingsTab.swift
+++ b/Type4Me/UI/Settings/DebugSettingsTab.swift
@@ -25,7 +25,7 @@ struct DebugSettingsTab: View, SettingsCardHelpers {
 
     var body: some View {
         SettingsSectionHeader(
-            label: "DEBUG",
+            label: "DEVELOPER",
             title: L("调试与诊断", "Debug & Diagnostics"),
             description: L(
                 "查看当前构建、运行环境、系统权限与实时日志，快速定位 Type4Me 的问题。",

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -172,17 +172,15 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
                         ]
                     )
                 }
-                #if TYPE4ME_DEV_BUILD
                 SettingsDivider()
                 settingsToggleRow(
-                    L("Debug 模式", "Debug Mode"),
+                    L("开发者模式", "Developer Mode"),
                     subtitle: L(
                         "在左侧菜单显示调试与诊断入口。",
                         "Show the Debug & Diagnostics entry in the sidebar."
                     ),
                     isOn: $debugPanelEnabled
                 )
-                #endif
             }
 
         }

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -27,8 +27,6 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
     @AppStorage(AudioInputDevicePreferenceStore.modeKey) private var microphonePreferenceMode = AudioInputDevicePreferenceMode.systemDefault.rawValue
     @AppStorage(AudioInputDevicePreferenceStore.priorityEntriesKey) private var microphonePriorityEntriesStorage = ""
     @AppStorage("tf_selectedSpeakerUID") private var selectedSpeakerUID = ""
-    @AppStorage(DebugSettingsAvailability.defaultsKey)
-    private var debugPanelEnabled = DebugSettingsAvailability.defaultEnabled
 
     @State private var hasMic = false
     @State private var hasAccessibility = false
@@ -172,15 +170,6 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
                         ]
                     )
                 }
-                SettingsDivider()
-                settingsToggleRow(
-                    L("开发者模式", "Developer Mode"),
-                    subtitle: L(
-                        "在左侧菜单显示开发者页（日志），并启用转写反馈。",
-                        "Show the Developer tab for logs and enable transcription feedback."
-                    ),
-                    isOn: $debugPanelEnabled
-                )
             }
 
         }

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -176,8 +176,8 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
                 settingsToggleRow(
                     L("开发者模式", "Developer Mode"),
                     subtitle: L(
-                        "在左侧菜单显示调试与诊断入口。",
-                        "Show the Debug & Diagnostics entry in the sidebar."
+                        "在左侧菜单显示开发者页（日志），并启用转写反馈。",
+                        "Show the Developer tab for logs and enable transcription feedback."
                     ),
                     isOn: $debugPanelEnabled
                 )

--- a/Type4Me/UI/Settings/HistoryTab.swift
+++ b/Type4Me/UI/Settings/HistoryTab.swift
@@ -306,6 +306,8 @@ struct HistoryTab: View {
     @State private var searchText = ""
     @State private var copiedId: String?
     @State private var qualityScores: [String: Int] = [:]
+    @AppStorage(DebugSettingsAvailability.defaultsKey)
+    private var developerModeEnabled = DebugSettingsAvailability.defaultEnabled
     @State private var expandedRecordIds: Set<String> = []
     @State private var statistics: HistoryStore.Statistics?
     @State private var usageBreakdown: [HistoryStore.UsageBreakdown] = []
@@ -1063,6 +1065,10 @@ struct HistoryTab: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
 
                         HStack(spacing: 10) {
+                            if developerModeEnabled && (qualityScores[record.id] ?? 0) < 0 {
+                                Text("👎")
+                                    .accessibilityLabel(L("已标记为差", "Marked as bad"))
+                            }
                             if let chars = record.characterCount {
                                 Label(L("\(chars) 字", "\(chars) chars"), systemImage: "doc.text")
                             }
@@ -1135,13 +1141,15 @@ struct HistoryTab: View {
                     }
                 }
 
-                let isMarkedBad = (qualityScores[record.id] ?? 0) < 0
-                historyRecordAction(
-                    icon: isMarkedBad ? "hand.thumbsdown.fill" : "hand.thumbsdown",
-                    tooltip: isMarkedBad ? L("取消差评标记", "Unmark as bad") : L("标记为差", "Mark as bad"),
-                    color: isMarkedBad ? TF.settingsAccentRed : TF.settingsTextSecondary
-                ) {
-                    toggleBadRecord(record.id)
+                if developerModeEnabled {
+                    let isMarkedBad = (qualityScores[record.id] ?? 0) < 0
+                    historyRecordAction(
+                        icon: isMarkedBad ? "hand.thumbsdown.fill" : "hand.thumbsdown",
+                        tooltip: isMarkedBad ? L("取消差评标记", "Unmark as bad") : L("标记为差", "Mark as bad"),
+                        color: isMarkedBad ? TF.settingsAccentRed : TF.settingsTextSecondary
+                    ) {
+                        toggleBadRecord(record.id)
+                    }
                 }
 
                 historyRecordAction(

--- a/Type4Me/UI/Settings/HistoryTab.swift
+++ b/Type4Me/UI/Settings/HistoryTab.swift
@@ -1171,15 +1171,28 @@ struct HistoryTab: View {
             )
             .transition(.opacity)
         } else if isMarkedBad {
-            Image(systemName: "hand.thumbsdown.fill")
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(TF.settingsAccentRed)
-                .frame(width: 26, height: 26)
-                .background(
-                    RoundedRectangle(cornerRadius: 7, style: .continuous)
-                        .fill(TF.settingsControl)
-                )
-                .accessibilityLabel(L("已标记为差", "Marked as bad"))
+            HStack(spacing: 5) {
+                Color.clear
+                    .frame(width: 26, height: 26)
+                    .allowsHitTesting(false)
+                Color.clear
+                    .frame(width: 26, height: 26)
+                    .allowsHitTesting(false)
+                Image(systemName: "hand.thumbsdown.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(TF.settingsAccentRed)
+                    .frame(width: 26, height: 26)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .fill(TF.settingsControl)
+                    )
+                    .accessibilityLabel(L("已标记为差", "Marked as bad"))
+                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(TF.settingsTextTertiary.opacity(0.65))
+                    .frame(width: 26, height: 26)
+            }
+            .padding(.leading, 8)
         } else {
             Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                 .font(.system(size: 9, weight: .bold))

--- a/Type4Me/UI/Settings/HistoryTab.swift
+++ b/Type4Me/UI/Settings/HistoryTab.swift
@@ -306,8 +306,6 @@ struct HistoryTab: View {
     @State private var searchText = ""
     @State private var copiedId: String?
     @State private var qualityScores: [String: Int] = [:]
-    @AppStorage(DebugSettingsAvailability.defaultsKey)
-    private var developerModeEnabled = DebugSettingsAvailability.defaultEnabled
     @State private var expandedRecordIds: Set<String> = []
     @State private var statistics: HistoryStore.Statistics?
     @State private var usageBreakdown: [HistoryStore.UsageBreakdown] = []
@@ -1126,7 +1124,7 @@ struct HistoryTab: View {
         isHovered: Bool,
         isExpanded: Bool
     ) -> some View {
-        let isMarkedBad = developerModeEnabled && (qualityScores[record.id] ?? 0) < 0
+        let isMarkedBad = (qualityScores[record.id] ?? 0) < 0
 
         if isHovered || copiedId == record.id {
             HStack(spacing: 5) {
@@ -1150,14 +1148,12 @@ struct HistoryTab: View {
                     }
                 }
 
-                if developerModeEnabled {
-                    historyRecordAction(
-                        icon: isMarkedBad ? "hand.thumbsdown.fill" : "hand.thumbsdown",
-                        tooltip: isMarkedBad ? L("取消差评标记", "Unmark as bad") : L("标记为差", "Mark as bad"),
-                        color: isMarkedBad ? TF.settingsAccentRed : TF.settingsTextSecondary
-                    ) {
-                        toggleBadRecord(record.id)
-                    }
+                historyRecordAction(
+                    icon: isMarkedBad ? "hand.thumbsdown.fill" : "hand.thumbsdown",
+                    tooltip: isMarkedBad ? L("取消差评标记", "Unmark as bad") : L("标记为差", "Mark as bad"),
+                    color: isMarkedBad ? TF.settingsAccentRed : TF.settingsTextSecondary
+                ) {
+                    toggleBadRecord(record.id)
                 }
 
                 historyRecordAction(

--- a/Type4Me/UI/Settings/HistoryTab.swift
+++ b/Type4Me/UI/Settings/HistoryTab.swift
@@ -612,6 +612,13 @@ struct HistoryTab: View {
                 await loadStatistics()
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .historyFeedbackDidChange)) { _ in
+            guard isActive else { return }
+            Task {
+                qualityScores = await historyStore.fetchQualityScores()
+                await loadStatistics()
+            }
+        }
         .sheet(item: $correctionRecord) { record in
             QuickCorrectionSheet(text: record.rawText)
         }

--- a/Type4Me/UI/Settings/HistoryTab.swift
+++ b/Type4Me/UI/Settings/HistoryTab.swift
@@ -344,6 +344,10 @@ struct HistoryTab: View {
         Set(sections.flatMap { $0.records.map(\.id) })
     }
 
+    private var showsFeedbackMetrics: Bool {
+        usageBreakdown.contains { $0.badCount > 0 }
+    }
+
     /// True when every row in the current list (loaded + search filter) is selected.
     private var isAllFilteredSelected: Bool {
         HistorySelectionHelpers.isAllFilteredSelected(
@@ -1065,10 +1069,6 @@ struct HistoryTab: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
 
                         HStack(spacing: 10) {
-                            if developerModeEnabled && (qualityScores[record.id] ?? 0) < 0 {
-                                Text("👎")
-                                    .accessibilityLabel(L("已标记为差", "Marked as bad"))
-                            }
                             if let chars = record.characterCount {
                                 Label(L("\(chars) 字", "\(chars) chars"), systemImage: "doc.text")
                             }
@@ -1119,6 +1119,8 @@ struct HistoryTab: View {
         isHovered: Bool,
         isExpanded: Bool
     ) -> some View {
+        let isMarkedBad = developerModeEnabled && (qualityScores[record.id] ?? 0) < 0
+
         if isHovered || copiedId == record.id {
             HStack(spacing: 5) {
                 historyRecordAction(
@@ -1142,7 +1144,6 @@ struct HistoryTab: View {
                 }
 
                 if developerModeEnabled {
-                    let isMarkedBad = (qualityScores[record.id] ?? 0) < 0
                     historyRecordAction(
                         icon: isMarkedBad ? "hand.thumbsdown.fill" : "hand.thumbsdown",
                         tooltip: isMarkedBad ? L("取消差评标记", "Unmark as bad") : L("标记为差", "Mark as bad"),
@@ -1169,6 +1170,16 @@ struct HistoryTab: View {
                     .fill(TF.settingsRowHover)
             )
             .transition(.opacity)
+        } else if isMarkedBad {
+            Image(systemName: "hand.thumbsdown.fill")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(TF.settingsAccentRed)
+                .frame(width: 26, height: 26)
+                .background(
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .fill(TF.settingsControl)
+                )
+                .accessibilityLabel(L("已标记为差", "Marked as bad"))
         } else {
             Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                 .font(.system(size: 9, weight: .bold))
@@ -1605,7 +1616,7 @@ struct HistoryTab: View {
             }
         }
         .padding(16)
-        .frame(width: 760)
+        .frame(width: showsFeedbackMetrics ? 760 : 600)
     }
 
     private var usageDetailsHeader: some View {
@@ -1620,10 +1631,12 @@ struct HistoryTab: View {
                 .frame(width: 70, alignment: .trailing)
             Text(L("全部", "All time"))
                 .frame(width: 70, alignment: .trailing)
-            Text("👎")
-                .frame(width: 60, alignment: .trailing)
-            Text(L("差评率", "% Bad"))
-                .frame(width: 68, alignment: .trailing)
+            if showsFeedbackMetrics {
+                Text("👎")
+                    .frame(width: 60, alignment: .trailing)
+                Text(L("差评率", "% Bad"))
+                    .frame(width: 68, alignment: .trailing)
+            }
         }
         .font(.system(size: 10, weight: .semibold))
         .foregroundStyle(TF.settingsTextTertiary)
@@ -1655,10 +1668,12 @@ struct HistoryTab: View {
                     .foregroundStyle(TF.settingsTextTertiary)
             }
             .frame(width: 70, alignment: .trailing)
-            Text("\(row.badCount)")
-                .frame(width: 60, alignment: .trailing)
-            Text(formatBadPercentage(row.badPercentage))
-                .frame(width: 68, alignment: .trailing)
+            if showsFeedbackMetrics {
+                Text("\(row.badCount)")
+                    .frame(width: 60, alignment: .trailing)
+                Text(formatBadPercentage(row.badPercentage))
+                    .frame(width: 68, alignment: .trailing)
+            }
         }
         .font(.system(size: 11, weight: .medium, design: .rounded))
         .foregroundStyle(TF.settingsText)

--- a/Type4Me/UI/Settings/HistoryTab.swift
+++ b/Type4Me/UI/Settings/HistoryTab.swift
@@ -305,6 +305,7 @@ struct HistoryTab: View {
     @State private var isLoadingMore = false
     @State private var searchText = ""
     @State private var copiedId: String?
+    @State private var qualityScores: [String: Int] = [:]
     @State private var expandedRecordIds: Set<String> = []
     @State private var statistics: HistoryStore.Statistics?
     @State private var usageBreakdown: [HistoryStore.UsageBreakdown] = []
@@ -706,7 +707,16 @@ struct HistoryTab: View {
         let range = dateFilter.dateRange
         let fetched = await historyStore.fetchPage(limit: Self.pageSize, from: range?.start, to: range?.end)
         records = fetched
+        qualityScores = await historyStore.fetchQualityScores()
         hasMore = fetched.count >= Self.pageSize
+    }
+
+    private func toggleBadRecord(_ recordID: String) {
+        let nextScore = (qualityScores[recordID] ?? 0) < 0 ? 0 : -1
+        Task {
+            guard await historyStore.setRecordQualityScore(recordID: recordID, score: nextScore) else { return }
+            qualityScores = await historyStore.fetchQualityScores()
+        }
     }
 
     private func loadStatistics() async {
@@ -1123,6 +1133,15 @@ struct HistoryTab: View {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
                         if copiedId == record.id { copiedId = nil }
                     }
+                }
+
+                let isMarkedBad = (qualityScores[record.id] ?? 0) < 0
+                historyRecordAction(
+                    icon: isMarkedBad ? "hand.thumbsdown.fill" : "hand.thumbsdown",
+                    tooltip: isMarkedBad ? L("取消差评标记", "Unmark as bad") : L("标记为差", "Mark as bad"),
+                    color: isMarkedBad ? TF.settingsAccentRed : TF.settingsTextSecondary
+                ) {
+                    toggleBadRecord(record.id)
                 }
 
                 historyRecordAction(
@@ -1578,21 +1597,25 @@ struct HistoryTab: View {
             }
         }
         .padding(16)
-        .frame(width: 650)
+        .frame(width: 760)
     }
 
     private var usageDetailsHeader: some View {
         HStack(spacing: 10) {
             Text(L("模型 / 引擎", "Model / Engine"))
-                .frame(width: 270, alignment: .leading)
+                .frame(width: 250, alignment: .leading)
             Text(L("近1天", "1 day"))
-                .frame(width: 78, alignment: .trailing)
+                .frame(width: 70, alignment: .trailing)
             Text(L("7天", "7 days"))
-                .frame(width: 78, alignment: .trailing)
+                .frame(width: 70, alignment: .trailing)
             Text(L("30天", "30 days"))
-                .frame(width: 78, alignment: .trailing)
+                .frame(width: 70, alignment: .trailing)
             Text(L("全部", "All time"))
-                .frame(width: 78, alignment: .trailing)
+                .frame(width: 70, alignment: .trailing)
+            Text("👎")
+                .frame(width: 60, alignment: .trailing)
+            Text(L("差评率", "% Bad"))
+                .frame(width: 68, alignment: .trailing)
         }
         .font(.system(size: 10, weight: .semibold))
         .foregroundStyle(TF.settingsTextTertiary)
@@ -1609,21 +1632,25 @@ struct HistoryTab: View {
                     .foregroundStyle(TF.settingsText)
                     .lineLimit(1)
             }
-            .frame(width: 270, alignment: .leading)
+            .frame(width: 250, alignment: .leading)
 
             Text(formatUsageDuration(row.lastDayDuration))
-                .frame(width: 78, alignment: .trailing)
+                .frame(width: 70, alignment: .trailing)
             Text(formatUsageDuration(row.last7DaysDuration))
-                .frame(width: 78, alignment: .trailing)
+                .frame(width: 70, alignment: .trailing)
             Text(formatUsageDuration(row.last30DaysDuration))
-                .frame(width: 78, alignment: .trailing)
+                .frame(width: 70, alignment: .trailing)
             VStack(alignment: .trailing, spacing: 2) {
                 Text(formatUsageDuration(row.allTimeDuration))
                 Text(L("\(row.recordCount) 条记录", "\(row.recordCount) records"))
                     .font(.system(size: 9))
                     .foregroundStyle(TF.settingsTextTertiary)
             }
-            .frame(width: 78, alignment: .trailing)
+            .frame(width: 70, alignment: .trailing)
+            Text("\(row.badCount)")
+                .frame(width: 60, alignment: .trailing)
+            Text(formatBadPercentage(row.badPercentage))
+                .frame(width: 68, alignment: .trailing)
         }
         .font(.system(size: 11, weight: .medium, design: .rounded))
         .foregroundStyle(TF.settingsText)
@@ -1666,6 +1693,10 @@ struct HistoryTab: View {
             return String(format: "%dm %02ds", minutes, secs)
         }
         return "\(secs)s"
+    }
+
+    private func formatBadPercentage(_ value: Double) -> String {
+        String(format: "%.1f%%", value * 100)
     }
 
     private func formatNumber(_ number: Int) -> String {

--- a/Type4Me/UI/Settings/SettingsView.swift
+++ b/Type4Me/UI/Settings/SettingsView.swift
@@ -41,7 +41,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .preferences: return L("设置", "Settings")
         case .appearance:  return L("外观", "Appearance")
         case .about:       return L("关于", "About")
-        case .debug:       return L("调试", "Debug")
+        case .debug:       return L("开发者", "Developer")
         #if HAS_CLOUD_SUBSCRIPTION
         case .account:     return L("账户", "Account")
         #endif

--- a/Type4Me/UI/Settings/SettingsView.swift
+++ b/Type4Me/UI/Settings/SettingsView.swift
@@ -41,7 +41,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .preferences: return L("设置", "Settings")
         case .appearance:  return L("外观", "Appearance")
         case .about:       return L("关于", "About")
-        case .debug:       return L("开发者", "Developer")
+        case .debug:       return L("调试", "Debug")
         #if HAS_CLOUD_SUBSCRIPTION
         case .account:     return L("账户", "Account")
         #endif
@@ -111,8 +111,6 @@ struct SettingsView: View {
     @State private var isContentMounted = false
     @State private var bypassNextCloseGuard = false
     @AppStorage("tf_language") private var language = AppLanguage.systemDefault
-    @AppStorage(DebugSettingsAvailability.defaultsKey)
-    private var debugPanelEnabled = DebugSettingsAvailability.defaultEnabled
     #if HAS_CLOUD_SUBSCRIPTION
     @State private var showDeviceConflict = false
     @AppStorage("tf_app_edition") private var editionRaw: String?
@@ -233,11 +231,6 @@ struct SettingsView: View {
                 }
             }
         }
-        .onChange(of: debugPanelEnabled) { _, isEnabled in
-            if !isEnabled && selectedTab == .debug {
-                requestNavigation(to: .preferences)
-            }
-        }
     }
 
     // MARK: - Sidebar
@@ -269,10 +262,10 @@ struct SettingsView: View {
 
             Spacer()
 
-            if debugPanelEnabled {
+            #if TYPE4ME_DEV_BUILD
                 navItem(.debug)
                     .padding(.horizontal, 10)
-            }
+            #endif
             #if HAS_CLOUD_SUBSCRIPTION
             if edition == .member {
                 navItem(.account)
@@ -453,11 +446,11 @@ struct SettingsView: View {
         case .preferences, .appearance, .models, .modes, .about:
             settingsHubPage
         case .debug:
-            if debugPanelEnabled {
-                tabPage { DebugSettingsTab() }
-            } else {
-                settingsHubPage
-            }
+            #if TYPE4ME_DEV_BUILD
+            tabPage { DebugSettingsTab() }
+            #else
+            settingsHubPage
+            #endif
             #if HAS_CLOUD_SUBSCRIPTION
         case .account:
             tabPage { AccountTab() }

--- a/Type4MeTests/HistoryStoreTests.swift
+++ b/Type4MeTests/HistoryStoreTests.swift
@@ -268,6 +268,37 @@ final class HistoryStoreTests: XCTestCase {
         XCTAssertEqual(futurePositiveScores[record.id], 2)
     }
 
+    func testLegacyFeedbackTableMigratesToIntegerScore() async {
+        let legacyPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("type4me-legacy-feedback-\(UUID().uuidString).db").path
+        defer { try? FileManager.default.removeItem(atPath: legacyPath) }
+
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(legacyPath, &db), SQLITE_OK)
+        let createLegacyTable = """
+        CREATE TABLE recognition_feedback (
+            record_id TEXT PRIMARY KEY,
+            marked_at TEXT NOT NULL
+        );
+        """
+        XCTAssertEqual(sqlite3_exec(db, createLegacyTable, nil, nil, nil), SQLITE_OK)
+        sqlite3_close(db)
+
+        let migratedStore = HistoryStore(path: legacyPath)
+        let record = HistoryRecord(
+            id: "legacy-feedback-record", createdAt: Date(), durationSeconds: 1,
+            rawText: "legacy feedback", processingMode: nil, processedText: nil,
+            finalText: "legacy feedback", status: "completed", characterCount: 15,
+            asrProvider: "Deepgram", asrModel: "nova-3"
+        )
+        await migratedStore.insert(record)
+        let marked = await migratedStore.setRecordQualityScore(recordID: record.id, score: -1)
+
+        XCTAssertTrue(marked)
+        let scores = await migratedStore.fetchQualityScores()
+        XCTAssertEqual(scores[record.id], -1)
+    }
+
     func testDeleteBatchEmptyDoesNothing() async {
         let id = "only-one"
         await store.insert(HistoryRecord(

--- a/Type4MeTests/HistoryStoreTests.swift
+++ b/Type4MeTests/HistoryStoreTests.swift
@@ -236,6 +236,38 @@ final class HistoryStoreTests: XCTestCase {
         XCTAssertTrue(all.isEmpty)
     }
 
+    func testBadFeedbackIsStoredSeparatelyFromHistoryRecord() async {
+        let record = HistoryRecord(
+            id: "feedback-record", createdAt: Date(), durationSeconds: 1,
+            rawText: "feedback", processingMode: nil, processedText: nil,
+            finalText: "feedback", status: "completed", characterCount: 8,
+            asrProvider: "Deepgram", asrModel: "Deepgram · nova-3"
+        )
+        await store.insert(record)
+
+        let marked = await store.setRecordQualityScore(recordID: record.id, score: -1)
+        let markedScores = await store.fetchQualityScores()
+        let fetched = await store.fetchAll()
+        XCTAssertTrue(marked)
+        XCTAssertEqual(markedScores[record.id], -1)
+        XCTAssertEqual(fetched.first?.finalText, record.finalText)
+
+        let unmarked = await store.setRecordQualityScore(recordID: record.id, score: 0)
+        let neutralScores = await store.fetchQualityScores()
+        XCTAssertTrue(unmarked)
+        XCTAssertEqual(neutralScores[record.id], 0)
+
+        let futureNegativeScore = await store.setRecordQualityScore(recordID: record.id, score: -3)
+        let futureNegativeScores = await store.fetchQualityScores()
+        XCTAssertTrue(futureNegativeScore)
+        XCTAssertEqual(futureNegativeScores[record.id], -3)
+
+        let futurePositiveScore = await store.setRecordQualityScore(recordID: record.id, score: 2)
+        let futurePositiveScores = await store.fetchQualityScores()
+        XCTAssertTrue(futurePositiveScore)
+        XCTAssertEqual(futurePositiveScores[record.id], 2)
+    }
+
     func testDeleteBatchEmptyDoesNothing() async {
         let id = "only-one"
         await store.insert(HistoryRecord(
@@ -429,6 +461,10 @@ final class HistoryStoreTests: XCTestCase {
         for record in records {
             await store.insert(record)
         }
+        let markedSoniox = await store.setRecordQualityScore(recordID: "soniox-now", score: -1)
+        let markedDeepgram = await store.setRecordQualityScore(recordID: "deepgram-model", score: -1)
+        XCTAssertTrue(markedSoniox)
+        XCTAssertTrue(markedDeepgram)
 
         let rows = await store.getUsageBreakdown(now: now)
         let byModel = Dictionary(uniqueKeysWithValues: rows.map { ($0.modelName, $0) })
@@ -437,6 +473,8 @@ final class HistoryStoreTests: XCTestCase {
         XCTAssertEqual(byModel["Soniox · stt-rt-v5"]?.last7DaysDuration ?? 0, 120, accuracy: 0.01)
         XCTAssertEqual(byModel["Soniox · stt-rt-v5"]?.last30DaysDuration ?? 0, 120, accuracy: 0.01)
         XCTAssertEqual(byModel["Soniox · stt-rt-v5"]?.allTimeDuration ?? 0, 120, accuracy: 0.01)
+        XCTAssertEqual(byModel["Soniox · stt-rt-v5"]?.badCount, 1)
+        XCTAssertEqual(byModel["Soniox · stt-rt-v5"]?.badPercentage ?? 0, 0.5, accuracy: 0.01)
         XCTAssertEqual(byModel["OpenAI"]?.lastDayDuration ?? 0, 0, accuracy: 0.01)
         XCTAssertEqual(byModel["OpenAI"]?.last7DaysDuration ?? 0, 0, accuracy: 0.01)
         XCTAssertEqual(byModel["OpenAI"]?.last30DaysDuration ?? 0, 120, accuracy: 0.01)
@@ -453,6 +491,8 @@ final class HistoryStoreTests: XCTestCase {
         XCTAssertEqual(byModel["Deepgram · nova-3"]?.recordCount, 1)
         XCTAssertEqual(byModel["Deepgram · nova-3"]?.last30DaysDuration ?? 0, 0, accuracy: 0.01)
         XCTAssertEqual(byModel["Deepgram · nova-3"]?.allTimeDuration ?? 0, 20, accuracy: 0.01)
+        XCTAssertEqual(byModel["Deepgram · nova-3"]?.badCount, 1)
+        XCTAssertEqual(byModel["Deepgram · nova-3"]?.badPercentage ?? 0, 1.0, accuracy: 0.01)
         XCTAssertEqual(rows.last?.modelName, L("未知", "Unknown"))
         XCTAssertEqual(rows.dropLast().map(\.allTimeDuration), rows.dropLast().map(\.allTimeDuration).sorted(by: >))
     }

--- a/Type4MeTests/HistoryStoreTests.swift
+++ b/Type4MeTests/HistoryStoreTests.swift
@@ -282,9 +282,17 @@ final class HistoryStoreTests: XCTestCase {
         );
         """
         XCTAssertEqual(sqlite3_exec(db, createLegacyTable, nil, nil, nil), SQLITE_OK)
+        let legacyTimestamp = ISO8601DateFormatter().string(from: Date())
+        let insertLegacyFeedback = """
+        INSERT INTO recognition_feedback (record_id, marked_at)
+        VALUES ('legacy-feedback-record', '\(legacyTimestamp)');
+        """
+        XCTAssertEqual(sqlite3_exec(db, insertLegacyFeedback, nil, nil, nil), SQLITE_OK)
         sqlite3_close(db)
 
         let migratedStore = HistoryStore(path: legacyPath)
+        let migratedScores = await migratedStore.fetchQualityScores()
+        XCTAssertEqual(migratedScores["legacy-feedback-record"], -1)
         let record = HistoryRecord(
             id: "legacy-feedback-record", createdAt: Date(), durationSeconds: 1,
             rawText: "legacy feedback", processingMode: nil, processedText: nil,


### PR DESCRIPTION
## Summary
- Add a Developer Mode setting to reveal the Debug tab.
- Add a separate integer-scored transcription feedback table: 0 neutral, -1 bad, with future scores supported.
- Add a thumbs-down toggle to history records and bad-count / bad-percentage usage aggregation.

## Verification
- swift test: 914 tests passed, 2 skipped
- swift test --filter HistoryStoreTests: 22 tests passed
- swift build -c release: passed

## Screenshots
Default off
<img width="1171" height="202" alt="image" src="https://github.com/user-attachments/assets/a13f41be-874c-445d-984c-2291769e5804" />


But this can be turned on even you are not running the debug mode. 
Once it's on, 3 changes
1) the Developer tab is visible
<img width="1165" height="195" alt="image" src="https://github.com/user-attachments/assets/c94f16e2-0d99-4fbc-9104-471465ec531a" />

2) In the History tab, you can mark one record as improperly transcribed
<img width="166" height="158" alt="image" src="https://github.com/user-attachments/assets/892fcdc0-59bf-4923-8f04-515804c426dc" />

3) the aggregated history record also show number of such bad transcription and percentage
<img width="228" height="126" alt="image" src="https://github.com/user-attachments/assets/944ca50a-c20b-47c3-9477-609d6121973f" />

For people trying various ASR models, such features could be helpful but I disable them by default to avoid overwhelming UI.


## Follow-up
- DEV builds now enable Developer Mode by default, matching the previous Debug tab behavior; release builds remain off by default.

## Design follow-up
- The user-facing Developer Mode toggle has been removed.
- The Debug tab is available only in DEV builds.
- Transcription feedback and its metrics are available on the History page for all builds.
- Legacy feedback rows migrate to quality_score = -1.