### PR TITLE
feat(asr): add StepFun realtime transcription

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 macOS menu bar voice input tool with dual-engine local ASR, multi-provider cloud ASR, and LLM post-processing.
 Local ASR: SenseVoice via native sherpa-onnx (streaming) + Qwen3-ASR (final calibration, Python WebSocket service managed by `SenseVoiceServerManager`).
-Cloud ASR: 13 providers implemented (Volcano, StepFun batch, MiMo batch, OpenAI, Deepgram, Cartesia, AssemblyAI, ElevenLabs, Gemini, Grok, Soniox, Bailian, Baidu), plus Apple Speech.
+Cloud ASR: 14 providers implemented (Volcano, StepFun streaming, StepFun batch, MiMo batch, OpenAI, Deepgram, Cartesia, AssemblyAI, ElevenLabs, Gemini, Grok, Soniox, Bailian, Baidu), plus Apple Speech.
 Swift Package Manager project, no Xcode project file. Optional `sherpa-onnx.xcframework` enables local SenseVoice, Silero VAD, and punctuation restoration.
 
 ## Branch Naming and Lifecycle
@@ -148,10 +148,10 @@ All subscription/cloud-proxy code lives in `Type4Me/CloudSubscription/`. Main co
 
 Multi-provider ASR support via `ASRProvider` enum + `ASRProviderConfig` protocol + `ASRProviderRegistry`.
 
-- `ASRProvider` enum: 22 standard cases (`sherpa`, `apple`, international and China cloud providers, and `custom`), plus conditional `cloud` when `HAS_CLOUD_SUBSCRIPTION` is enabled.
+- `ASRProvider` enum: 23 standard cases (`sherpa`, `apple`, international and China cloud providers, and `custom`), plus conditional `cloud` when `HAS_CLOUD_SUBSCRIPTION` is enabled.
 - Each provider has its own Config type (e.g., `SherpaASRConfig`, `VolcanoASRConfig`) defining `credentialFields` for dynamic UI rendering
 - `ASRProviderRegistry`: maps provider to config type + client factory; `capabilities` indicates availability and streaming support
-- **Fully implemented**: Apple Speech (streaming); Volcano, Deepgram, Cartesia, AssemblyAI, ElevenLabs, Gemini, Grok, Soniox, Bailian, and Baidu (streaming); StepFun, MiMo, and OpenAI (batch); and Sherpa/SenseVoice when `HAS_SHERPA_ONNX` is enabled.
+- **Fully implemented**: Apple Speech (streaming); Volcano, StepFun, Deepgram, Cartesia, AssemblyAI, ElevenLabs, Gemini, Grok, Soniox, Bailian, and Baidu (streaming); StepFun, MiMo, and OpenAI (batch); and Sherpa/SenseVoice when `HAS_SHERPA_ONNX` is enabled.
 - **Config only (no client)**: azure, google, aws, aliyun, tencent, iflytek, custom
 
 ### Adding a New Provider
@@ -235,6 +235,8 @@ API keys and other secure values are stored in Keychain, not in this file.
 | `Type4Me/ASR/VolcASRClient.swift` | Cloud streaming ASR (Volcano, WebSocket) |
 | `Type4Me/ASR/DeepgramASRClient.swift` | Cloud streaming ASR (Deepgram, WebSocket) |
 | `Type4Me/ASR/ElevenLabsASRClient.swift` | Cloud streaming ASR (ElevenLabs Scribe v2, WebSocket) |
+| `Type4Me/ASR/StepFunASRClient.swift` | Cloud streaming ASR (StepFun, WebSocket) |
+| `Type4Me/Protocol/StepFunASRProtocol.swift` | StepFun realtime wire format and response parsing |
 | `Type4Me/ASR/GeminiASRClient.swift` | Cloud streaming ASR (Gemini Live API, model selectable) |
 | `Type4Me/Protocol/GeminiTranscribeProtocol.swift` | Gemini Live wire format: setup/audio messages, response parsing |
 | `Type4Me/ASR/GeminiConnectionGate.swift` | Gemini connection gate, close tracker, WebSocket delegate |

--- a/README.md
+++ b/README.md
@@ -1528,7 +1528,7 @@ For non-Dev packaging, a signing identity can be supplied explicitly with
 
 - **Swift Package Manager** project, no `.xcodeproj` needed
 - **Local ASR**: dual-engine design. SenseVoice (streaming partial results) + Qwen3-ASR (final calibration via MLX/Metal). Both run as Python WebSocket servers managed by `SenseVoiceServerManager`
-- **Cloud ASR**: 13 providers implemented (Volcano, StepFun batch, MiMo batch, OpenAI, Deepgram, Cartesia, AssemblyAI, ElevenLabs, Gemini, Grok, Soniox, Bailian, Baidu)
+- **Cloud ASR**: 14 providers implemented (Volcano, StepFun streaming, StepFun batch, MiMo batch, OpenAI, Deepgram, Cartesia, AssemblyAI, ElevenLabs, Gemini, Grok, Soniox, Bailian, Baidu)
 - **Credentials**: stored at `~/Library/Application Support/Type4Me/credentials.json` (mode 0600), never in code or environment variables. GUI apps cannot read shell env vars from `~/.zshrc`
 - **ASR provider architecture**: plugin-based. To add a new provider: implement `ASRProviderConfig` + `SpeechRecognizer` protocol, register in `ASRProviderRegistry.all`. See `AGENTS.md` for details
 - **Audio format**: 16kHz mono PCM16-LE, 200ms chunks (6400 bytes)

--- a/Type4Me/ASR/ASRProvider.swift
+++ b/Type4Me/ASR/ASRProvider.swift
@@ -20,6 +20,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
     case soniox
     // China
     case volcano
+    case stepfun
     case stepfunBatch
     case mimo
     case aliyun
@@ -50,6 +51,7 @@ enum ASRProvider: String, CaseIterable, Codable, Sendable {
         case .grok:     return "Grok"
         case .soniox:   return "Soniox"
         case .volcano:  return L("火山引擎 (Doubao)", "Volcano (Doubao)")
+        case .stepfun:  return L("阶跃星辰", "StepFun")
         case .stepfunBatch: return L("阶跃星辰", "StepFun")
         case .mimo:     return L("小米 MiMo", "Xiaomi MiMo")
         case .aliyun:   return L("阿里云", "Alibaba Cloud")

--- a/Type4Me/ASR/ASRProviderRegistry.swift
+++ b/Type4Me/ASR/ASRProviderRegistry.swift
@@ -81,6 +81,11 @@ enum ASRProviderRegistry {
                 createClient: { VolcASRClient() },
                 capabilities: .streaming()
             ),
+            .stepfun: ProviderEntry(
+                configType: StepFunASRConfig.self,
+                createClient: { StepFunASRClient() },
+                capabilities: .streaming()
+            ),
             .stepfunBatch: ProviderEntry(
                 configType: StepFunBatchASRConfig.self,
                 createClient: { StepFunBatchASRClient() },

--- a/Type4Me/ASR/Providers/StepFunASRConfig.swift
+++ b/Type4Me/ASR/Providers/StepFunASRConfig.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+struct StepFunASRConfig: ASRProviderConfig, Sendable {
+
+    static let provider = ASRProvider.stepfun
+    static let displayName = L("阶跃星辰", "StepFun")
+    static let model = "stepaudio-2.5-asr-stream"
+    static let endpoint = URL(string: "wss://api.stepfun.com/v1/realtime/asr/stream")!
+
+    static var credentialFields: [CredentialField] {[
+        CredentialField(
+            key: "apiKey",
+            label: "API Key",
+            placeholder: "sk-...",
+            isSecure: true,
+            isOptional: false,
+            defaultValue: ""
+        ),
+    ]}
+
+    let apiKey: String
+
+    init?(credentials: [String: String]) {
+        guard let apiKey = credentials["apiKey"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !apiKey.isEmpty
+        else {
+            return nil
+        }
+        self.apiKey = apiKey
+    }
+
+    func toCredentials() -> [String: String] {
+        ["apiKey": apiKey]
+    }
+
+    var isValid: Bool { !apiKey.isEmpty }
+}

--- a/Type4Me/ASR/StepFunASRClient.swift
+++ b/Type4Me/ASR/StepFunASRClient.swift
@@ -1,0 +1,304 @@
+import Foundation
+import os
+
+protocol StepFunWebSocketTransport: Sendable {
+    func start() async
+    func send(_ message: String) async throws
+    func receive() async throws -> Data
+    func close() async
+}
+
+typealias StepFunWebSocketTransportFactory = @Sendable (
+    URLRequest,
+    URLSessionConfiguration,
+    StepFunSessionReadinessGate
+) -> any StepFunWebSocketTransport
+
+actor StepFunASRClient: SpeechRecognizer {
+
+    private let logger = Logger(
+        subsystem: "com.type4me.asr",
+        category: "StepFunASRClient"
+    )
+
+    private let transportFactory: StepFunWebSocketTransportFactory
+    private var transport: (any StepFunWebSocketTransport)?
+    private var receiveTask: Task<Void, Never>?
+    private var readinessGate: StepFunSessionReadinessGate?
+
+    private var eventContinuation: AsyncStream<RecognitionEvent>.Continuation?
+    private var stream: AsyncStream<RecognitionEvent>?
+    private var lastTranscript: RecognitionTranscript = .empty
+    private var didRequestCommit = false
+    private var didComplete = false
+
+    init(transportFactory: @escaping StepFunWebSocketTransportFactory = { request, configuration, gate in
+        StepFunURLSessionWebSocketTransport(
+            request: request,
+            configuration: configuration,
+            readinessGate: gate
+        )
+    }) {
+        self.transportFactory = transportFactory
+    }
+
+    var events: AsyncStream<RecognitionEvent> {
+        if let stream { return stream }
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        self.stream = stream
+        eventContinuation = continuation
+        return stream
+    }
+
+    func connect(config: any ASRProviderConfig, options: ASRRequestOptions = ASRRequestOptions()) async throws {
+        guard let config = config as? StepFunASRConfig else {
+            throw StepFunASRError.invalidConfig
+        }
+
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        self.stream = stream
+        eventContinuation = continuation
+        lastTranscript = .empty
+        didRequestCommit = false
+        didComplete = false
+
+        var request = URLRequest(url: StepFunASRConfig.endpoint)
+        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+
+        let gate = StepFunSessionReadinessGate()
+        let transport = transportFactory(
+            request,
+            options.urlSessionConfiguration,
+            gate
+        )
+
+        readinessGate = gate
+        self.transport = transport
+        await transport.start()
+        startReceiveLoop()
+
+        try await transport.send(StepFunASRProtocol.buildSessionUpdateMessage(options: options))
+        try await gate.waitUntilReady(timeout: .seconds(5))
+        logger.info("StepFun streaming ASR session ready")
+    }
+
+    func sendAudio(_ data: Data) async throws {
+        guard let transport, !data.isEmpty else { return }
+        let message = StepFunASRProtocol.buildAppendAudioMessage(data)
+        try await transport.send(message)
+    }
+
+    func endAudio() async throws {
+        guard let transport, !didRequestCommit else { return }
+        try await transport.send(StepFunASRProtocol.buildCommitMessage())
+        didRequestCommit = true
+    }
+
+    func disconnect() async {
+        // Wake a connect() that is still waiting for session.updated. Do this
+        // explicitly instead of relying on URLSession's close callback, which
+        // may arrive later (or not at all for an injected transport).
+        await readinessGate?.markFailure(CancellationError())
+        receiveTask?.cancel()
+        receiveTask = nil
+        await transport?.close()
+        transport = nil
+        readinessGate = nil
+        eventContinuation?.finish()
+        eventContinuation = nil
+        stream = nil
+        lastTranscript = .empty
+        didRequestCommit = false
+        didComplete = false
+        logger.info("StepFun streaming ASR disconnected")
+    }
+
+    private func startReceiveLoop() {
+        receiveTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                do {
+                    guard let transport = await self.transport else { break }
+                    let data = try await transport.receive()
+                    await self.handle(data)
+                } catch {
+                    if Task.isCancelled { break }
+                    await self.handleReceiveFailure(error)
+                    break
+                }
+            }
+            let continuation = await self.eventContinuation
+            continuation?.finish()
+        }
+    }
+
+    private func handle(_ data: Data) async {
+        do {
+            guard let event = try StepFunASRProtocol.parseServerEvent(from: data) else { return }
+            switch event {
+            case .sessionReady:
+                await readinessGate?.markReady()
+
+            case .transcript(let transcript):
+                guard transcript != lastTranscript else { return }
+                lastTranscript = transcript
+                eventContinuation?.yield(.transcript(transcript))
+                if transcript.isFinal {
+                    finishRecognition()
+                }
+
+            case .error(let error):
+                await readinessGate?.markFailure(error)
+                eventContinuation?.yield(.error(error))
+                finishRecognition()
+            }
+        } catch {
+            await readinessGate?.markFailure(error)
+            eventContinuation?.yield(.error(error))
+            if didRequestCommit {
+                finishRecognition()
+            }
+        }
+    }
+
+    private func handleReceiveFailure(_ error: Error) async {
+        let isReady = await readinessGate?.isReady ?? false
+        if !isReady {
+            await readinessGate?.markFailure(error)
+            return
+        }
+        if !didComplete {
+            eventContinuation?.yield(.error(error))
+            finishRecognition()
+        }
+    }
+
+    private func finishRecognition() {
+        guard !didComplete else { return }
+        didComplete = true
+        eventContinuation?.yield(.completed)
+    }
+}
+
+actor StepFunSessionReadinessGate {
+
+    private var continuation: CheckedContinuation<Void, Error>?
+    private(set) var isReady = false
+    private var failure: Error?
+
+    func waitUntilReady(timeout: Duration) async throws {
+        let timeoutTask = Task {
+            try? await Task.sleep(for: timeout)
+            self.markFailure(StepFunASRError.handshakeTimedOut)
+        }
+        defer { timeoutTask.cancel() }
+        try await wait()
+    }
+
+    func markReady() {
+        guard !isReady, failure == nil else { return }
+        isReady = true
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func markFailure(_ error: Error) {
+        guard !isReady, failure == nil else { return }
+        failure = error
+        continuation?.resume(throwing: error)
+        continuation = nil
+    }
+
+    private func wait() async throws {
+        if isReady { return }
+        if let failure { throw failure }
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+}
+
+private final class StepFunURLSessionWebSocketTransport: StepFunWebSocketTransport, @unchecked Sendable {
+
+    private let session: URLSession
+    private let task: URLSessionWebSocketTask
+    private let delegate: StepFunWebSocketDelegate
+
+    init(
+        request: URLRequest,
+        configuration: URLSessionConfiguration,
+        readinessGate: StepFunSessionReadinessGate
+    ) {
+        let delegate = StepFunWebSocketDelegate(readinessGate: readinessGate)
+        let session = URLSession(
+            configuration: configuration,
+            delegate: delegate,
+            delegateQueue: nil
+        )
+        self.delegate = delegate
+        self.session = session
+        self.task = session.webSocketTask(with: request)
+    }
+
+    func start() async {
+        task.resume()
+    }
+
+    func send(_ message: String) async throws {
+        try await task.send(.string(message))
+    }
+
+    func receive() async throws -> Data {
+        switch try await task.receive() {
+        case .data(let data):
+            return data
+        case .string(let text):
+            return Data(text.utf8)
+        @unknown default:
+            throw StepFunASRError.invalidResponse
+        }
+    }
+
+    func close() async {
+        task.cancel(with: .normalClosure, reason: nil)
+        session.invalidateAndCancel()
+    }
+}
+
+private final class StepFunWebSocketDelegate: NSObject, URLSessionWebSocketDelegate, URLSessionTaskDelegate {
+
+    private let readinessGate: StepFunSessionReadinessGate
+
+    init(readinessGate: StepFunSessionReadinessGate) {
+        self.readinessGate = readinessGate
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
+        reason: Data?
+    ) {
+        let reasonText = reason.flatMap { String(data: $0, encoding: .utf8) }
+        Task {
+            guard await !readinessGate.isReady else { return }
+            await readinessGate.markFailure(
+                StepFunASRError.closedBeforeSessionReady(
+                    code: Int(closeCode.rawValue),
+                    reason: reasonText
+                )
+            )
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        guard let error else { return }
+        Task {
+            await readinessGate.markFailure(error)
+        }
+    }
+}

--- a/Type4Me/Protocol/StepFunASRProtocol.swift
+++ b/Type4Me/Protocol/StepFunASRProtocol.swift
@@ -1,0 +1,203 @@
+import Foundation
+
+enum StepFunASRError: Error, LocalizedError, Equatable {
+    case invalidConfig
+    case handshakeTimedOut
+    case closedBeforeSessionReady(code: Int, reason: String?)
+    case invalidResponse
+    case serverError(code: String?, message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidConfig:
+            return "StepFun streaming ASR requires StepFunASRConfig"
+        case .handshakeTimedOut:
+            return L("阶跃星辰实时识别握手超时", "StepFun streaming ASR handshake timed out")
+        case .closedBeforeSessionReady(let code, let reason):
+            if let reason, !reason.isEmpty {
+                return L(
+                    "阶跃星辰连接在会话就绪前关闭（\(code)）：\(reason)",
+                    "StepFun socket closed before the session was ready (\(code)): \(reason)"
+                )
+            }
+            return L(
+                "阶跃星辰连接在会话就绪前关闭（\(code)）",
+                "StepFun socket closed before the session was ready (\(code))"
+            )
+        case .invalidResponse:
+            return L("阶跃星辰返回了无法解析的识别结果", "StepFun returned an invalid transcription response")
+        case .serverError(let code, let message):
+            let codePart = code?.isEmpty == false ? "[\(code!)] " : ""
+            return L(
+                "阶跃星辰实时识别失败：\(codePart)\(message)",
+                "StepFun streaming ASR failed: \(codePart)\(message)"
+            )
+        }
+    }
+}
+
+enum StepFunASRServerEvent: Sendable, Equatable {
+    case sessionReady
+    case transcript(RecognitionTranscript)
+    case error(StepFunASRError)
+}
+
+enum StepFunASRProtocol {
+
+    private static let hotwordPromptPrefix = "专业术语："
+    private static let maxHotwordCount = 100
+    private static let maxHotwordPromptCharacters = 2_000
+
+    static func buildSessionUpdateMessage(options: ASRRequestOptions) -> String {
+        var transcription: [String: Any] = [
+            "model": StepFunASRConfig.model,
+            "language": "zh",
+            "full_rerun_on_commit": true,
+            "enable_itn": true,
+        ]
+
+        if let prompt = hotwordPrompt(from: options.hotwords) {
+            transcription["prompt"] = prompt
+        }
+
+        let payload: [String: Any] = [
+            "event_id": eventID(),
+            "type": "session.update",
+            "session": [
+                "audio": [
+                    "input": [
+                        "format": [
+                            "type": "pcm",
+                            "codec": "pcm_s16le",
+                            "rate": 16_000,
+                            "bits": 16,
+                            "channel": 1,
+                        ],
+                        "transcription": transcription,
+                    ],
+                ],
+            ],
+        ]
+        return jsonString(from: payload)
+    }
+
+    static func buildAppendAudioMessage(_ data: Data) -> String {
+        jsonString(from: [
+            "event_id": eventID(),
+            "type": "input_audio_buffer.append",
+            "audio": data.base64EncodedString(),
+        ])
+    }
+
+    static func buildCommitMessage() -> String {
+        jsonString(from: [
+            "event_id": eventID(),
+            "type": "input_audio_buffer.commit",
+        ])
+    }
+
+    static func parseServerEvent(from data: Data) throws -> StepFunASRServerEvent? {
+        let decoder = JSONDecoder()
+        guard let envelope = try? decoder.decode(Envelope.self, from: data) else {
+            throw StepFunASRError.invalidResponse
+        }
+
+        switch envelope.type {
+        case "session.updated":
+            return .sessionReady
+
+        case "conversation.item.input_audio_transcription.delta":
+            guard let message = try? decoder.decode(DeltaMessage.self, from: data) else {
+                throw StepFunASRError.invalidResponse
+            }
+            let text = message.text ?? ""
+            let stash = message.stash ?? ""
+            guard !text.isEmpty || !stash.isEmpty else { return nil }
+            return .transcript(RecognitionTranscript(
+                confirmedSegments: text.isEmpty ? [] : [text],
+                partialText: stash,
+                authoritativeText: text + stash,
+                isFinal: false
+            ))
+
+        case "conversation.item.input_audio_transcription.completed":
+            guard let message = try? decoder.decode(CompletedMessage.self, from: data) else {
+                throw StepFunASRError.invalidResponse
+            }
+            let transcript = message.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+            return .transcript(RecognitionTranscript(
+                confirmedSegments: transcript.isEmpty ? [] : [transcript],
+                partialText: "",
+                authoritativeText: transcript,
+                isFinal: true
+            ))
+
+        case "error":
+            guard let message = try? decoder.decode(ErrorMessage.self, from: data) else {
+                throw StepFunASRError.invalidResponse
+            }
+            return .error(.serverError(
+                code: message.error.code,
+                message: message.error.message
+            ))
+
+        default:
+            return nil
+        }
+    }
+
+    private static func hotwordPrompt(from hotwords: [String]) -> String? {
+        var seen: Set<String> = []
+        var prompt = hotwordPromptPrefix
+        var termCount = 0
+
+        for rawTerm in hotwords {
+            guard termCount < maxHotwordCount else { break }
+            let term = rawTerm.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !term.isEmpty else { continue }
+
+            let comparisonKey = term.lowercased()
+            guard seen.insert(comparisonKey).inserted else { continue }
+
+            let separator = termCount == 0 ? "" : "、"
+            let candidate = prompt + separator + term
+            guard candidate.count <= maxHotwordPromptCharacters else { continue }
+
+            prompt = candidate
+            termCount += 1
+        }
+
+        return termCount == 0 ? nil : prompt
+    }
+
+    private static func eventID() -> String {
+        "event_" + UUID().uuidString.lowercased()
+    }
+
+    private static func jsonString(from object: [String: Any]) -> String {
+        let data = try! JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        return String(data: data, encoding: .utf8)!
+    }
+
+    private struct Envelope: Decodable {
+        let type: String
+    }
+
+    private struct DeltaMessage: Decodable {
+        let text: String?
+        let stash: String?
+    }
+
+    private struct CompletedMessage: Decodable {
+        let transcript: String
+    }
+
+    private struct ErrorMessage: Decodable {
+        let error: ErrorDetail
+    }
+
+    private struct ErrorDetail: Decodable {
+        let code: String?
+        let message: String
+    }
+}

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -93,6 +93,17 @@ actor RecognitionSession {
         state = newState
     }
 
+    /// A connect error is actionable only while the same session still owns
+    /// the recording lifecycle. Stopping or replacing the session deliberately
+    /// tears down an in-flight connection.
+    static func shouldReportASRConnectFailure(
+        expectedGeneration: Int,
+        currentGeneration: Int,
+        state: SessionState
+    ) -> Bool {
+        expectedGeneration == currentGeneration && state == .recording
+    }
+
     /// Exposed for testing; production code should resolve modes through startRecording / switchMode.
     func currentModeForTesting() -> ProcessingMode {
         currentMode
@@ -220,6 +231,9 @@ actor RecognitionSession {
         if provider == .cartesia {
             return "\(providerName) · \(CartesiaASRConfig.model)"
         }
+        if provider == .stepfun {
+            return "\(providerName) · \(StepFunASRConfig.model)"
+        }
 
         guard let credentials = KeychainService.loadASRConfig(for: provider)?.toCredentials() else {
             return providerName
@@ -301,6 +315,8 @@ actor RecognitionSession {
         switch provider {
         case .volcano:
             return "https://openspeech.bytedance.com"
+        case .stepfun:
+            return "https://api.stepfun.com"
         case .stepfunBatch:
             return "https://api.stepfun.com"
         case .soniox:
@@ -997,6 +1013,26 @@ actor RecognitionSession {
             )
             DebugFileLogger.log("ASR connected OK provider=\(provider.rawValue)")
         } catch {
+            // stopRecording() may intentionally disconnect the recognizer while
+            // connect() is suspended. That cancellation belongs to the stopped
+            // (or superseded) session and must not surface as an ASR failure.
+            guard Self.shouldReportASRConnectFailure(
+                expectedGeneration: myGeneration,
+                currentGeneration: sessionGeneration,
+                state: state
+            ) else {
+                DebugFileLogger.log(
+                    "ASR connect ended after session stopped "
+                        + "provider=\(provider.rawValue) gen=\(myGeneration) "
+                        + "current=\(sessionGeneration) state=\(state) "
+                        + "error=\(String(describing: error))"
+                )
+                await client.disconnect()
+                if sessionGeneration == myGeneration {
+                    self.asrClient = nil
+                }
+                return
+            }
             NSLog("[Session] ASR connect FAILED provider=%@ error=%@", provider.rawValue, String(describing: error))
             DebugFileLogger.log("ASR connect failed provider=\(provider.rawValue): \(String(describing: error))")
             SoundFeedback.playError()
@@ -1018,7 +1054,9 @@ actor RecognitionSession {
         guard sessionGeneration == myGeneration, state == .recording else {
             DebugFileLogger.log("startRecording: zombie or state change after connect (gen=\(myGeneration) current=\(sessionGeneration) state=\(state)), bailing")
             await client.disconnect()
-            self.asrClient = nil
+            if sessionGeneration == myGeneration {
+                self.asrClient = nil
+            }
             return
         }
 

--- a/Type4Me/UI/Settings/ASRSettingsCard.swift
+++ b/Type4Me/UI/Settings/ASRSettingsCard.swift
@@ -149,9 +149,11 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
                 (L("可用模型", "Models"), L("查看", "view"), URL(string: "https://help.aliyun.com/zh/model-studio/fun-asr-realtime-websocket-api")!),
                 (L("API Key", "API Key"), L("获取", "get"), URL(string: "https://help.aliyun.com/zh/model-studio/get-api-key")!),
             ]
-        case .stepfunBatch:
+        case .stepfun, .stepfunBatch:
             return [
-                (L("接入文档", "Setup guide"), L("查看", "view"), URL(string: "https://platform.stepfun.com/docs/zh/api-reference/audio/asr-sse")!),
+                (L("接入文档", "Setup guide"), L("查看", "view"), URL(string: selectedASRProvider == .stepfun
+                    ? "https://platform.stepfun.com/docs/zh/api-reference/audio/asr-stream"
+                    : "https://platform.stepfun.com/docs/zh/api-reference/audio/asr-sse")!),
                 ("API Key", L("获取", "get"), URL(string: "https://platform.stepfun.com/interface-key")!),
             ]
         case .mimo:
@@ -231,6 +233,11 @@ struct ASRSettingsCard: View, SettingsCardHelpers {
             return L(
                 "松开快捷键后提交完整录音进行转写。",
                 "The complete recording is submitted after you release the hotkey."
+            )
+        case .stepfun:
+            return L(
+                "实时流式识别使用开放平台按量付费 API Key，不支持 Step Plan 路径。",
+                "Real-time streaming recognition uses a standard pay-as-you-go API key and is not available through the Step Plan endpoint."
             )
         case .stepfunBatch:
             return L(

--- a/Type4MeTests/ASRProviderRegistryTests.swift
+++ b/Type4MeTests/ASRProviderRegistryTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class ASRProviderRegistryTests: XCTestCase {
 
     func testAvailableProvidersSupportDirectMode() {
-        for provider in [ASRProvider.volcano, .stepfunBatch, .mimo, .baidu, .bailian, .deepgram, .gemini, .assemblyai, .soniox, .openai] {
+        for provider in [ASRProvider.volcano, .stepfun, .stepfunBatch, .mimo, .baidu, .bailian, .deepgram, .gemini, .assemblyai, .soniox, .openai] {
             XCTAssertTrue(ASRProviderRegistry.supports(.direct, for: provider))
         }
     }
@@ -77,7 +77,7 @@ final class ASRProviderRegistryTests: XCTestCase {
         // Realtime streaming providers
         for realtime in [
             ASRProvider.apple, .volcano, .deepgram, .cartesia,
-            .assemblyai, .elevenlabs, .gemini, .grok, .soniox, .bailian, .baidu
+            .assemblyai, .elevenlabs, .gemini, .grok, .soniox, .stepfun, .bailian, .baidu
         ] {
             let caps = ASRProviderRegistry.capabilities(for: realtime)
             XCTAssertTrue(caps.isAvailable)
@@ -87,6 +87,7 @@ final class ASRProviderRegistryTests: XCTestCase {
     }
 
     func testProviderDisplayNames_areCleanWithoutBatchSuffix() {
+        XCTAssertEqual(ASRProvider.stepfun.displayName, L("阶跃星辰", "StepFun"))
         XCTAssertEqual(ASRProvider.stepfunBatch.displayName, L("阶跃星辰", "StepFun"))
         XCTAssertEqual(ASRProvider.mimo.displayName, L("小米 MiMo", "Xiaomi MiMo"))
         XCTAssertEqual(ASRProvider.openai.displayName, "OpenAI")

--- a/Type4MeTests/RecognitionSessionTests.swift
+++ b/Type4MeTests/RecognitionSessionTests.swift
@@ -36,6 +36,24 @@ final class RecognitionSessionTests: XCTestCase {
         await session.setState(.idle)
     }
 
+    func testASRConnectFailureIsReportedOnlyForCurrentRecordingSession() {
+        XCTAssertTrue(RecognitionSession.shouldReportASRConnectFailure(
+            expectedGeneration: 3,
+            currentGeneration: 3,
+            state: .recording
+        ))
+        XCTAssertFalse(RecognitionSession.shouldReportASRConnectFailure(
+            expectedGeneration: 3,
+            currentGeneration: 3,
+            state: .finishing
+        ))
+        XCTAssertFalse(RecognitionSession.shouldReportASRConnectFailure(
+            expectedGeneration: 3,
+            currentGeneration: 4,
+            state: .recording
+        ))
+    }
+
     func testRecoveryHotkeyRequiresSecondPressToInterrupt() async {
         let session = RecognitionSession()
         await session.setState(.recovering)

--- a/Type4MeTests/StepFunASRClientTests.swift
+++ b/Type4MeTests/StepFunASRClientTests.swift
@@ -1,0 +1,324 @@
+import XCTest
+@testable import Type4Me
+
+final class StepFunASRClientTests: XCTestCase {
+
+    func testStreamingLifecycleEmitsPartialThenSingleFinalCompletion() async throws {
+        let socket = MockStepFunWebSocket()
+        let client = makeClient(socket: socket)
+        try await connect(client, socket: socket)
+        let eventsTask = collectUntilCompleted(from: client)
+
+        let pcm = Data([0x00, 0x01, 0x02])
+        try await client.sendAudio(pcm)
+        await socket.push(#"{"type":"conversation.item.input_audio_transcription.delta","text":"你好，","stash":"世"}"#)
+        await socket.push(#"{"type":"conversation.item.input_audio_transcription.delta","text":"你好，","stash":"世界"}"#)
+        try await client.endAudio()
+        try await client.endAudio()
+        await socket.push(#"{"type":"conversation.item.input_audio_transcription.completed","transcript":"你好，世界"}"#)
+
+        let events = await eventsTask.value
+        let transcripts = events.compactMap { event -> RecognitionTranscript? in
+            guard case .transcript(let transcript) = event else { return nil }
+            return transcript
+        }
+        XCTAssertEqual(transcripts.map(\.authoritativeText), ["你好，世", "你好，世界", "你好，世界"])
+        XCTAssertEqual(transcripts.map(\.isFinal), [false, false, true])
+        XCTAssertEqual(completedCount(in: events), 1)
+
+        let sent = await socket.waitForSentMessages(count: 3)
+        XCTAssertEqual(messageTypes(in: sent), [
+            "session.update",
+            "input_audio_buffer.append",
+            "input_audio_buffer.commit",
+        ])
+        XCTAssertEqual(audioPayload(in: sent[1]), pcm.base64EncodedString())
+
+        await client.disconnect()
+    }
+
+    func testFailedCommitCanBeRetried() async throws {
+        let socket = MockStepFunWebSocket()
+        let client = makeClient(socket: socket)
+        try await connect(client, socket: socket)
+
+        await socket.failNextSend(with: URLError(.networkConnectionLost))
+        do {
+            try await client.endAudio()
+            XCTFail("Expected commit send failure")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, .networkConnectionLost)
+        }
+
+        try await client.endAudio()
+        let sent = await socket.waitForSentMessages(count: 2)
+        XCTAssertEqual(messageTypes(in: sent), [
+            "session.update",
+            "input_audio_buffer.commit",
+        ])
+
+        await client.disconnect()
+    }
+
+    func testServerErrorAfterReadyEmitsErrorAndCompletes() async throws {
+        let socket = MockStepFunWebSocket()
+        let client = makeClient(socket: socket)
+        try await connect(client, socket: socket)
+        let eventsTask = collectUntilCompleted(from: client)
+
+        await socket.push(#"{"type":"error","error":{"code":"invalid_value","message":"bad audio"}}"#)
+        let events = await eventsTask.value
+
+        let errors = events.compactMap { event -> StepFunASRError? in
+            guard case .error(let error) = event else { return nil }
+            return error as? StepFunASRError
+        }
+        XCTAssertEqual(errors, [.serverError(code: "invalid_value", message: "bad audio")])
+        XCTAssertEqual(completedCount(in: events), 1)
+
+        await client.disconnect()
+    }
+
+    func testDuplicateFinalMessageEmitsCompletionOnlyOnce() async throws {
+        let socket = MockStepFunWebSocket()
+        let client = makeClient(socket: socket)
+        try await connect(client, socket: socket)
+        let eventsTask = Task {
+            var events: [RecognitionEvent] = []
+            for await event in await client.events {
+                events.append(event)
+            }
+            return events
+        }
+
+        let finalMessage = #"{"type":"conversation.item.input_audio_transcription.completed","transcript":"你好，世界"}"#
+        await socket.push(finalMessage)
+        await socket.push(finalMessage)
+        try await Task.sleep(for: .milliseconds(30))
+        await client.disconnect()
+
+        let events = await eventsTask.value
+        XCTAssertEqual(completedCount(in: events), 1)
+        XCTAssertEqual(events.compactMap { event -> RecognitionTranscript? in
+            guard case .transcript(let transcript) = event else { return nil }
+            return transcript
+        }.filter(\.isFinal).count, 1)
+    }
+
+    func testTransportFailureBeforeReadyFailsConnect() async throws {
+        let socket = MockStepFunWebSocket()
+        let client = makeClient(socket: socket)
+        let config = try makeConfig()
+
+        let connectTask = Task {
+            try await client.connect(config: config, options: ASRRequestOptions())
+        }
+        _ = await socket.waitForSentMessages(count: 1)
+        await socket.failReceive(with: URLError(.networkConnectionLost))
+
+        do {
+            try await connectTask.value
+            XCTFail("Expected transport failure")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, .networkConnectionLost)
+        }
+
+        await client.disconnect()
+    }
+
+    func testDisconnectWhileConnectingCancelsReadinessWait() async throws {
+        let socket = MockStepFunWebSocket()
+        let client = makeClient(socket: socket)
+        let config = try makeConfig()
+
+        let connectTask = Task {
+            try await client.connect(config: config, options: ASRRequestOptions())
+        }
+        _ = await socket.waitForSentMessages(count: 1)
+
+        await client.disconnect()
+
+        do {
+            try await connectTask.value
+            XCTFail("Expected connect to be cancelled")
+        } catch is CancellationError {
+            // Expected: disconnect must wake the pending readiness wait.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        let closeCount = await socket.closeCount
+        XCTAssertEqual(closeCount, 1)
+    }
+
+    func testDisconnectIsIdempotentAndClosesTransportOnce() async throws {
+        let socket = MockStepFunWebSocket()
+        let client = makeClient(socket: socket)
+        try await connect(client, socket: socket)
+
+        await client.disconnect()
+        await client.disconnect()
+
+        let closeCount = await socket.closeCount
+        XCTAssertEqual(closeCount, 1)
+    }
+
+    func testCallsBeforeConnectAreSafe() async throws {
+        let client = StepFunASRClient()
+        try await client.sendAudio(Data())
+        try await client.sendAudio(Data([0x01]))
+        try await client.endAudio()
+        await client.disconnect()
+        await client.disconnect()
+    }
+
+    private func makeClient(socket: MockStepFunWebSocket) -> StepFunASRClient {
+        StepFunASRClient { _, _, _ in socket }
+    }
+
+    private func makeConfig() throws -> StepFunASRConfig {
+        try XCTUnwrap(StepFunASRConfig(credentials: ["apiKey": "sk-test"]))
+    }
+
+    private func connect(_ client: StepFunASRClient, socket: MockStepFunWebSocket) async throws {
+        let config = try makeConfig()
+        let connectTask = Task {
+            try await client.connect(config: config, options: ASRRequestOptions())
+        }
+        _ = await socket.waitForSentMessages(count: 1)
+        await socket.push(#"{"type":"session.updated"}"#)
+        try await connectTask.value
+    }
+
+    private func collectUntilCompleted(from client: StepFunASRClient) -> Task<[RecognitionEvent], Never> {
+        Task {
+            var events: [RecognitionEvent] = []
+            for await event in await client.events {
+                events.append(event)
+                if case .completed = event { break }
+            }
+            return events
+        }
+    }
+
+    private func completedCount(in events: [RecognitionEvent]) -> Int {
+        events.reduce(into: 0) { count, event in
+            if case .completed = event { count += 1 }
+        }
+    }
+
+    private func messageTypes(in messages: [String]) -> [String] {
+        messages.compactMap { message in
+            guard let data = message.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return nil }
+            return json["type"] as? String
+        }
+    }
+
+    private func audioPayload(in message: String) -> String? {
+        guard let data = message.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return json["audio"] as? String
+    }
+}
+
+private actor MockStepFunWebSocket: StepFunWebSocketTransport {
+
+    private enum Incoming {
+        case data(Data)
+        case failure(Error)
+    }
+
+    private struct SendWaiter {
+        let count: Int
+        let continuation: CheckedContinuation<[String], Never>
+    }
+
+    private var incoming: [Incoming] = []
+    private var receiveContinuation: CheckedContinuation<Data, Error>?
+    private var sentMessages: [String] = []
+    private var sendWaiters: [SendWaiter] = []
+    private var nextSendFailure: Error?
+    private var isClosed = false
+    private(set) var closeCount = 0
+
+    func start() async {}
+
+    func send(_ message: String) async throws {
+        if let failure = nextSendFailure {
+            nextSendFailure = nil
+            throw failure
+        }
+        sentMessages.append(message)
+        resumeSatisfiedSendWaiters()
+    }
+
+    func receive() async throws -> Data {
+        if !incoming.isEmpty {
+            return try resolve(incoming.removeFirst())
+        }
+        if isClosed { throw CancellationError() }
+        return try await withCheckedThrowingContinuation { continuation in
+            receiveContinuation = continuation
+        }
+    }
+
+    func close() async {
+        guard !isClosed else { return }
+        isClosed = true
+        closeCount += 1
+        receiveContinuation?.resume(throwing: CancellationError())
+        receiveContinuation = nil
+    }
+
+    func push(_ json: String) {
+        enqueue(.data(Data(json.utf8)))
+    }
+
+    func failReceive(with error: Error) {
+        enqueue(.failure(error))
+    }
+
+    func failNextSend(with error: Error) {
+        nextSendFailure = error
+    }
+
+    func waitForSentMessages(count: Int) async -> [String] {
+        if sentMessages.count >= count { return sentMessages }
+        return await withCheckedContinuation { continuation in
+            sendWaiters.append(SendWaiter(count: count, continuation: continuation))
+        }
+    }
+
+    private func enqueue(_ message: Incoming) {
+        if let continuation = receiveContinuation {
+            receiveContinuation = nil
+            switch message {
+            case .data(let data): continuation.resume(returning: data)
+            case .failure(let error): continuation.resume(throwing: error)
+            }
+        } else {
+            incoming.append(message)
+        }
+    }
+
+    private func resolve(_ message: Incoming) throws -> Data {
+        switch message {
+        case .data(let data): return data
+        case .failure(let error): throw error
+        }
+    }
+
+    private func resumeSatisfiedSendWaiters() {
+        var remaining: [SendWaiter] = []
+        for waiter in sendWaiters {
+            if sentMessages.count >= waiter.count {
+                waiter.continuation.resume(returning: sentMessages)
+            } else {
+                remaining.append(waiter)
+            }
+        }
+        sendWaiters = remaining
+    }
+}

--- a/Type4MeTests/StepFunASRConfigTests.swift
+++ b/Type4MeTests/StepFunASRConfigTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import Type4Me
+
+final class StepFunASRConfigTests: XCTestCase {
+
+    func testConfigTrimsAPIKey() throws {
+        let config = try XCTUnwrap(StepFunASRConfig(credentials: ["apiKey": "  sk-test  "]))
+        XCTAssertEqual(config.apiKey, "sk-test")
+        XCTAssertEqual(config.toCredentials(), ["apiKey": "sk-test"])
+        XCTAssertTrue(config.isValid)
+    }
+
+    func testConfigRequiresAPIKey() {
+        XCTAssertNil(StepFunASRConfig(credentials: [:]))
+        XCTAssertNil(StepFunASRConfig(credentials: ["apiKey": "   "]))
+    }
+
+    func testRegistryUsesStreamingClient() {
+        XCTAssertTrue(ASRProviderRegistry.configType(for: .stepfun) == StepFunASRConfig.self)
+        XCTAssertEqual(ASRProviderRegistry.capabilities(for: .stepfun), .streaming())
+        XCTAssertNotNil(ASRProviderRegistry.createClient(for: .stepfun))
+    }
+}

--- a/Type4MeTests/StepFunASRProtocolTests.swift
+++ b/Type4MeTests/StepFunASRProtocolTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import Type4Me
+
+final class StepFunASRProtocolTests: XCTestCase {
+
+    func testSessionUpdateUsesManualCommitAndHotwordPrompt() throws {
+        let message = StepFunASRProtocol.buildSessionUpdateMessage(options: ASRRequestOptions(
+            hotwords: [" Type4Me ", "", "type4me", "阶跃星辰"]
+        ))
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(message.utf8)) as? [String: Any])
+
+        XCTAssertEqual(json["type"] as? String, "session.update")
+        XCTAssertNotNil(json["event_id"] as? String)
+
+        let session = try XCTUnwrap(json["session"] as? [String: Any])
+        let audio = try XCTUnwrap(session["audio"] as? [String: Any])
+        let input = try XCTUnwrap(audio["input"] as? [String: Any])
+        let format = try XCTUnwrap(input["format"] as? [String: Any])
+        XCTAssertEqual(format["type"] as? String, "pcm")
+        XCTAssertEqual(format["codec"] as? String, "pcm_s16le")
+        XCTAssertEqual(format["rate"] as? Int, 16_000)
+        XCTAssertEqual(format["bits"] as? Int, 16)
+        XCTAssertEqual(format["channel"] as? Int, 1)
+
+        let transcription = try XCTUnwrap(input["transcription"] as? [String: Any])
+        XCTAssertEqual(transcription["model"] as? String, StepFunASRConfig.model)
+        XCTAssertEqual(transcription["language"] as? String, "zh")
+        XCTAssertEqual(transcription["full_rerun_on_commit"] as? Bool, true)
+        XCTAssertEqual(transcription["enable_itn"] as? Bool, true)
+        XCTAssertEqual(transcription["prompt"] as? String, "专业术语：Type4Me、阶跃星辰")
+        XCTAssertNil(input["turn_detection"])
+    }
+
+    func testSessionUpdateSanitizesAndBoundsHotwordPrompt() throws {
+        let oversizedTerms = (0..<120).map { "术语\($0)-" + String(repeating: "字", count: 30) }
+        let message = StepFunASRProtocol.buildSessionUpdateMessage(options: ASRRequestOptions(
+            hotwords: [" Type4Me ", "type4me", "TYPE4ME"] + oversizedTerms
+        ))
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(message.utf8)) as? [String: Any])
+        let session = try XCTUnwrap(json["session"] as? [String: Any])
+        let audio = try XCTUnwrap(session["audio"] as? [String: Any])
+        let input = try XCTUnwrap(audio["input"] as? [String: Any])
+        let transcription = try XCTUnwrap(input["transcription"] as? [String: Any])
+        let prompt = try XCTUnwrap(transcription["prompt"] as? String)
+
+        XCTAssertTrue(prompt.hasPrefix("专业术语：Type4Me"))
+        XCTAssertEqual(prompt.components(separatedBy: "Type4Me").count - 1, 1)
+        XCTAssertLessThanOrEqual(prompt.count, 2_000)
+        XCTAssertLessThanOrEqual(prompt.split(separator: "、").count, 100)
+    }
+
+    func testSessionUpdateOmitsPromptWhenHotwordsAreBlank() throws {
+        let message = StepFunASRProtocol.buildSessionUpdateMessage(options: ASRRequestOptions(
+            hotwords: ["", "   ", "\n"]
+        ))
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(message.utf8)) as? [String: Any])
+        let session = try XCTUnwrap(json["session"] as? [String: Any])
+        let audio = try XCTUnwrap(session["audio"] as? [String: Any])
+        let input = try XCTUnwrap(audio["input"] as? [String: Any])
+        let transcription = try XCTUnwrap(input["transcription"] as? [String: Any])
+
+        XCTAssertNil(transcription["prompt"])
+    }
+
+    func testAppendMessageEncodesRawPCM() throws {
+        let pcm = Data([0x00, 0x7f, 0xff])
+        let message = StepFunASRProtocol.buildAppendAudioMessage(pcm)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(message.utf8)) as? [String: Any])
+
+        XCTAssertEqual(json["type"] as? String, "input_audio_buffer.append")
+        XCTAssertEqual(json["audio"] as? String, pcm.base64EncodedString())
+        XCTAssertNotNil(json["event_id"] as? String)
+    }
+
+    func testCommitMessage() throws {
+        let message = StepFunASRProtocol.buildCommitMessage()
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(message.utf8)) as? [String: Any])
+
+        XCTAssertEqual(json["type"] as? String, "input_audio_buffer.commit")
+        XCTAssertNotNil(json["event_id"] as? String)
+    }
+
+    func testDeltaUsesTextAsConfirmedPrefixAndStashAsPartial() throws {
+        let data = Data(#"{"type":"conversation.item.input_audio_transcription.delta","text":"你好，","stash":"世界"}"#.utf8)
+        let event = try StepFunASRProtocol.parseServerEvent(from: data)
+
+        guard case .transcript(let transcript) = event else {
+            return XCTFail("Expected transcript event")
+        }
+        XCTAssertEqual(transcript.confirmedSegments, ["你好，"])
+        XCTAssertEqual(transcript.partialText, "世界")
+        XCTAssertEqual(transcript.authoritativeText, "你好，世界")
+        XCTAssertFalse(transcript.isFinal)
+    }
+
+    func testCompletedTranscriptIsFinalAndAuthoritative() throws {
+        let data = Data(#"{"type":"conversation.item.input_audio_transcription.completed","transcript":"你好，世界"}"#.utf8)
+        let event = try StepFunASRProtocol.parseServerEvent(from: data)
+
+        guard case .transcript(let transcript) = event else {
+            return XCTFail("Expected transcript event")
+        }
+        XCTAssertEqual(transcript.confirmedSegments, ["你好，世界"])
+        XCTAssertEqual(transcript.partialText, "")
+        XCTAssertEqual(transcript.authoritativeText, "你好，世界")
+        XCTAssertTrue(transcript.isFinal)
+    }
+
+    func testSessionUpdatedMarksSessionReady() throws {
+        let data = Data(#"{"type":"session.updated"}"#.utf8)
+        XCTAssertEqual(try StepFunASRProtocol.parseServerEvent(from: data), .sessionReady)
+    }
+
+    func testErrorMessagePreservesCodeAndMessage() throws {
+        let data = Data(#"{"type":"error","error":{"code":"invalid_value","message":"bad audio"}}"#.utf8)
+        XCTAssertEqual(
+            try StepFunASRProtocol.parseServerEvent(from: data),
+            .error(.serverError(code: "invalid_value", message: "bad audio"))
+        )
+    }
+
+    func testUnknownEventIsIgnored() throws {
+        let data = Data(#"{"type":"session.created"}"#.utf8)
+        XCTAssertNil(try StepFunASRProtocol.parseServerEvent(from: data))
+    }
+}

--- a/Type4MeTests/StepFunSessionReadinessGateTests.swift
+++ b/Type4MeTests/StepFunSessionReadinessGateTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import Type4Me
+
+final class StepFunSessionReadinessGateTests: XCTestCase {
+
+    func testWaitUntilReadyReturnsAfterSessionUpdate() async throws {
+        let gate = StepFunSessionReadinessGate()
+
+        Task {
+            try? await Task.sleep(for: .milliseconds(20))
+            await gate.markReady()
+        }
+
+        try await gate.waitUntilReady(timeout: .milliseconds(200))
+        let isReady = await gate.isReady
+        XCTAssertTrue(isReady)
+    }
+
+    func testWaitUntilReadyThrowsStoredFailure() async {
+        let gate = StepFunSessionReadinessGate()
+        let expected = URLError(.userAuthenticationRequired)
+        await gate.markFailure(expected)
+
+        do {
+            try await gate.waitUntilReady(timeout: .milliseconds(200))
+            XCTFail("Expected stored failure")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, expected.code)
+        }
+    }
+
+    func testFailureAfterReadyDoesNotInvalidateGate() async throws {
+        let gate = StepFunSessionReadinessGate()
+        await gate.markReady()
+        await gate.markFailure(URLError(.networkConnectionLost))
+
+        try await gate.waitUntilReady(timeout: .milliseconds(50))
+        let isReady = await gate.isReady
+        XCTAssertTrue(isReady)
+    }
+
+    func testWaitUntilReadyTimesOut() async {
+        let gate = StepFunSessionReadinessGate()
+
+        do {
+            try await gate.waitUntilReady(timeout: .milliseconds(30))
+            XCTFail("Expected handshake timeout")
+        } catch {
+            XCTAssertEqual(error as? StepFunASRError, .handshakeTimedOut)
+        }
+    }
+}


### PR DESCRIPTION
## 问题

Type4Me 已支持阶跃星辰批量识别，但尚不能使用开放平台的实时 WebSocket ASR。现有 Batch Provider 和 Step Plan 行为保持不变。

## 实现

- 新增独立的 StepFun 实时 Provider，使用 stepaudio-2.5-asr-stream
- 支持 16 kHz PCM 流式上传、增量文本替换、最终转写、手动 commit 和热词 prompt
- 录音先于 Provider 握手开始，连接期间缓存音频并在就绪后补发
- 正确处理握手超时、服务端错误、重复完成和快速按下后松开的取消竞态
- 设置页明确区分开放平台按量付费实时接口与 Step Plan / Batch 接口

## 验证

- 完整测试：939 项 XCTest，2 项按环境跳过，0 失败；另有 5 项 Swift Testing 通过
- StepFun 与 Registry 定向测试：50 项，0 失败
- arm64 Release 开发包构建、签名和启动通过
- 使用真实开放平台 API Key 验证实时转写可用
- 实机验证快速按下后立即松开不会再显示取消或启动失败错误

官方接口文档：https://platform.stepfun.com/docs/zh/api-reference/audio/asr-stream