### PR TITLE
feat: enable inline mode management on Home dashboard

### DIFF
--- a/Type4Me/UI/Settings/HomeDashboardView.swift
+++ b/Type4Me/UI/Settings/HomeDashboardView.swift
@@ -46,13 +46,19 @@ struct HomeDashboardView: View {
     @State private var heatmapHoverGeneration = 0
     @State private var hoveredModeID: UUID?
     @State private var isModesButtonHovered = false
+    /// Live-editable mirror of `appState.availableModes`, kept in sync so the
+    /// Home card can reorder and edit hotkeys inline and persist back.
+    @State private var modes: [ProcessingMode] = []
+    @State private var recordingTarget: RecordingTarget?
+    @State private var draggingModeID: UUID?
+    /// Measured natural heights used to bottom-align the modes card with the
+    /// left column and scroll only when the mode list overflows.
+    @State private var primaryColumnHeight: CGFloat = 0
+    @State private var shortcutsHeaderHeight: CGFloat = 0
+    @State private var modeListContentHeight: CGFloat = 0
 
     private let historyStore = HistoryStore.shared
     private let assumedTypingSpeed = 40.0
-
-    /// Use the same live source as the menu bar so edits and reordering are
-    /// immediately reflected without waiting for persistence notifications.
-    private var modes: [ProcessingMode] { appState.availableModes }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -63,18 +69,45 @@ struct HomeDashboardView: View {
                 HStack(alignment: .top, spacing: 18) {
                     primaryColumn
                         .frame(minWidth: 350, maxWidth: .infinity)
-                    shortcutsCard
+                        .background(
+                            GeometryReader { proxy in
+                                Color.clear.preference(
+                                    key: PrimaryColumnHeightKey.self,
+                                    value: proxy.size.height
+                                )
+                            }
+                        )
+                    shortcutsCard(capHeight: primaryColumnHeight > 0 ? primaryColumnHeight : nil)
                         .frame(width: 200)
                 }
+                .onPreferenceChange(PrimaryColumnHeightKey.self) { primaryColumnHeight = $0 }
 
                 VStack(alignment: .leading, spacing: 18) {
                     primaryColumn
-                    shortcutsCard
+                    shortcutsCard(capHeight: nil)
                 }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .sheet(item: $recordingTarget) { target in
+            HotkeyRecordingSheet(
+                target: target,
+                checkConflict: ModeHotkeyEditing.makeConflictCheck(in: modes, target: target),
+                checkDuplicateInMode: ModeHotkeyEditing.makeDuplicateCheck(in: modes, target: target),
+                checkPrefixConflict: ModeHotkeyEditing.makePrefixConflictCheck(in: modes, target: target),
+                onConfirm: { code, mods, style in
+                    ModeHotkeyEditing.applyBinding(
+                        keyCode: code, modifiers: mods, style: style,
+                        to: &modes, for: target
+                    )
+                    persistHomeModes()
+                    recordingTarget = nil
+                },
+                onCancel: { recordingTarget = nil }
+            )
+        }
         .onAppear {
+            syncModes()
             if isActive { refreshDashboard() }
         }
         .onChange(of: isActive) { _, isNowActive in
@@ -84,9 +117,11 @@ struct HomeDashboardView: View {
             if isActive { refreshDashboard() }
         }
         .onReceive(NotificationCenter.default.publisher(for: .selectMode)) { _ in
+            syncModes()
             refreshDashboard()
         }
         .onReceive(NotificationCenter.default.publisher(for: .modesDidChange)) { _ in
+            syncModes()
             refreshDashboard()
         }
     }
@@ -453,17 +488,12 @@ struct HomeDashboardView: View {
 
     // MARK: - Shortcuts
 
-    private var shortcutsCard: some View {
+    private func shortcutsCard(capHeight: CGFloat?) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 8) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(L("我的模式", "My Modes"))
-                        .font(.system(size: 16, weight: .bold))
-                        .foregroundStyle(TF.settingsText)
-                    Text(L("按模式快速输入", "Dictate by mode"))
-                        .font(.system(size: 10))
-                        .foregroundStyle(TF.settingsTextTertiary)
-                }
+                Text(L("我的模式", "My Modes"))
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundStyle(TF.settingsText)
 
                 Spacer(minLength: 4)
 
@@ -481,157 +511,204 @@ struct HomeDashboardView: View {
                 }
             }
             .padding(15)
+            .background(
+                GeometryReader { proxy in
+                    Color.clear.preference(
+                        key: ShortcutsHeaderHeightKey.self,
+                        value: proxy.size.height
+                    )
+                }
+            )
 
             Divider().padding(.horizontal, 15)
 
-            if modes.isEmpty {
-                Text(L("还没有模式", "No modes yet"))
-                    .font(.system(size: 11))
-                    .foregroundStyle(TF.settingsTextTertiary)
-                    .frame(maxWidth: .infinity, minHeight: 96)
-            } else {
-                VStack(spacing: 0) {
-                    ForEach(Array(modes.prefix(6).enumerated()), id: \.element.id) { index, mode in
-                        shortcutRow(mode)
-                        if index < min(modes.count, 6) - 1 {
-                            Divider().padding(.leading, 15)
-                        }
-                    }
-
-                    if modes.count > 6 {
-                        Button(action: { openModesEditor(nil) }) {
-                            Text(L("查看全部 \(modes.count) 个模式", "View all \(modes.count) modes"))
-                                .font(.system(size: 10, weight: .semibold))
-                                .foregroundStyle(TF.settingsTextSecondary)
-                                .frame(maxWidth: .infinity)
-                                .frame(height: 38)
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-            }
+            modeListSection(capHeight: capHeight)
         }
+        .onPreferenceChange(ShortcutsHeaderHeightKey.self) { shortcutsHeaderHeight = $0 }
         .dashboardCard()
     }
 
-    private func shortcutRow(_ mode: ProcessingMode) -> some View {
-        Button(action: { openModesEditor(mode.id) }) {
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 6) {
-                    Text(mode.localizedDisplayName)
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(TF.settingsText)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.55)
-                        .allowsTightening(true)
-                        .layoutPriority(1)
-                    Spacer(minLength: 0)
-                    if mode.isBuiltin {
-                        Circle()
-                            .fill(TF.settingsAccentBlue.opacity(0.65))
-                            .frame(width: 5, height: 5)
-                            .help(L("内置模式", "Built-in mode"))
-                    }
-                }
+    @ViewBuilder
+    private func modeListSection(capHeight: CGFloat?) -> some View {
+        if modes.isEmpty {
+            Text(L("还没有模式", "No modes yet"))
+                .font(.system(size: 11))
+                .foregroundStyle(TF.settingsTextTertiary)
+                .frame(maxWidth: .infinity, minHeight: 96)
+        } else {
+            // Available list height when the card is capped to the left column:
+            // total cap minus the measured header (the 1pt divider is negligible).
+            let available = capHeight.map { max(0, $0 - shortcutsHeaderHeight) }
+            let shouldScroll = available.map { modeListContentHeight > $0 + 0.5 } ?? false
 
-                hotkeyBadge(mode)
+            if shouldScroll, let available {
+                ScrollView(.vertical, showsIndicators: false) {
+                    modeListContent
+                }
+                .scrollBounceBehavior(.basedOnSize)
+                .frame(height: available)
+            } else {
+                modeListContent
             }
-            .padding(.horizontal, 15)
-            .padding(.vertical, 12)
-            .frame(maxWidth: .infinity, minHeight: 62, alignment: .leading)
-            .background(hoveredModeID == mode.id ? TF.settingsRowHover : Color.clear)
-            .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+    }
+
+    private var modeListContent: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(modes.enumerated()), id: \.element.id) { index, mode in
+                shortcutRow(mode)
+                if index < modes.count - 1 {
+                    Divider().padding(.leading, 15)
+                }
+            }
+        }
+        .background(
+            GeometryReader { proxy in
+                Color.clear.preference(
+                    key: ModeListContentHeightKey.self,
+                    value: proxy.size.height
+                )
+            }
+        )
+        .onPreferenceChange(ModeListContentHeightKey.self) { modeListContentHeight = $0 }
+        .onDrop(of: [.text], isTargeted: nil) { _ in
+            // Fallback: reset drag state when released over empty list space.
+            if draggingModeID != nil {
+                persistHomeModes()
+                draggingModeID = nil
+            }
+            return true
+        }
+    }
+
+    private func shortcutRow(_ mode: ProcessingMode) -> some View {
+        let isDragging = draggingModeID == mode.id
+        let hasBindings = !mode.hotkeyBindings.isEmpty
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Text(mode.localizedDisplayName)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(TF.settingsText)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.55)
+                    .allowsTightening(true)
+                    .layoutPriority(1)
+
+                Spacer(minLength: 4)
+
+                Button { addBinding(mode) } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(TF.settingsTextTertiary)
+                        .frame(width: 22, height: 22)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help(L("添加快捷键", "Add hotkey"))
+            }
+
+            if hasBindings {
+                HotkeySectionView(
+                    bindings: mode.hotkeyBindings,
+                    onEdit: { editBinding(mode, $0) },
+                    onDelete: { deleteBinding(mode.id, $0) },
+                    onAdd: { addBinding(mode) },
+                    showsHeader: false,
+                    showsAddButton: false
+                )
+            }
+        }
+        .padding(.horizontal, 15)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(hoveredModeID == mode.id ? TF.settingsRowHover : Color.clear)
+        .overlay(alignment: .leading) {
+            // Drag affordance pinned inside the row's left padding, so revealing
+            // it never shifts the name or the capsules below (both stay aligned).
+            dragDots
+                .padding(.leading, 3)
+                .opacity(hoveredModeID == mode.id || isDragging ? 1 : 0)
+                .allowsHitTesting(false)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { openModesEditor(mode.id) }
         .help(L("管理「\(mode.localizedDisplayName)」", "Manage \"\(mode.localizedDisplayName)\""))
+        .opacity(isDragging ? 0.45 : 1)
         .onHover { hovering in
             withAnimation(.easeOut(duration: 0.1)) { hoveredModeID = hovering ? mode.id : nil }
         }
+        .onDrag {
+            draggingModeID = mode.id
+            return NSItemProvider(object: mode.id.uuidString as NSString)
+        } preview: {
+            Text(mode.localizedDisplayName)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(TF.settingsText)
+                .padding(.horizontal, 12)
+                .frame(height: 30)
+                .background(RoundedRectangle(cornerRadius: 7).fill(TF.settingsCard))
+        }
+        .onDrop(of: [.text], delegate: ModeDropDelegate(
+            targetId: mode.id,
+            modes: $modes,
+            draggingId: $draggingModeID,
+            onReorder: { persistHomeModes() }
+        ))
     }
 
-    @ViewBuilder
-    private func hotkeyBadge(_ mode: ProcessingMode) -> some View {
-        let bindings = mode.hotkeyBindings
-        if bindings.isEmpty {
-            Text(L("未设置", "Not set"))
-                .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(TF.settingsTextTertiary)
-        } else if bindings.count == 1 {
-            hotkeyChip(bindings[0])
-        } else {
-            ViewThatFits(in: .horizontal) {
-                ForEach((1...bindings.count).reversed(), id: \.self) { count in
-                    hotkeyRowCandidate(bindings: bindings, visibleCount: count)
+    /// Six-dot drag affordance (2×3), matching the modes settings list handle.
+    private var dragDots: some View {
+        VStack(spacing: 2.5) {
+            ForEach(0..<3, id: \.self) { _ in
+                HStack(spacing: 2.5) {
+                    Circle().frame(width: 2.5, height: 2.5)
+                    Circle().frame(width: 2.5, height: 2.5)
                 }
             }
         }
+        .foregroundStyle(TF.settingsTextTertiary.opacity(0.55))
+        .frame(width: 12)
     }
 
-    private func hotkeyRowCandidate(bindings: [HotkeyBinding], visibleCount: Int) -> some View {
-        let visible = Array(bindings.prefix(visibleCount))
-        let overflow = bindings.count - visibleCount
-
-        return HStack(spacing: 5) {
-            ForEach(visible) { binding in
-                hotkeyChip(binding)
-            }
-            if overflow > 0 {
-                Text("+\(overflow)")
-                    .font(.system(size: 9, weight: .semibold, design: .rounded))
-                    .foregroundStyle(TF.settingsTextSecondary)
-            }
-        }
-        .fixedSize(horizontal: true, vertical: false)
+    // MARK: - Mode state + hotkey editing
+    /// Mirror `appState.availableModes` into local editable state. The Home card
+    /// mutates `modes` for reorder/hotkey edits and persists back through the
+    /// shared helper, which broadcasts `.modesDidChange` to re-sync every source.
+    private func syncModes() {
+        modes = appState.availableModes
     }
 
-    private func hotkeyChip(_ binding: HotkeyBinding) -> some View {
-        let accent = hotkeyStyleColor(binding.style)
-        let key = HotkeyRecorderView.keyDisplayName(keyCode: binding.keyCode, modifiers: binding.modifiers)
-        return HStack(spacing: 4) {
-            Image(systemName: hotkeyStyleIcon(binding.style))
-                .font(.system(size: 9, weight: .bold))
-                .foregroundStyle(accent)
+    @discardableResult
+    private func persistHomeModes() -> Bool {
+        ModeHotkeyEditing.persistModes(modes, appState: appState)
+    }
 
-            Text(key)
-                .font(.system(size: 10, weight: .semibold, design: .rounded))
-                .foregroundStyle(TF.settingsText)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-        }
-        .padding(.horizontal, 7)
-        .frame(height: 24)
-        .background(
-            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .fill(accent.opacity(0.12))
+    private func editBinding(_ mode: ProcessingMode, _ binding: HotkeyBinding) {
+        recordingTarget = RecordingTarget(
+            modeId: mode.id,
+            modeName: mode.localizedDisplayName,
+            editingBindingId: binding.id,
+            initialKeyCode: binding.keyCode,
+            initialModifiers: binding.modifiers,
+            initialStyle: binding.style
         )
-        .overlay(
-            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .stroke(accent.opacity(0.35), lineWidth: 1)
+    }
+
+    private func addBinding(_ mode: ProcessingMode) {
+        recordingTarget = RecordingTarget(
+            modeId: mode.id,
+            modeName: mode.localizedDisplayName,
+            editingBindingId: nil,
+            initialKeyCode: nil,
+            initialModifiers: nil,
+            initialStyle: ProcessingMode.defaultHotkeyStyle
         )
-        .help(hotkeyChipTooltip(binding))
     }
 
-    private func hotkeyChipTooltip(_ binding: HotkeyBinding) -> String {
-        let key = HotkeyRecorderView.keyDisplayName(
-            keyCode: binding.keyCode, modifiers: binding.modifiers)
-        return "\(key) · \(hotkeyStyleLabel(binding.style))"
-    }
-
-    private func hotkeyStyleIcon(_ style: ProcessingMode.HotkeyStyle) -> String {
-        switch style {
-        case .hold:
-            return "hand.tap.fill"
-        case .toggle:
-            return "arrow.triangle.2.circlepath"
-        }
-    }
-
-    private func hotkeyStyleColor(_ style: ProcessingMode.HotkeyStyle) -> Color {
-        switch style {
-        case .hold:
-            return Color(red: 0.20, green: 0.60, blue: 0.86)
-        case .toggle:
-            return Color(red: 0.36, green: 0.56, blue: 0.32)
+    private func deleteBinding(_ modeId: UUID, _ binding: HotkeyBinding) {
+        if let idx = modes.firstIndex(where: { $0.id == modeId }) {
+            modes[idx].hotkeyBindings.removeAll { $0.id == binding.id }
+            persistHomeModes()
         }
     }
 
@@ -680,13 +757,6 @@ struct HomeDashboardView: View {
 
     private func formatNumber(_ value: Int) -> String {
         value.formatted(.number.grouping(.automatic))
-    }
-
-    private func hotkeyStyleLabel(_ style: ProcessingMode.HotkeyStyle) -> String {
-        switch style {
-        case .hold: return L("按住录制", "Hold")
-        case .toggle: return L("按下切换", "Toggle")
-        }
     }
 
     private func heatmapWeeks(weekCount: Int) -> [[HeatmapDay]] {
@@ -838,6 +908,35 @@ struct HomeDashboardView: View {
         let id: String
         let label: String
         let weekIndex: Int
+    }
+}
+
+// MARK: - Home layout measurement
+
+/// Natural height of the left column (usage + activity cards). Drives the
+/// bottom-alignment cap applied to the modes card in the wide layout.
+private struct PrimaryColumnHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+/// Measured height of the modes-card header (title + gear). Subtracted from the
+/// cap to size the scroll region so it ends flush with the left column.
+private struct ShortcutsHeaderHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+/// Natural height of the full mode list. Compared against the available cap to
+/// decide whether the list scrolls or lays out at its intrinsic height.
+private struct ModeListContentHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
     }
 }
 

--- a/Type4Me/UI/Settings/ModeHotkeyEditing.swift
+++ b/Type4Me/UI/Settings/ModeHotkeyEditing.swift
@@ -1,0 +1,191 @@
+import SwiftUI
+
+// MARK: - Recording Sheet Target
+
+/// Identifies which mode (and optionally which existing binding) a hotkey
+/// recording sheet is editing. Shared by the modes settings page and the Home
+/// dashboard so both open the same `HotkeyRecordingSheet`.
+struct RecordingTarget: Identifiable {
+    /// Fresh identity per presentation so re-opening the sheet always re-presents.
+    let id = UUID()
+    let modeId: UUID
+    let modeName: String
+    /// Non-nil when editing an existing binding; nil when adding a new one.
+    let editingBindingId: UUID?
+    let initialKeyCode: Int?
+    let initialModifiers: UInt64?
+    let initialStyle: ProcessingMode.HotkeyStyle
+}
+
+// MARK: - Drop Delegate
+
+/// Reorders modes as a dragged row passes over its neighbors, persisting via
+/// `onReorder`. Shared by the modes settings list and the Home dashboard list.
+struct ModeDropDelegate: DropDelegate {
+    let targetId: UUID
+    @Binding var modes: [ProcessingMode]
+    @Binding var draggingId: UUID?
+    let onReorder: () -> Void
+
+    func performDrop(info: DropInfo) -> Bool {
+        draggingId = nil
+        onReorder()
+        return true
+    }
+
+    func dropEntered(info: DropInfo) {
+        guard let dragId = draggingId,
+              dragId != targetId,
+              let fromIndex = modes.firstIndex(where: { $0.id == dragId }),
+              let toIndex = modes.firstIndex(where: { $0.id == targetId })
+        else { return }
+
+        withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
+            modes.move(
+                fromOffsets: IndexSet(integer: fromIndex),
+                toOffset: toIndex > fromIndex ? toIndex + 1 : toIndex
+            )
+        }
+        // `dropEntered` is the point where the visible order actually changes.
+        // Persist here instead of relying only on `performDrop`: AppKit may end a
+        // drag over row gaps or scroll-view edges without calling the row's
+        // `performDrop`, which previously left a reordered UI backed by stale disk data.
+        onReorder()
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+}
+
+// MARK: - Shared hotkey editing + persistence
+
+/// Pure, view-agnostic building blocks for editing per-mode hotkey bindings and
+/// persisting the mode list. Extracted so the modes settings page and the Home
+/// dashboard share one implementation of conflict detection, binding transfer,
+/// and disk/state persistence instead of each maintaining its own copy.
+enum ModeHotkeyEditing {
+
+    /// Cross-mode conflict: returns the *other* mode that already owns an
+    /// equivalent binding, or nil. Confirming will transfer the binding.
+    static func makeConflictCheck(
+        in modes: [ProcessingMode],
+        target: RecordingTarget
+    ) -> (Int?, UInt64?) -> ProcessingMode? {
+        { code, mods in
+            guard let code else { return nil }
+            return modes.first { other in
+                guard other.id != target.modeId else { return false }
+                return other.hotkeyBindings.contains { b in
+                    ModeBinding.hotkeysAreEquivalent(
+                        keyCode: code, modifiers: mods,
+                        otherKeyCode: b.keyCode, otherModifiers: b.modifiers
+                    )
+                }
+            }
+        }
+    }
+
+    /// Whether an equivalent binding already exists inside the *same* mode,
+    /// excluding the binding currently being edited.
+    static func makeDuplicateCheck(
+        in modes: [ProcessingMode],
+        target: RecordingTarget
+    ) -> (Int?, UInt64?) -> Bool {
+        { code, mods in
+            guard let code,
+                  let mode = modes.first(where: { $0.id == target.modeId })
+            else { return false }
+            return mode.hotkeyBindings.contains { b in
+                b.id != target.editingBindingId
+                    && ModeBinding.hotkeysAreEquivalent(
+                        keyCode: code, modifiers: mods,
+                        otherKeyCode: b.keyCode, otherModifiers: b.modifiers
+                    )
+            }
+        }
+    }
+
+    /// Returns a mode whose binding is a modifier prefix of the recorded combo.
+    /// Prefix conflict is per-binding: exclude only the binding being edited.
+    static func makePrefixConflictCheck(
+        in modes: [ProcessingMode],
+        target: RecordingTarget
+    ) -> (Int?, UInt64?) -> ProcessingMode? {
+        { code, mods in
+            guard let code else { return nil }
+            return modes.first { other in
+                other.hotkeyBindings.contains { b in
+                    !(other.id == target.modeId && b.id == target.editingBindingId)
+                        && ModeBinding.hasModifierPrefixConflict(
+                            keyCode: code, modifiers: mods,
+                            otherKeyCode: b.keyCode, otherModifiers: b.modifiers
+                        )
+                }
+            }
+        }
+    }
+
+    /// Applies a recorded binding to `modes` for the sheet's target: first
+    /// enforcing global uniqueness by removing the single conflicting binding
+    /// from every other mode, then editing the existing binding in place (when
+    /// editing) or appending a new one.
+    static func applyBinding(
+        keyCode code: Int,
+        modifiers mods: UInt64?,
+        style: ProcessingMode.HotkeyStyle,
+        to modes: inout [ProcessingMode],
+        for target: RecordingTarget
+    ) {
+        // Global uniqueness: transfer by removing the single conflicting
+        // binding from any other mode.
+        for i in modes.indices where modes[i].id != target.modeId {
+            modes[i].hotkeyBindings.removeAll { b in
+                ModeBinding.hotkeysAreEquivalent(
+                    keyCode: code, modifiers: mods,
+                    otherKeyCode: b.keyCode, otherModifiers: b.modifiers
+                )
+            }
+        }
+        if let idx = modes.firstIndex(where: { $0.id == target.modeId }) {
+            if let editId = target.editingBindingId,
+               let bIdx = modes[idx].hotkeyBindings.firstIndex(where: { $0.id == editId }) {
+                modes[idx].hotkeyBindings[bIdx].keyCode = code
+                modes[idx].hotkeyBindings[bIdx].modifiers = mods
+                modes[idx].hotkeyBindings[bIdx].style = style
+            } else {
+                modes[idx].hotkeyBindings.append(
+                    HotkeyBinding(keyCode: code, modifiers: mods, style: style)
+                )
+            }
+        }
+    }
+
+    /// Shared persistence for the mode list: writes to disk, mirrors into
+    /// `AppState`, broadcasts `.modesDidChange`, and keeps `currentMode` valid.
+    /// Returns whether the disk write succeeded. `storage` is injectable for
+    /// tests; production callers use the default application-support location.
+    @MainActor
+    @discardableResult
+    static func persistModes(
+        _ modes: [ProcessingMode],
+        appState: AppState,
+        storage: ModeStorage = ModeStorage()
+    ) -> Bool {
+        do {
+            try storage.save(modes)
+        } catch {
+            NSLog("[Type4Me] Failed to persist mode order/settings: %@", error.localizedDescription)
+            DebugFileLogger.log("failed to persist mode order/settings: \(error)")
+            return false
+        }
+        appState.availableModes = modes
+        NotificationCenter.default.post(name: .modesDidChange, object: nil)
+        if let updatedCurrentMode = modes.first(where: { $0.id == appState.currentMode.id }) {
+            appState.currentMode = updatedCurrentMode
+        } else if let fallback = modes.first {
+            appState.currentMode = fallback
+        }
+        return true
+    }
+}

--- a/Type4Me/UI/Settings/ModesSettingsTab.swift
+++ b/Type4Me/UI/Settings/ModesSettingsTab.swift
@@ -21,20 +21,6 @@ private func fieldLabel(_ title: String, _ hint: String? = nil) -> some View {
     }
 }
 
-// MARK: - Recording Sheet Target
-
-private struct RecordingTarget: Identifiable {
-    /// Fresh identity per presentation so re-opening the sheet always re-presents.
-    let id = UUID()
-    let modeId: UUID
-    let modeName: String
-    /// Non-nil when editing an existing binding; nil when adding a new one.
-    let editingBindingId: UUID?
-    let initialKeyCode: Int?
-    let initialModifiers: UInt64?
-    let initialStyle: ProcessingMode.HotkeyStyle
-}
-
 // MARK: - Main View
 
 struct ModesSettingsTab: View {
@@ -44,6 +30,7 @@ struct ModesSettingsTab: View {
 
     @Environment(AppState.self) private var appState
     @Environment(AskAnythingCoordinator.self) private var askAnythingCoordinator
+    @Environment(AppNavigationModel.self) private var navigationModel
     @State private var modes: [ProcessingMode] = ModeStorage().load()
     @State private var selectedModeId: UUID?
     @State private var recordingTarget: RecordingTarget?
@@ -133,9 +120,13 @@ struct ModesSettingsTab: View {
         }
         .onAppear {
             selectedASRProvider = KeychainService.selectedASRProvider
+            consumePendingSelection()
             if selectedModeId == nil {
                 selectedModeId = modes.first?.id
             }
+        }
+        .onChange(of: navigationModel.pendingModeSelectionID) { _, _ in
+            consumePendingSelection()
         }
         .onReceive(NotificationCenter.default.publisher(for: .asrProviderDidChange)) { note in
             if let provider = note.object as? ASRProvider {
@@ -151,67 +142,14 @@ struct ModesSettingsTab: View {
         .sheet(item: $recordingTarget) { target in
             HotkeyRecordingSheet(
                 target: target,
-                checkConflict: { code, mods in
-                    guard let code else { return nil }
-                    // Cross-mode conflict: another mode owns an equivalent binding.
-                    return modes.first { other in
-                        guard other.id != target.modeId else { return false }
-                        return other.hotkeyBindings.contains { b in
-                            ModeBinding.hotkeysAreEquivalent(
-                                keyCode: code, modifiers: mods,
-                                otherKeyCode: b.keyCode, otherModifiers: b.modifiers
-                            )
-                        }
-                    }
-                },
-                checkDuplicateInMode: { code, mods in
-                    guard let code,
-                          let mode = modes.first(where: { $0.id == target.modeId })
-                    else { return false }
-                    return mode.hotkeyBindings.contains { b in
-                        b.id != target.editingBindingId
-                            && ModeBinding.hotkeysAreEquivalent(
-                                keyCode: code, modifiers: mods,
-                                otherKeyCode: b.keyCode, otherModifiers: b.modifiers
-                            )
-                    }
-                },
-                checkPrefixConflict: { code, mods in
-                    guard let code else { return nil }
-                    // Prefix conflict is per-binding: exclude only the binding being edited.
-                    return modes.first { other in
-                        other.hotkeyBindings.contains { b in
-                            !(other.id == target.modeId && b.id == target.editingBindingId)
-                                && ModeBinding.hasModifierPrefixConflict(
-                                    keyCode: code, modifiers: mods,
-                                    otherKeyCode: b.keyCode, otherModifiers: b.modifiers
-                                )
-                        }
-                    }
-                },
+                checkConflict: ModeHotkeyEditing.makeConflictCheck(in: modes, target: target),
+                checkDuplicateInMode: ModeHotkeyEditing.makeDuplicateCheck(in: modes, target: target),
+                checkPrefixConflict: ModeHotkeyEditing.makePrefixConflictCheck(in: modes, target: target),
                 onConfirm: { code, mods, style in
-                    // Global uniqueness: transfer by removing the single conflicting
-                    // binding from any other mode.
-                    for i in modes.indices where modes[i].id != target.modeId {
-                        modes[i].hotkeyBindings.removeAll { b in
-                            ModeBinding.hotkeysAreEquivalent(
-                                keyCode: code, modifiers: mods,
-                                otherKeyCode: b.keyCode, otherModifiers: b.modifiers
-                            )
-                        }
-                    }
-                    if let idx = modes.firstIndex(where: { $0.id == target.modeId }) {
-                        if let editId = target.editingBindingId,
-                           let bIdx = modes[idx].hotkeyBindings.firstIndex(where: { $0.id == editId }) {
-                            modes[idx].hotkeyBindings[bIdx].keyCode = code
-                            modes[idx].hotkeyBindings[bIdx].modifiers = mods
-                            modes[idx].hotkeyBindings[bIdx].style = style
-                        } else {
-                            modes[idx].hotkeyBindings.append(
-                                HotkeyBinding(keyCode: code, modifiers: mods, style: style)
-                            )
-                        }
-                    }
+                    ModeHotkeyEditing.applyBinding(
+                        keyCode: code, modifiers: mods, style: style,
+                        to: &modes, for: target
+                    )
                     persistModes()
                     recordingTarget = nil
                 },
@@ -300,6 +238,20 @@ struct ModesSettingsTab: View {
     }
 
     // MARK: - Selection with unsaved-changes guard
+
+    /// Consume a synchronous mode-selection request handed off by navigation
+    /// (from Home or the menu bar). Selecting here rather than via an async
+    /// notification avoids racing the `onAppear` first-mode fallback below.
+    private func consumePendingSelection() {
+        guard let id = navigationModel.pendingModeSelectionID else { return }
+        navigationModel.pendingModeSelectionID = nil
+        guard modes.contains(where: { $0.id == id }) else { return }
+        if selectedModeId == nil {
+            commitSelection(id)
+        } else {
+            attemptSelect(id)
+        }
+    }
 
     private func attemptSelect(_ id: UUID) {
         guard id != selectedModeId else { return }
@@ -895,21 +847,7 @@ struct ModesSettingsTab: View {
 
     @discardableResult
     private func persistModes() -> Bool {
-        do {
-            try ModeStorage().save(modes)
-        } catch {
-            NSLog("[Type4Me] Failed to persist mode order/settings: %@", error.localizedDescription)
-            DebugFileLogger.log("failed to persist mode order/settings: \(error)")
-            return false
-        }
-        appState.availableModes = modes
-        NotificationCenter.default.post(name: .modesDidChange, object: nil)
-        if let updatedCurrentMode = modes.first(where: { $0.id == appState.currentMode.id }) {
-            appState.currentMode = updatedCurrentMode
-        } else if let fallback = modes.first {
-            appState.currentMode = fallback
-        }
-        return true
+        ModeHotkeyEditing.persistModes(modes, appState: appState)
     }
 
     private func saveDraftBeforeLeaving() -> Bool {
@@ -944,45 +882,6 @@ struct ModesSettingsTab: View {
     }
 }
 
-// MARK: - Drop Delegate
-
-private struct ModeDropDelegate: DropDelegate {
-    let targetId: UUID
-    @Binding var modes: [ProcessingMode]
-    @Binding var draggingId: UUID?
-    let onReorder: () -> Void
-
-    func performDrop(info: DropInfo) -> Bool {
-        draggingId = nil
-        onReorder()
-        return true
-    }
-
-    func dropEntered(info: DropInfo) {
-        guard let dragId = draggingId,
-              dragId != targetId,
-              let fromIndex = modes.firstIndex(where: { $0.id == dragId }),
-              let toIndex = modes.firstIndex(where: { $0.id == targetId })
-        else { return }
-
-        withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
-            modes.move(
-                fromOffsets: IndexSet(integer: fromIndex),
-                toOffset: toIndex > fromIndex ? toIndex + 1 : toIndex
-            )
-        }
-        // `dropEntered` is the point where the visible order actually changes.
-        // Persist here instead of relying only on `performDrop`: AppKit may end a
-        // drag over row gaps or scroll-view edges without calling the row's
-        // `performDrop`, which previously left a reordered UI backed by stale disk data.
-        onReorder()
-    }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        DropProposal(operation: .move)
-    }
-}
-
 // MARK: - Hotkey Section (detail pane)
 
 /// A hotkey list styled to match the other detail-form fields: a small section
@@ -993,45 +892,72 @@ struct HotkeySectionView: View {
     let onEdit: (HotkeyBinding) -> Void
     let onDelete: (HotkeyBinding) -> Void
     let onAdd: () -> Void
+    /// Whether to show the "快捷键" label row (with its hint) above the capsules.
+    /// The Home card hides it to keep each mode row compact.
+    var showsHeader = true
+    /// Whether to render the inline dashed "add hotkey" capsule. The Home card
+    /// hides it and provides its own "+" in the mode-name row instead.
+    var showsAddButton = true
 
     @State private var hoveredId: UUID?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 6) {
-                Text(L("快捷键", "Hotkeys"))
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(TF.settingsTextTertiary)
-                Text(L("键盘、鼠标或耳机按键", "Keyboard, mouse or headphone keys"))
-                    .font(.system(size: 10))
-                    .foregroundStyle(TF.settingsTextTertiary.opacity(0.7))
-                Spacer(minLength: 0)
+            if showsHeader {
+                HStack(spacing: 6) {
+                    Text(L("快捷键", "Hotkeys"))
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(TF.settingsTextTertiary)
+                    Text(L("键盘、鼠标或耳机按键", "Keyboard, mouse or headphone keys"))
+                        .font(.system(size: 10))
+                        .foregroundStyle(TF.settingsTextTertiary.opacity(0.7))
+                    Spacer(minLength: 0)
+                }
             }
 
             FlowLayout(spacing: 6, lineSpacing: 6) {
                 ForEach(bindings) { binding in
                     capsule(binding)
                 }
-                addCapsule
+                if showsAddButton {
+                    addCapsule
+                }
             }
         }
     }
 
     /// A read-style capsule matching the Home dashboard: color-coded style glyph
-    /// + key, tap to edit, hover to reveal a delete affordance.
+    /// + key, tap to edit, hover to reveal a delete affordance. Edit is the base
+    /// button and delete is an overlay button pinned inside the top-trailing
+    /// corner — as an in-bounds sibling on top it reliably receives its own taps,
+    /// and being an overlay it never changes the capsule's layout width (which
+    /// would otherwise push a neighboring "add" button to the next line and make
+    /// hover oscillate near a wrap boundary).
     private func capsule(_ binding: HotkeyBinding) -> some View {
         let accent = styleColor(binding.style)
         let hovered = hoveredId == binding.id
-        return HStack(spacing: 5) {
-            Image(systemName: styleIcon(binding.style))
-                .font(.system(size: 10, weight: .bold))
-                .foregroundStyle(accent)
+        return Button {
+            onEdit(binding)
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: styleIcon(binding.style))
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(accent)
 
-            Text(HotkeyRecorderView.keyDisplayName(
-                keyCode: binding.keyCode, modifiers: binding.modifiers))
-                .font(.system(size: 12, weight: .semibold, design: .rounded))
-                .foregroundStyle(TF.settingsText)
-
+                Text(HotkeyRecorderView.keyDisplayName(
+                    keyCode: binding.keyCode, modifiers: binding.modifiers))
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    .foregroundStyle(TF.settingsText)
+            }
+            .padding(.horizontal, 9)
+            .frame(height: 28)
+            .background(Capsule().fill(accent.opacity(0.12)))
+            .overlay(Capsule().stroke(accent.opacity(0.35), lineWidth: 1))
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .help(L("点击编辑 · \(styleLabel(binding.style))", "Click to edit · \(styleLabel(binding.style))"))
+        .overlay(alignment: .topTrailing) {
             if hovered {
                 Button {
                     onDelete(binding)
@@ -1039,22 +965,16 @@ struct HotkeySectionView: View {
                     Image(systemName: "xmark")
                         .font(.system(size: 8, weight: .bold))
                         .foregroundStyle(TF.settingsAccentRed)
-                        .frame(width: 15, height: 15)
-                        .background(Circle().fill(Color.white.opacity(0.85)))
+                        .frame(width: 16, height: 16)
+                        .background(Circle().fill(Color.white))
+                        .overlay(Circle().stroke(accent.opacity(0.4), lineWidth: 1))
                         .contentShape(Circle())
                 }
                 .buttonStyle(.plain)
-                .help(L("删除", "Delete"))
+                .help(L("删除快捷键", "Delete hotkey"))
+                .transition(.scale.combined(with: .opacity))
             }
         }
-        .padding(.leading, 9)
-        .padding(.trailing, hovered ? 4 : 9)
-        .frame(height: 28)
-        .background(Capsule().fill(accent.opacity(0.12)))
-        .overlay(Capsule().stroke(accent.opacity(0.35), lineWidth: 1))
-        .contentShape(Capsule())
-        .onTapGesture { onEdit(binding) }
-        .help(L("点击编辑 · \(styleLabel(binding.style))", "Click to edit · \(styleLabel(binding.style))"))
         .onHover { h in
             withAnimation(.easeOut(duration: 0.12)) {
                 hoveredId = h ? binding.id : nil
@@ -1161,7 +1081,7 @@ private struct FlowLayout: Layout {
 
 // MARK: - Hotkey Recording Sheet
 
-private struct HotkeyRecordingSheet: View {
+struct HotkeyRecordingSheet: View {
 
     let target: RecordingTarget
     let checkConflict: (Int?, UInt64?) -> ProcessingMode?

--- a/Type4Me/UI/Settings/SettingsView.swift
+++ b/Type4Me/UI/Settings/SettingsView.swift
@@ -90,6 +90,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
 final class AppNavigationModel {
     var selectedTab: SettingsTab = .general
     var pendingAskAnythingSessionID: UUID?
+    var pendingModeSelectionID: UUID?
 }
 
 // MARK: - Settings View
@@ -217,11 +218,10 @@ struct SettingsView: View {
         }
         #endif
         .onReceive(NotificationCenter.default.publisher(for: .navigateToMode)) { note in
-            requestNavigation(to: .modes) {
-                if let modeId = note.object as? UUID {
-                    NotificationCenter.default.post(name: .selectMode, object: modeId)
-                }
+            if let modeId = note.object as? UUID {
+                navigationModel.pendingModeSelectionID = modeId
             }
+            requestNavigation(to: .modes)
         }
         .onReceive(NotificationCenter.default.publisher(for: .navigateToHistory)) { _ in
             requestNavigation(to: .history)
@@ -434,11 +434,10 @@ struct SettingsView: View {
                 HomeDottedWaveBackground()
                 tabPage {
                     HomeDashboardView(isActive: selectedTab == .general) { modeId in
-                        requestNavigation(to: .modes) {
-                            if let modeId {
-                                NotificationCenter.default.post(name: .selectMode, object: modeId)
-                            }
+                        if let modeId {
+                            navigationModel.pendingModeSelectionID = modeId
                         }
+                        requestNavigation(to: .modes)
                     }
                 }
             }

--- a/Type4Me/UI/Settings/SettingsView.swift
+++ b/Type4Me/UI/Settings/SettingsView.swift
@@ -98,7 +98,11 @@ final class AppNavigationModel {
 struct SettingsView: View {
 
     private enum PendingTransition {
-        case navigate(SettingsTab, afterCommit: (() -> Void)? = nil)
+        case navigate(
+            SettingsTab,
+            beforeCommit: (() -> Void)? = nil,
+            afterCommit: (() -> Void)? = nil
+        )
         case closeWindow
     }
 
@@ -187,9 +191,9 @@ struct SettingsView: View {
         }
         .onAppear {
             if VocabularyNavigationCenter.shared.hasPendingSettingsNavigation {
-                requestNavigation(to: .vocabulary) {
+                requestNavigation(to: .vocabulary, afterCommit: {
                     VocabularyNavigationCenter.shared.consumeSettingsNavigation()
-                }
+                })
             }
         }
         #if HAS_CLOUD_SUBSCRIPTION
@@ -218,20 +222,20 @@ struct SettingsView: View {
         }
         #endif
         .onReceive(NotificationCenter.default.publisher(for: .navigateToMode)) { note in
-            if let modeId = note.object as? UUID {
+            let modeId = note.object as? UUID
+            requestNavigation(to: .modes, beforeCommit: {
                 navigationModel.pendingModeSelectionID = modeId
-            }
-            requestNavigation(to: .modes)
+            })
         }
         .onReceive(NotificationCenter.default.publisher(for: .navigateToHistory)) { _ in
             requestNavigation(to: .history)
         }
         .onReceive(NotificationCenter.default.publisher(for: .navigateToVocabulary)) { note in
-            requestNavigation(to: .vocabulary) {
+            requestNavigation(to: .vocabulary, afterCommit: {
                 if note.object is VocabularyNavigationRequest {
                     VocabularyNavigationCenter.shared.consumeSettingsNavigation()
                 }
-            }
+            })
         }
         .onChange(of: debugPanelEnabled) { _, isEnabled in
             if !isEnabled && selectedTab == .debug {
@@ -434,10 +438,9 @@ struct SettingsView: View {
                 HomeDottedWaveBackground()
                 tabPage {
                     HomeDashboardView(isActive: selectedTab == .general) { modeId in
-                        if let modeId {
+                        requestNavigation(to: .modes, beforeCommit: {
                             navigationModel.pendingModeSelectionID = modeId
-                        }
-                        requestNavigation(to: .modes)
+                        })
                     }
                 }
             }
@@ -551,20 +554,31 @@ struct SettingsView: View {
 
     private func requestNavigation(
         to tab: SettingsTab,
+        beforeCommit: (() -> Void)? = nil,
         afterCommit: (() -> Void)? = nil
     ) {
         guard tab != selectedTab else {
+            beforeCommit?()
             afterCommit?()
             return
         }
         guard draftCoordinator.hasUnsavedChanges else {
-            commitNavigation(to: tab, afterCommit: afterCommit)
+            commitNavigation(to: tab, beforeCommit: beforeCommit, afterCommit: afterCommit)
             return
         }
-        pendingTransition = .navigate(tab, afterCommit: afterCommit)
+        pendingTransition = .navigate(
+            tab,
+            beforeCommit: beforeCommit,
+            afterCommit: afterCommit
+        )
     }
 
-    private func commitNavigation(to tab: SettingsTab, afterCommit: (() -> Void)?) {
+    private func commitNavigation(
+        to tab: SettingsTab,
+        beforeCommit: (() -> Void)?,
+        afterCommit: (() -> Void)?
+    ) {
+        beforeCommit?()
         selectedTab = tab
         if tab == .about {
             UpdateChecker.shared.markAsSeen(appState: appState)
@@ -592,8 +606,8 @@ struct SettingsView: View {
         guard let transition = pendingTransition else { return }
         pendingTransition = nil
         switch transition {
-        case .navigate(let tab, let afterCommit):
-            commitNavigation(to: tab, afterCommit: afterCommit)
+        case .navigate(let tab, let beforeCommit, let afterCommit):
+            commitNavigation(to: tab, beforeCommit: beforeCommit, afterCommit: afterCommit)
         case .closeWindow:
             bypassNextCloseGuard = true
             isContentMounted = false

--- a/Type4MeTests/ModeHotkeyEditingTests.swift
+++ b/Type4MeTests/ModeHotkeyEditingTests.swift
@@ -1,0 +1,211 @@
+import XCTest
+@testable import Type4Me
+
+/// Coverage for the shared Home/Settings mode-hotkey editing helpers and the
+/// synchronous navigation hand-off that selects a mode without a notification
+/// race. Layout and view wiring are exercised manually; these tests pin the
+/// pure logic that both surfaces now depend on.
+@MainActor
+final class ModeHotkeyEditingTests: XCTestCase {
+
+    private func target(
+        modeId: UUID,
+        editing: UUID? = nil
+    ) -> RecordingTarget {
+        RecordingTarget(
+            modeId: modeId,
+            modeName: "Mode",
+            editingBindingId: editing,
+            initialKeyCode: nil,
+            initialModifiers: nil,
+            initialStyle: .hold
+        )
+    }
+
+    // MARK: - applyBinding: cross-mode uniqueness transfer
+
+    func testApplyBindingTransfersConflictingBindingFromOtherMode() {
+        let modeA = ProcessingMode(
+            id: UUID(), name: "A", prompt: "{text}", isBuiltin: false,
+            hotkeyBindings: [
+                HotkeyBinding(keyCode: 20, modifiers: 524288, style: .toggle),
+                HotkeyBinding(keyCode: 21, modifiers: 524288, style: .toggle),
+            ]
+        )
+        let modeB = ProcessingMode(id: UUID(), name: "B", prompt: "{text}", isBuiltin: false)
+        var modes = [modeA, modeB]
+
+        ModeHotkeyEditing.applyBinding(
+            keyCode: 20, modifiers: 524288, style: .hold,
+            to: &modes, for: target(modeId: modeB.id)
+        )
+
+        // Only the single conflicting binding leaves A; its sibling stays.
+        XCTAssertEqual(modes[0].hotkeyBindings.map(\.keyCode), [21])
+        // B receives the transferred binding as a fresh append.
+        XCTAssertEqual(modes[1].hotkeyBindings.count, 1)
+        XCTAssertEqual(modes[1].hotkeyBindings.first?.keyCode, 20)
+        XCTAssertEqual(modes[1].hotkeyBindings.first?.style, .hold)
+    }
+
+    // MARK: - applyBinding: append vs edit within a mode
+
+    func testApplyBindingAppendsNewBindingWhenNotEditing() {
+        let mode = ProcessingMode(
+            id: UUID(), name: "A", prompt: "{text}", isBuiltin: false,
+            hotkeyBindings: [HotkeyBinding(keyCode: 20, modifiers: 0, style: .toggle)]
+        )
+        var modes = [mode]
+
+        ModeHotkeyEditing.applyBinding(
+            keyCode: 21, modifiers: 0, style: .hold,
+            to: &modes, for: target(modeId: mode.id)
+        )
+
+        XCTAssertEqual(modes[0].hotkeyBindings.map(\.keyCode), [20, 21])
+    }
+
+    func testApplyBindingEditsExistingBindingInPlace() {
+        let editing = HotkeyBinding(keyCode: 20, modifiers: 0, style: .toggle)
+        let sibling = HotkeyBinding(keyCode: 21, modifiers: 0, style: .hold)
+        let mode = ProcessingMode(
+            id: UUID(), name: "A", prompt: "{text}", isBuiltin: false,
+            hotkeyBindings: [editing, sibling]
+        )
+        var modes = [mode]
+
+        ModeHotkeyEditing.applyBinding(
+            keyCode: 30, modifiers: 262144, style: .hold,
+            to: &modes, for: target(modeId: mode.id, editing: editing.id)
+        )
+
+        // Same identity is retained; only key/modifiers/style change.
+        XCTAssertEqual(modes[0].hotkeyBindings.count, 2)
+        let updated = modes[0].hotkeyBindings.first { $0.id == editing.id }
+        XCTAssertEqual(updated?.keyCode, 30)
+        XCTAssertEqual(updated?.modifiers, 262144)
+        XCTAssertEqual(updated?.style, .hold)
+        // Sibling is untouched.
+        XCTAssertEqual(modes[0].hotkeyBindings.first { $0.id == sibling.id }?.keyCode, 21)
+    }
+
+    // MARK: - Conflict / duplicate checks
+
+    func testConflictCheckFindsOtherModeOwningEquivalentBinding() {
+        let owner = ProcessingMode(
+            id: UUID(), name: "Owner", prompt: "{text}", isBuiltin: false,
+            hotkeyBindings: [HotkeyBinding(keyCode: 20, modifiers: 524288, style: .toggle)]
+        )
+        let editingMode = ProcessingMode(id: UUID(), name: "Editing", prompt: "{text}", isBuiltin: false)
+        let modes = [owner, editingMode]
+
+        let check = ModeHotkeyEditing.makeConflictCheck(
+            in: modes, target: target(modeId: editingMode.id)
+        )
+        XCTAssertEqual(check(20, 524288)?.id, owner.id)
+        XCTAssertNil(check(99, 0))
+    }
+
+    func testDuplicateCheckExcludesBindingBeingEdited() {
+        let editing = HotkeyBinding(keyCode: 20, modifiers: 524288, style: .toggle)
+        let sibling = HotkeyBinding(keyCode: 21, modifiers: 524288, style: .hold)
+        let mode = ProcessingMode(
+            id: UUID(), name: "A", prompt: "{text}", isBuiltin: false,
+            hotkeyBindings: [editing, sibling]
+        )
+        let modes = [mode]
+
+        let check = ModeHotkeyEditing.makeDuplicateCheck(
+            in: modes, target: target(modeId: mode.id, editing: editing.id)
+        )
+        // Recording the sibling's combo is a duplicate.
+        XCTAssertTrue(check(21, 524288))
+        // Recording the edited binding's own combo is not a duplicate of itself.
+        XCTAssertFalse(check(20, 524288))
+    }
+
+    // MARK: - persistModes
+
+    func testPersistModesWritesReorderedListAndSyncsAppState() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("type4me-persist-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let storage = ModeStorage(fileURL: url)
+        let suite = "ModeHotkeyEditingTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        try storage.save(ProcessingMode.defaults)
+        let appState = AppState(modeStorage: storage, userDefaults: defaults)
+
+        let reordered = Array(appState.availableModes.reversed())
+        let ok = ModeHotkeyEditing.persistModes(reordered, appState: appState, storage: storage)
+
+        XCTAssertTrue(ok)
+        XCTAssertEqual(appState.availableModes.map(\.id), reordered.map(\.id))
+        // The persisted file reflects the new order across a reload.
+        XCTAssertEqual(storage.load().map(\.id), reordered.map(\.id))
+    }
+
+    func testPersistModesFallsBackCurrentModeWhenRemoved() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("type4me-persist-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let storage = ModeStorage(fileURL: url)
+        let suite = "ModeHotkeyEditingTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let custom = ProcessingMode(id: UUID(), name: "Custom", prompt: "{text}", isBuiltin: false)
+        try storage.save([ProcessingMode.direct, custom])
+        let appState = AppState(modeStorage: storage, userDefaults: defaults)
+        appState.currentMode = custom
+
+        // Persist a list without the custom mode; current mode must fall back.
+        ModeHotkeyEditing.persistModes([ProcessingMode.direct], appState: appState, storage: storage)
+
+        XCTAssertEqual(appState.currentMode.id, ProcessingMode.directId)
+    }
+
+    // MARK: - AppNavigationModel pending selection
+
+    func testPendingModeSelectionIDCanBeConsumedOnce() {
+        let model = AppNavigationModel()
+        let id = UUID()
+        model.pendingModeSelectionID = id
+
+        // Simulate the consumer: read, then clear.
+        let consumed = model.pendingModeSelectionID
+        model.pendingModeSelectionID = nil
+
+        XCTAssertEqual(consumed, id)
+        XCTAssertNil(model.pendingModeSelectionID)
+    }
+
+    // MARK: - Home mode-row localization
+
+    /// The Home card renders each row through `mode.localizedDisplayName`, which
+    /// reads the live `tf_language`. System modes must follow the setting while
+    /// custom names stay verbatim.
+    func testHomeRowNameFollowsLiveLanguageForSystemModesOnly() {
+        let previous = UserDefaults.standard.string(forKey: "tf_language")
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: "tf_language")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "tf_language")
+            }
+        }
+
+        let system = ProcessingMode.direct
+        let custom = ProcessingMode(id: UUID(), name: "会议记录", prompt: "{text}", isBuiltin: false)
+
+        UserDefaults.standard.set("zh", forKey: "tf_language")
+        XCTAssertEqual(system.localizedDisplayName, "快速模式")
+        XCTAssertEqual(custom.localizedDisplayName, "会议记录")
+
+        UserDefaults.standard.set("en", forKey: "tf_language")
+        XCTAssertEqual(system.localizedDisplayName, "Quick Mode")
+        XCTAssertEqual(custom.localizedDisplayName, "会议记录")
+    }
+}


### PR DESCRIPTION
Bring the modes settings capabilities to the Home "My Modes" card and fix a mode-selection race, reusing the settings implementations.

- Fix mode selection: replace the async .selectMode notification race with a synchronous AppNavigationModel.pendingModeSelectionID handed off before navigation, consumed once in ModesSettingsTab (falls back to the first mode only when no pending id), mirroring the Ask Anything pending-session pattern.
- Extract shared ModeHotkeyEditing unit (internal RecordingTarget and ModeDropDelegate, conflict/duplicate/prefix checks, applyBinding transfer, and persistModes) used by both the settings tab and Home.
- Rebuild the Home shortcuts card: mirror availableModes into editable state, render all modes, per-mode inline hotkey add/edit/delete via HotkeySectionView, drag-to-reorder, and min(content, left-column) capped scrolling.
- Home row polish: right-aligned "+" add button in the name row, delete "x" as an overlay (no width change, no hover oscillation), whole-row tap navigates to the mode, and a hover-revealed left drag handle that never shifts alignment.
- Add ModeHotkeyEditingTests covering applyBinding, conflict/duplicate checks, persistModes reorder/fallback, pending-selection consume, and live-language rows.

 Verification: swift build -c release and full swift test pass
  (922 tests, 2 skipped, 0 failures).
  
<img width="1447" height="1087" alt="image" src="https://github.com/user-attachments/assets/ed1b714f-fbaf-41ac-92dc-546e0f0e5428" />
