### PR TITLE
feat(ui): add Light recording theme, native frosted glass, and UI enhancements

### DIFF
--- a/Type4Me/Injection/ClipboardOutputPolicy.swift
+++ b/Type4Me/Injection/ClipboardOutputPolicy.swift
@@ -59,6 +59,53 @@ enum ClipboardOutputPolicy: String, CaseIterable, Identifiable {
         self == .alwaysCopy || self == .cancelProcessed
     }
 
+    /// User-facing cancellation retention modes for granular Settings UI.
+    enum CancellationRetentionMode: String, CaseIterable, Identifiable {
+        case processed
+        case raw
+        case none
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .processed: return L("AI 润色", "AI Processed")
+            case .raw: return L("原始文本", "Raw Text")
+            case .none: return L("不留存", "None")
+            }
+        }
+    }
+
+    /// Derived cancellation retention mode from the composite policy.
+    var cancellationMode: CancellationRetentionMode {
+        switch self {
+        case .alwaysCopy, .cancelProcessed:
+            return .processed
+        case .cancelRawTranscript:
+            return .raw
+        case .neverCopy:
+            return .none
+        }
+    }
+
+    /// Map individual normal and cancellation preferences back to the canonical storage policy.
+    static func policy(
+        retainsNormal: Bool,
+        cancellationMode: CancellationRetentionMode
+    ) -> ClipboardOutputPolicy {
+        if retainsNormal {
+            return .alwaysCopy
+        }
+        switch cancellationMode {
+        case .processed:
+            return .cancelProcessed
+        case .raw:
+            return .cancelRawTranscript
+        case .none:
+            return .neverCopy
+        }
+    }
+
     /// Resolve clipboard retention from the frozen completion intent.
     func retainsResult(forCancellation isCancelled: Bool) -> Bool {
         isCancelled ? retainsCancelledResult : retainsNormalResult

--- a/Type4Me/Services/AppBuildInfo.swift
+++ b/Type4Me/Services/AppBuildInfo.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// The app's bundle version data, with display-safe fallbacks for development
+/// and test hosts that do not provide Type4Me's Info.plist values.
+struct AppBuildInfo: Equatable, Sendable {
+    let version: String
+    let buildNumber: String
+
+    init(version: String?, buildNumber: String?) {
+        self.version = Self.displayValue(version)
+        self.buildNumber = Self.displayValue(buildNumber)
+    }
+
+    init(infoDictionary: [String: Any]?) {
+        self.init(
+            version: infoDictionary?["CFBundleShortVersionString"] as? String,
+            buildNumber: infoDictionary?["CFBundleVersion"] as? String
+        )
+    }
+
+    static var current: Self {
+        Self(infoDictionary: Bundle.main.infoDictionary)
+    }
+
+    /// Compact form used next to the sidebar Settings navigation item.
+    var compactLabel: String {
+        "v\(version)(\(buildNumber))"
+    }
+
+    var debugLabel: String {
+        "\(version) (\(buildNumber))"
+    }
+
+    private static func displayValue(_ value: String?) -> String {
+        guard let value, !value.isEmpty else { return "—" }
+        return value
+    }
+}

--- a/Type4Me/Services/VocabularyCommands.swift
+++ b/Type4Me/Services/VocabularyCommands.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum VocabularySection: String, Sendable {
+enum VocabularySection: String, Sendable, Hashable {
     case hotwords
     case snippets
 }

--- a/Type4Me/UI/AppState.swift
+++ b/Type4Me/UI/AppState.swift
@@ -36,7 +36,7 @@ enum RecordingIndicatorStyle: String, CaseIterable {
         case .regular:
             return L("常规", "Regular")
         case .compact:
-            return L("紧凑型", "Compact")
+            return L("紧凑", "Compact")
         }
     }
 

--- a/Type4Me/UI/DesignSystem.swift
+++ b/Type4Me/UI/DesignSystem.swift
@@ -49,6 +49,8 @@ enum TF {
     /// Recording indicator palette from the floating-bar design specification.
     static let floatingBackground = Color(red: 17 / 255, green: 18 / 255, blue: 20 / 255) // #111214
     static let floatingBorder = Color(red: 38 / 255, green: 39 / 255, blue: 41 / 255) // #262729
+    static let floatingBackgroundLight = Color(red: 246 / 255, green: 246 / 255, blue: 248 / 255)
+    static let floatingBorderLight = Color(red: 218 / 255, green: 218 / 255, blue: 222 / 255)
     /// A translucent highlight that takes on the material beneath it instead of reading as a flat white rule.
     static let recordingGlassRim = LinearGradient(
         colors: [
@@ -59,9 +61,21 @@ enum TF {
         startPoint: .top,
         endPoint: .bottom
     )
+    /// A translucent highlight for the light frosted glass theme.
+    static let recordingLightGlassRim = LinearGradient(
+        colors: [
+            .white.opacity(0.95),
+            .white.opacity(0.60),
+            Color.black.opacity(0.12),
+        ],
+        startPoint: .top,
+        endPoint: .bottom
+    )
     static let floatingControl = Color(red: 51 / 255, green: 51 / 255, blue: 51 / 255)
     static let floatingControlLight = Color(red: 251 / 255, green: 251 / 255, blue: 251 / 255)
     static let floatingText = Color.white
+    static let floatingTextLight = Color(red: 28 / 255, green: 28 / 255, blue: 30 / 255)
+    static let floatingTextSecondaryLight = Color(red: 90 / 255, green: 90 / 255, blue: 95 / 255)
 
     // MARK: Settings Palette
 

--- a/Type4Me/UI/DesignSystem.swift
+++ b/Type4Me/UI/DesignSystem.swift
@@ -49,6 +49,16 @@ enum TF {
     /// Recording indicator palette from the floating-bar design specification.
     static let floatingBackground = Color(red: 17 / 255, green: 18 / 255, blue: 20 / 255) // #111214
     static let floatingBorder = Color(red: 38 / 255, green: 39 / 255, blue: 41 / 255) // #262729
+    /// A translucent highlight that takes on the material beneath it instead of reading as a flat white rule.
+    static let recordingGlassRim = LinearGradient(
+        colors: [
+            .white.opacity(0.80),
+            .white.opacity(0.48),
+            .white.opacity(0.30),
+        ],
+        startPoint: .top,
+        endPoint: .bottom
+    )
     static let floatingControl = Color(red: 51 / 255, green: 51 / 255, blue: 51 / 255)
     static let floatingControlLight = Color(red: 251 / 255, green: 251 / 255, blue: 251 / 255)
     static let floatingText = Color.white

--- a/Type4Me/UI/FloatingBar/CompactAudioIndicator.swift
+++ b/Type4Me/UI/FloatingBar/CompactAudioIndicator.swift
@@ -66,6 +66,7 @@ private final class CompactAudioHistoryModel {
 struct CompactAudioIndicator: View {
 
     let meter: AudioLevelMeter
+    var theme: RecordingTheme = .dark
 
     @State private var history = CompactAudioHistoryModel()
 
@@ -84,6 +85,9 @@ struct CompactAudioIndicator: View {
                 let rightEdge = size.width - 1.0 - fraction * pitch
                 let totalColumns = Int(ceil((size.width + pitch) / pitch)) + 1
 
+                let activeColor = theme == .light ? TF.floatingTextLight : TF.compactIndicatorActive
+                let inactiveColor = theme == .light ? Color.black.opacity(0.18) : TF.compactIndicatorInactive
+
                 for i in 0..<totalColumns {
                     let x = rightEdge - CGFloat(i) * pitch
                     guard x >= -barWidth && x <= size.width else { continue }
@@ -94,11 +98,11 @@ struct CompactAudioIndicator: View {
                     if i < history.samples.count {
                         let sample = history.samples[i]
                         barHeight = sample.height
-                        barColor = sample.isActive ? TF.compactIndicatorActive : TF.compactIndicatorInactive
+                        barColor = sample.isActive ? activeColor : inactiveColor
                     } else {
                         // Unreached / idle track dots
                         barHeight = minHeight
-                        barColor = TF.compactIndicatorInactive
+                        barColor = inactiveColor
                     }
 
                     let y = (size.height - barHeight) / 2

--- a/Type4Me/UI/FloatingBar/CompactLiveTranscriptRow.swift
+++ b/Type4Me/UI/FloatingBar/CompactLiveTranscriptRow.swift
@@ -16,6 +16,7 @@ func compactTranscriptOffset(textWidth: CGFloat, viewportWidth: CGFloat) -> CGFl
 struct CompactLiveTranscriptRow: View {
 
     let text: String
+    var theme: RecordingTheme = .dark
 
     private static let measurementFont = NSFont.systemFont(
         ofSize: TF.compactTranscriptFontSize,
@@ -43,7 +44,7 @@ struct CompactLiveTranscriptRow: View {
         HStack(spacing: 0) {
             Text(text)
                 .font(.system(size: TF.compactTranscriptFontSize, weight: .medium))
-                .foregroundStyle(TF.floatingText)
+                .foregroundStyle(theme == .light ? TF.floatingTextLight : TF.floatingText)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
                 .offset(x: offset)

--- a/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
@@ -65,7 +65,13 @@ final class FloatingBarPanel: NSPanel {
         ignoresMouseEvents = true
         acceptsMouseMovedEvents = true
         animationBehavior = .utilityWindow
-        appearance = NSAppearance(named: .darkAqua)
+        updateAppearance()
+    }
+
+    func updateAppearance() {
+        let themeRaw = UserDefaults.standard.string(forKey: RecordingTheme.storageKey) ?? RecordingTheme.defaultValue.rawValue
+        let theme = RecordingTheme(rawValue: themeRaw) ?? .dark
+        appearance = theme == .light ? NSAppearance(named: .aqua) : NSAppearance(named: .darkAqua)
     }
 
     override var canBecomeKey: Bool { false }
@@ -161,6 +167,7 @@ final class FloatingBarController {
 
     func show() {
         panelGeneration &+= 1
+        panel.updateAppearance()
 
         if anchorDisplayID == nil || state.barPhase == .preparing {
             anchorDisplayID = FloatingBarPanel.screenUnderMouse()

--- a/Type4Me/UI/FloatingBar/FloatingBarView.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarView.swift
@@ -489,7 +489,6 @@ struct FloatingBarView<S: FloatingBarState>: View {
             .overlay {
                 capsuleBorder
             }
-            .shadow(color: Color.black.opacity(0.12), radius: 8)
             // Critically damped (dampingFraction 1.0) so the width never
             // overshoots and settles back leftward between characters. An
             // underdamped spring makes the right edge/cancel button wiggle
@@ -987,9 +986,8 @@ struct FloatingBarView<S: FloatingBarState>: View {
     // MARK: - Background & Border
 
     private var capsuleBackground: some View {
-        ZStack {
-            TF.floatingBackground
-
+        RecordingGlassSurface(cornerRadius: barCornerRadius, tintOpacity: 0.32)
+        .overlay {
             if state.barPhase == .error {
                 LinearGradient(
                     colors: [TF.settingsAccentRed.opacity(0.16), .clear],
@@ -1000,26 +998,26 @@ struct FloatingBarView<S: FloatingBarState>: View {
         }
     }
 
+    @ViewBuilder
     private var capsuleBorder: some View {
-        barShape
-            .strokeBorder(borderColor, lineWidth: 0.5)
-    }
-
-    private var borderColor: Color {
         switch state.barPhase {
         case .preparing, .recording, .processing, .recovering:
-            TF.floatingBorder
+            barShape.strokeBorder(TF.recordingGlassRim, lineWidth: 0.8)
         case .done:
-            switch state.feedbackKind {
-            case .macActionUnsure:
-                TF.amber.opacity(0.40)
-            case .macActionSuccess, .macActionFailure, .standard:
-                TF.success.opacity(0.40)
-            }
+            barShape.strokeBorder(feedbackBorderColor, lineWidth: 0.5)
         case .error:
-            TF.settingsAccentRed.opacity(0.45)
+            barShape.strokeBorder(TF.settingsAccentRed.opacity(0.45), lineWidth: 0.5)
         case .hidden:
-            .clear
+            EmptyView()
+        }
+    }
+
+    private var feedbackBorderColor: Color {
+        switch state.feedbackKind {
+        case .macActionUnsure:
+            TF.amber.opacity(0.40)
+        case .macActionSuccess, .macActionFailure, .standard:
+            TF.success.opacity(0.40)
         }
     }
 
@@ -1236,14 +1234,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
         .lineLimit(1)
         .padding(.horizontal, 12)
         .padding(.vertical, 9)
-        .background(
-            RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous)
-                .fill(TF.floatingBackground)
-                .overlay {
-                    RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous)
-                        .strokeBorder(TF.floatingBorder, lineWidth: 0.5)
-                }
-        )
+        .background(FrostedGlassBubbleBackground())
         .frame(maxWidth: TF.recordingTooltipMaxWidth)
         .fixedSize(horizontal: true, vertical: false)
         .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 2)
@@ -1258,14 +1249,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 9)
             .frame(maxWidth: TF.barWidth + TF.recordingTooltipOverhang * 2)
-            .background(
-                RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous)
-                    .fill(TF.floatingBackground)
-                    .overlay {
-                        RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous)
-                            .strokeBorder(TF.floatingBorder, lineWidth: 0.5)
-                    }
-            )
+            .background(FrostedGlassBubbleBackground())
             .fixedSize(horizontal: true, vertical: false)
             .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 2)
     }
@@ -1332,6 +1316,46 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 }
 
+/// A dark HUD material that samples behind the transparent panel.
+private struct RecordingGlassSurface: View {
+    let cornerRadius: CGFloat
+    let tintOpacity: Double
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    private var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+    }
+
+    var body: some View {
+        if reduceTransparency {
+            TF.floatingBackground
+        } else {
+            ZStack {
+                VisualEffectBlur(cornerRadius: cornerRadius)
+                    .allowsHitTesting(false)
+                Color.black.opacity(tintOpacity)
+            }
+            .clipShape(shape)
+        }
+    }
+}
+
+private struct FrostedGlassBubbleBackground: View {
+    let cornerRadius: CGFloat = TF.transcriptPopupCorner
+
+    private var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+    }
+
+    var body: some View {
+        RecordingGlassSurface(cornerRadius: cornerRadius, tintOpacity: 0.40)
+            .overlay {
+                shape.strokeBorder(TF.floatingBorder, lineWidth: 0.5)
+            }
+    }
+}
+
 private struct TranscriptPopup: View {
     let text: String
     let height: CGFloat
@@ -1352,14 +1376,7 @@ private struct TranscriptPopup: View {
             }
             .scrollIndicators(.hidden)
             .frame(width: TF.transcriptPopupWidth, height: height)
-            .background(
-                RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous)
-                    .fill(TF.floatingBackground)
-                    .overlay {
-                        RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous)
-                            .strokeBorder(TF.floatingBorder, lineWidth: 0.5)
-                    }
-            )
+            .background(FrostedGlassBubbleBackground())
             .overlay {
                 FloatingBarHoverTracker(onHoverChanged: onHoverChanged)
             }

--- a/Type4Me/UI/FloatingBar/FloatingBarView.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarView.swift
@@ -9,6 +9,42 @@ private enum FloatingBarTopOverlay: Equatable {
     case mode
 }
 
+// MARK: - Thinking States Text Swap Transition
+
+private struct TextSwapTransitionModifier: ViewModifier {
+    let y: CGFloat
+    let blur: CGFloat
+    let opacity: Double
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func body(content: Content) -> some View {
+        content
+            .offset(y: reduceMotion ? 0 : y)
+            .blur(radius: reduceMotion ? 0 : blur)
+            .opacity(opacity)
+    }
+}
+
+extension AnyTransition {
+    /// Transitions.dev Thinking States text swap animation:
+    /// - 150ms ease-in-out duration
+    /// - Outgoing text translates up by 8pt with 2pt blur and fades to 0
+    /// - Incoming text enters from 8pt below with 2pt blur and fades to 1
+    static var textSwap: AnyTransition {
+        .asymmetric(
+            insertion: .modifier(
+                active: TextSwapTransitionModifier(y: 8, blur: 2, opacity: 0),
+                identity: TextSwapTransitionModifier(y: 0, blur: 0, opacity: 1)
+            ),
+            removal: .modifier(
+                active: TextSwapTransitionModifier(y: -8, blur: 2, opacity: 0),
+                identity: TextSwapTransitionModifier(y: 0, blur: 0, opacity: 1)
+            )
+        )
+    }
+}
+
 func recordingActionHorizontalOffset(
     _ action: RecordingControlAction,
     capsuleWidth: CGFloat,
@@ -486,20 +522,28 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
     @ViewBuilder
     private var compactPhaseContent: some View {
-        switch state.barPhase {
-        case .preparing, .recording:
-            compactRecordingContent
-        case .processing:
-            compactStatusContent(phase: .processing, text: state.effectiveProcessingLabel)
-        case .recovering:
-            compactStatusContent(phase: .recovering, text: state.effectiveProcessingLabel)
-        case .done:
-            compactDoneContent
-        case .error:
-            compactStatusContent(phase: .error, text: state.feedbackMessage)
-        case .hidden:
-            EmptyView()
+        ZStack {
+            switch state.barPhase {
+            case .preparing, .recording:
+                compactRecordingContent
+                    .transition(.opacity.animation(.easeInOut(duration: 0.18)))
+            case .processing:
+                compactStatusContent(phase: .processing, text: state.effectiveProcessingLabel)
+                    .transition(.textSwap.animation(.easeInOut(duration: 0.15)))
+            case .recovering:
+                compactStatusContent(phase: .recovering, text: state.effectiveProcessingLabel)
+                    .transition(.opacity.animation(.easeInOut(duration: 0.18)))
+            case .done:
+                compactDoneContent
+                    .transition(.textSwap.animation(.easeInOut(duration: 0.15)))
+            case .error:
+                compactStatusContent(phase: .error, text: state.feedbackMessage)
+                    .transition(.opacity.animation(.easeInOut(duration: 0.18)))
+            case .hidden:
+                EmptyView()
+            }
         }
+        .animation(.easeInOut(duration: 0.15), value: state.barPhase)
     }
 
     @ViewBuilder
@@ -511,13 +555,13 @@ struct FloatingBarView<S: FloatingBarState>: View {
                     .transition(.opacity.animation(.easeInOut(duration: 0.18)))
             case .processing:
                 processingContent
-                    .transition(.opacity.animation(.easeInOut(duration: 0.18)))
+                    .transition(.textSwap.animation(.easeInOut(duration: 0.15)))
             case .recovering:
                 recoveringContent
                     .transition(.opacity.animation(.easeInOut(duration: 0.18)))
             case .done:
                 doneContent
-                    .transition(.opacity.animation(.easeInOut(duration: 0.18)))
+                    .transition(.textSwap.animation(.easeInOut(duration: 0.15)))
             case .error:
                 errorContent
                     .transition(.opacity.animation(.easeInOut(duration: 0.18)))
@@ -525,7 +569,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
                 EmptyView()
             }
         }
-        .animation(.easeInOut(duration: 0.18), value: state.barPhase)
+        .animation(.easeInOut(duration: 0.15), value: state.barPhase)
     }
 
     private var compactRecordingControls: some View {

--- a/Type4Me/UI/FloatingBar/FloatingBarView.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarView.swift
@@ -91,6 +91,7 @@ protocol FloatingBarState: AnyObject, Observable {
 }
 
 struct FloatingBarPresentation: Equatable {
+    var theme: RecordingTheme = .dark
     var indicatorStyle: RecordingIndicatorStyle = .regular
     var visualStyle: RecordingVisualStyle = .siri
     var showsLiveTranscript: Bool = true
@@ -106,7 +107,7 @@ struct FloatingBarPresentation: Equatable {
     }
 }
 
-/// Dark-themed floating transcription bar.
+/// Dark or Light themed floating transcription bar.
 ///
 /// Design: state changes are immediate; recording starts directly in the full
 /// listening UI even while the audio service is still preparing internally.
@@ -143,6 +144,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
     @State private var showsModeHint = false
     @State private var modeHintTask: Task<Void, Never>?
     @State private var recordingActionLocked = false
+    @AppStorage(RecordingTheme.storageKey) private var theme = RecordingTheme.defaultValue
     @AppStorage(RecordingIndicatorStyle.storageKey) private var indicatorStyle = RecordingIndicatorStyle.defaultValue
     @AppStorage(LiveTranscriptDisplayPreference.storageKey) private var showLiveTranscript = LiveTranscriptDisplayPreference.defaultValue
     @AppStorage("tf_hoverTranscriptPreview") private var hoverTranscriptPreview = true
@@ -158,6 +160,12 @@ struct FloatingBarView<S: FloatingBarState>: View {
     @AppStorage("tf_language") private var language = AppLanguage.systemDefault
 
     // MARK: - Presentation Resolution
+
+    private var effectiveTheme: RecordingTheme {
+        presentationOverride?.theme
+            ?? RecordingTheme(rawValue: theme.rawValue)
+            ?? .dark
+    }
 
     private var effectiveIndicatorStyle: RecordingIndicatorStyle {
         presentationOverride?.indicatorStyle
@@ -576,7 +584,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
             compactRecordingButton(.finish)
                 .frame(width: 32, height: TF.compactIndicatorHeight)
 
-            CompactAudioIndicator(meter: state.audioLevel)
+            CompactAudioIndicator(meter: state.audioLevel, theme: effectiveTheme)
                 .frame(maxWidth: .infinity, maxHeight: TF.compactIndicatorHeight)
 
             if effectiveShowsCancelButton {
@@ -593,7 +601,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
     private var compactRecordingContent: some View {
         if effectiveShowsLiveTranscript {
             VStack(spacing: 0) {
-                CompactLiveTranscriptRow(text: state.transcriptionText)
+                CompactLiveTranscriptRow(text: state.transcriptionText, theme: effectiveTheme)
                 compactRecordingControls
             }
             .frame(width: TF.compactIndicatorWidth, height: TF.compactTranscriptExpandedHeight)
@@ -609,7 +617,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
             Text(text)
                 .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.white)
+                .foregroundStyle(effectiveTheme == .light ? TF.floatingTextLight : .white)
                 .lineLimit(1)
                 .truncationMode(.tail)
         }
@@ -625,7 +633,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
             Text(state.feedbackMessage)
                 .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.white)
+                .foregroundStyle(effectiveTheme == .light ? TF.floatingTextLight : .white)
                 .lineLimit(1)
                 .truncationMode(.tail)
 
@@ -639,10 +647,10 @@ struct FloatingBarView<S: FloatingBarState>: View {
                         Text(L("撤销", "Undo"))
                             .font(.system(size: 10, weight: .medium))
                     }
-                    .foregroundStyle(TF.floatingBackground)
+                    .foregroundStyle(effectiveTheme == .light ? Color.white : TF.floatingBackground)
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
-                    .background(TF.compactIndicatorActive)
+                    .background(effectiveTheme == .light ? TF.floatingTextLight : TF.compactIndicatorActive)
                     .clipShape(Capsule())
                 }
                 .buttonStyle(.plain)
@@ -694,9 +702,11 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 
     private func compactRecordingButton(_ action: RecordingControlAction) -> some View {
-        ZStack {
+        let controlFill = effectiveTheme == .light ? TF.floatingTextLight : TF.compactIndicatorActive
+        let glyphFill = effectiveTheme == .light ? TF.floatingBackgroundLight : TF.floatingBackground
+        return ZStack {
             Circle()
-                .fill(TF.compactIndicatorActive)
+                .fill(controlFill)
                 .frame(
                     width: TF.compactIndicatorControlVisualSize,
                     height: TF.compactIndicatorControlVisualSize
@@ -704,12 +714,12 @@ struct FloatingBarView<S: FloatingBarState>: View {
                 .overlay {
                     if action == .finish {
                         RoundedRectangle(cornerRadius: 1, style: .continuous)
-                            .fill(TF.floatingBackground)
+                            .fill(glyphFill)
                             .frame(width: 6, height: 6)
                     } else {
                         Image(systemName: "xmark")
                             .font(.system(size: 8, weight: .heavy))
-                            .foregroundStyle(TF.floatingBackground)
+                            .foregroundStyle(glyphFill)
                     }
                 }
         }
@@ -795,11 +805,12 @@ struct FloatingBarView<S: FloatingBarState>: View {
         if effectiveShowsLiveTranscript && !state.segments.isEmpty {
             Text(state.transcriptionText)
                 .font(.system(size: 14, weight: .medium))
-                .foregroundStyle(TF.floatingText)
+                .foregroundStyle(effectiveTheme == .light ? TF.floatingTextLight : TF.floatingText)
         } else {
             LiquidGlassText(
                 text: recordingDisplayText,
                 style: recordingVisualStyle,
+                theme: effectiveTheme,
                 audioEnergy: state.audioLevel.current
             )
         }
@@ -825,6 +836,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
                 .id("recording_orb_button")
             } else {
                 LiquidGlassCancelButton(
+                    theme: effectiveTheme,
                     isHovered: hoveredAction == .cancel,
                     isPressed: pressedAction == .cancel || recordingActionLocked,
                     dragOffset: pressedAction == .cancel ? cancelDragOffset : .zero
@@ -881,6 +893,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
         LiquidGlassText(
             text: state.effectiveProcessingLabel,
             style: recordingVisualStyle,
+            theme: effectiveTheme,
             audioEnergy: 0.25
         )
         .frame(maxWidth: .infinity)
@@ -896,6 +909,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
             LiquidGlassText(
                 text: state.effectiveProcessingLabel,
                 style: recordingVisualStyle,
+                theme: effectiveTheme,
                 audioEnergy: 0.25
             )
             .lineLimit(1)
@@ -910,7 +924,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
                 HStack(spacing: 8) {
                     Text(state.feedbackMessage)
                         .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(.white)
+                        .foregroundStyle(effectiveTheme == .light ? TF.floatingTextLight : .white)
                         .lineLimit(1)
                     Button(action: {
                         state.performReviseUndo()
@@ -921,10 +935,10 @@ struct FloatingBarView<S: FloatingBarState>: View {
                             Text(L("撤销", "Undo"))
                                 .font(.system(size: 12, weight: .medium))
                         }
-                        .foregroundStyle(TF.floatingBackground)
+                        .foregroundStyle(effectiveTheme == .light ? Color.white : TF.floatingBackground)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
-                        .background(TF.floatingControlLight)
+                        .background(effectiveTheme == .light ? TF.floatingTextLight : TF.floatingControlLight)
                         .clipShape(Capsule())
                     }
                     .buttonStyle(.plain)
@@ -937,14 +951,14 @@ struct FloatingBarView<S: FloatingBarState>: View {
                         .foregroundStyle(icon.color)
                     Text(state.feedbackMessage)
                         .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(.white)
+                        .foregroundStyle(effectiveTheme == .light ? TF.floatingTextLight : .white)
                         .lineLimit(1)
                 }
                 .padding(.horizontal, 14)
             } else {
                 Text(state.feedbackMessage)
                     .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(effectiveTheme == .light ? TF.floatingTextLight : .white)
                     .frame(maxWidth: .infinity)
             }
         }
@@ -962,7 +976,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
             Text(state.feedbackMessage)
                 .font(.system(size: 14, weight: .medium))
-                .foregroundStyle(.white)
+                .foregroundStyle(effectiveTheme == .light ? TF.floatingTextLight : .white)
                 .lineLimit(1)
         }
         .padding(.horizontal, 14)
@@ -986,7 +1000,11 @@ struct FloatingBarView<S: FloatingBarState>: View {
     // MARK: - Background & Border
 
     private var capsuleBackground: some View {
-        RecordingGlassSurface(cornerRadius: barCornerRadius, tintOpacity: 0.32)
+        RecordingGlassSurface(
+            cornerRadius: barCornerRadius,
+            theme: effectiveTheme,
+            tintOpacity: effectiveTheme == .light ? 0.68 : 0.32
+        )
         .overlay {
             if state.barPhase == .error {
                 LinearGradient(
@@ -1002,7 +1020,10 @@ struct FloatingBarView<S: FloatingBarState>: View {
     private var capsuleBorder: some View {
         switch state.barPhase {
         case .preparing, .recording, .processing, .recovering:
-            barShape.strokeBorder(TF.recordingGlassRim, lineWidth: 0.8)
+            barShape.strokeBorder(
+                effectiveTheme == .light ? TF.recordingLightGlassRim : TF.recordingGlassRim,
+                lineWidth: 0.8
+            )
         case .done:
             barShape.strokeBorder(feedbackBorderColor, lineWidth: 0.5)
         case .error:
@@ -1166,6 +1187,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
             TranscriptPopup(
                 text: state.transcriptionText,
                 height: transcriptPopupHeight,
+                theme: effectiveTheme,
                 onHoverChanged: updateTranscriptHover
             )
         case .mode:
@@ -1192,7 +1214,8 @@ struct FloatingBarView<S: FloatingBarState>: View {
         if effectiveShowsModelName, let model = state.recordingModelName, !model.isEmpty {
             components.append(model)
         }
-        return components.isEmpty ? nil : components.joined(separator: " · ")
+        guard !components.isEmpty else { return nil }
+        return components.joined(separator: " · ")
     }
 
     private func alignedActionHint(_ action: RecordingControlAction) -> some View {
@@ -1223,35 +1246,44 @@ struct FloatingBarView<S: FloatingBarState>: View {
             if action == .cancel {
                 Text("esc")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(TF.floatingText)
+                    .foregroundStyle(effectiveTheme == .light ? TF.floatingTextSecondaryLight : TF.floatingText)
                     .padding(.horizontal, 7)
                     .padding(.vertical, 2)
-                    .background(Capsule().fill(TF.recordingTooltipBadge))
+                    .background(
+                        Capsule()
+                            .fill(effectiveTheme == .light ? Color.black.opacity(0.06) : TF.recordingTooltipBadge)
+                    )
+                    .overlay(
+                        Capsule().stroke(
+                            effectiveTheme == .light ? Color.black.opacity(0.12) : Color.white.opacity(0.18),
+                            lineWidth: 0.5
+                        )
+                    )
             }
         }
         .font(.system(size: 14, weight: .semibold))
-        .foregroundStyle(TF.floatingText)
+        .foregroundStyle(effectiveTheme == .light ? TF.floatingTextLight : TF.floatingText)
         .lineLimit(1)
         .padding(.horizontal, 12)
         .padding(.vertical, 9)
-        .background(FrostedGlassBubbleBackground())
+        .background(FrostedGlassBubbleBackground(theme: effectiveTheme))
         .frame(maxWidth: TF.recordingTooltipMaxWidth)
         .fixedSize(horizontal: true, vertical: false)
-        .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 2)
+        .shadow(color: Color.black.opacity(effectiveTheme == .light ? 0.05 : 0.20), radius: 3, x: 0, y: 1.5)
     }
 
     private func hintBubble(text: String) -> some View {
         Text(text)
             .font(.system(size: 14, weight: .semibold))
-            .foregroundStyle(TF.floatingText)
+            .foregroundStyle(effectiveTheme == .light ? TF.floatingTextLight : TF.floatingText)
             .lineLimit(1)
             .truncationMode(.tail)
             .padding(.horizontal, 12)
             .padding(.vertical, 9)
             .frame(maxWidth: TF.barWidth + TF.recordingTooltipOverhang * 2)
-            .background(FrostedGlassBubbleBackground())
+            .background(FrostedGlassBubbleBackground(theme: effectiveTheme))
             .fixedSize(horizontal: true, vertical: false)
-            .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 2)
+            .shadow(color: Color.black.opacity(effectiveTheme == .light ? 0.05 : 0.20), radius: 3, x: 0, y: 1.5)
     }
 
     private func showModeHint() {
@@ -1316,9 +1348,10 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 }
 
-/// A dark HUD material that samples behind the transparent panel.
+/// A dark or light HUD material that samples behind the transparent panel.
 private struct RecordingGlassSurface: View {
     let cornerRadius: CGFloat
+    var theme: RecordingTheme = .dark
     let tintOpacity: Double
 
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
@@ -1329,12 +1362,20 @@ private struct RecordingGlassSurface: View {
 
     var body: some View {
         if reduceTransparency {
-            TF.floatingBackground
+            theme == .light ? TF.floatingBackgroundLight : TF.floatingBackground
         } else {
             ZStack {
-                VisualEffectBlur(cornerRadius: cornerRadius)
-                    .allowsHitTesting(false)
-                Color.black.opacity(tintOpacity)
+                VisualEffectBlur(
+                    cornerRadius: cornerRadius,
+                    appearanceName: theme == .light ? .aqua : .darkAqua
+                )
+                .allowsHitTesting(false)
+
+                if theme == .light {
+                    Color.white.opacity(tintOpacity)
+                } else {
+                    Color.black.opacity(tintOpacity)
+                }
             }
             .clipShape(shape)
         }
@@ -1343,22 +1384,31 @@ private struct RecordingGlassSurface: View {
 
 private struct FrostedGlassBubbleBackground: View {
     let cornerRadius: CGFloat = TF.transcriptPopupCorner
+    var theme: RecordingTheme = .dark
 
     private var shape: RoundedRectangle {
         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
     }
 
     var body: some View {
-        RecordingGlassSurface(cornerRadius: cornerRadius, tintOpacity: 0.40)
-            .overlay {
-                shape.strokeBorder(TF.floatingBorder, lineWidth: 0.5)
-            }
+        RecordingGlassSurface(
+            cornerRadius: cornerRadius,
+            theme: theme,
+            tintOpacity: theme == .light ? 0.75 : 0.40
+        )
+        .overlay {
+            shape.strokeBorder(
+                theme == .light ? TF.floatingBorderLight : TF.floatingBorder,
+                lineWidth: 0.5
+            )
+        }
     }
 }
 
 private struct TranscriptPopup: View {
     let text: String
     let height: CGFloat
+    var theme: RecordingTheme = .dark
     let onHoverChanged: (Bool) -> Void
 
     var body: some View {
@@ -1366,7 +1416,7 @@ private struct TranscriptPopup: View {
             ScrollView(.vertical) {
                 Text(text)
                     .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(TF.floatingText)
+                    .foregroundStyle(theme == .light ? TF.floatingTextLight : TF.floatingText)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(12)
 
@@ -1376,12 +1426,12 @@ private struct TranscriptPopup: View {
             }
             .scrollIndicators(.hidden)
             .frame(width: TF.transcriptPopupWidth, height: height)
-            .background(FrostedGlassBubbleBackground())
+            .background(FrostedGlassBubbleBackground(theme: theme))
             .overlay {
                 FloatingBarHoverTracker(onHoverChanged: onHoverChanged)
             }
             .clipShape(RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous))
-            .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 2)
+            .shadow(color: Color.black.opacity(theme == .light ? 0.05 : 0.20), radius: 4, x: 0, y: 2)
             .onAppear { proxy.scrollTo("transcript-end", anchor: .bottom) }
             .onChange(of: text) { _, _ in
                 proxy.scrollTo("transcript-end", anchor: .bottom)

--- a/Type4Me/UI/FloatingBar/LiquidGlass/LiquidGlassCancelButton.swift
+++ b/Type4Me/UI/FloatingBar/LiquidGlass/LiquidGlassCancelButton.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// Apple-style frosted liquid glass cancel button with liquid press & drag deformation physics.
 struct LiquidGlassCancelButton: View {
+    var theme: RecordingTheme = .dark
     var isHovered: Bool = false
     var isPressed: Bool = false
     var dragOffset: CGSize = .zero
@@ -46,73 +47,148 @@ struct LiquidGlassCancelButton: View {
 
     var body: some View {
         ZStack {
-            // 1. Dark translucent glass backdrop
-            Circle()
-                .fill(Color.black.opacity(isPressed ? 0.45 : 0.38))
+            if theme == .light {
+                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                // Light Theme: Frosted Liquid Glass Optics
+                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-            // 2. Translucent glass fill with dynamic liquid brightness boost (0.12 -> 0.45 on press)
-            Circle()
-                .fill(
-                    RadialGradient(
-                        colors: isPressed ? [
-                            Color.white.opacity(0.55),
-                            Color.white.opacity(0.38),
-                            Color.white.opacity(0.22),
-                        ] : [
-                            Color.white.opacity(isHovered ? 0.22 : 0.12),
-                            Color.white.opacity(isHovered ? 0.14 : 0.06),
-                            Color.white.opacity(isHovered ? 0.08 : 0.02),
-                        ],
-                        center: UnitPoint(x: 0.35, y: 0.30),
-                        startRadius: 2,
-                        endRadius: buttonSize * 0.55
+                // 1. Translucent glass base
+                Circle()
+                    .fill(Color.white.opacity(isPressed ? 0.65 : (isHovered ? 0.50 : 0.35)))
+
+                // 2. 3D Radial Refractive glass dome
+                Circle()
+                    .fill(
+                        RadialGradient(
+                            colors: isPressed ? [
+                                Color.white.opacity(0.95),
+                                Color.white.opacity(0.70),
+                                Color.black.opacity(0.12),
+                            ] : [
+                                Color.white.opacity(isHovered ? 0.80 : 0.65),
+                                Color.white.opacity(isHovered ? 0.45 : 0.30),
+                                Color.black.opacity(isHovered ? 0.08 : 0.04),
+                            ],
+                            center: UnitPoint(x: 0.35, y: 0.30),
+                            startRadius: 2,
+                            endRadius: buttonSize * 0.55
+                        )
                     )
-                )
 
-            // 3. Delicate glass outer rim (Fresnel reflection)
-            Circle()
-                .strokeBorder(
-                    LinearGradient(
-                        stops: isPressed ? [
-                            .init(color: Color.white.opacity(0.75), location: 0.0),
-                            .init(color: Color.white.opacity(0.45), location: 0.45),
-                            .init(color: Color.white.opacity(0.25), location: 1.0),
-                        ] : [
-                            .init(color: Color.white.opacity(isHovered ? 0.45 : 0.30), location: 0.0),
-                            .init(color: Color.white.opacity(isHovered ? 0.22 : 0.14), location: 0.45),
-                            .init(color: Color.white.opacity(isHovered ? 0.10 : 0.06), location: 1.0),
-                        ],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    ),
-                    lineWidth: isPressed ? 1.0 : 0.75
-                )
-
-            // 4. Top-left specular gloss sheen
-            Ellipse()
-                .fill(
-                    LinearGradient(
-                        colors: [
-                            Color.white.opacity(isPressed ? 0.50 : (isHovered ? 0.35 : 0.22)),
-                            Color.white.opacity(0.0),
-                        ],
-                        startPoint: .top,
-                        endPoint: .bottom
+                // 3. Delicate Fresnel reflection specular rim
+                Circle()
+                    .strokeBorder(
+                        LinearGradient(
+                            stops: isPressed ? [
+                                .init(color: Color.white.opacity(0.98), location: 0.0),
+                                .init(color: Color.white.opacity(0.60), location: 0.45),
+                                .init(color: Color.black.opacity(0.20), location: 1.0),
+                            ] : [
+                                .init(color: Color.white.opacity(isHovered ? 0.95 : 0.85), location: 0.0),
+                                .init(color: Color.white.opacity(isHovered ? 0.45 : 0.30), location: 0.45),
+                                .init(color: Color.black.opacity(isHovered ? 0.16 : 0.10), location: 1.0),
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        ),
+                        lineWidth: isPressed ? 1.0 : 0.75
                     )
-                )
-                .frame(width: buttonSize * 0.55, height: buttonSize * 0.22)
-                .offset(x: -buttonSize * 0.08, y: -buttonSize * 0.22)
 
-            // 5. Crisp SF Symbol xmark
-            Image(systemName: "xmark")
-                .font(.system(size: 13, weight: isPressed ? .bold : .semibold))
-                .foregroundStyle(Color.white.opacity(isPressed ? 1.0 : (isHovered ? 0.95 : 0.82)))
-                .shadow(color: Color.black.opacity(isPressed ? 0.6 : 0.4), radius: 1, x: 0, y: 0.5)
+                // 4. Top-left specular gloss sheen ellipse
+                Ellipse()
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                Color.white.opacity(isPressed ? 0.85 : (isHovered ? 0.70 : 0.50)),
+                                Color.white.opacity(0.0),
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                    .frame(width: buttonSize * 0.55, height: buttonSize * 0.22)
+                    .offset(x: -buttonSize * 0.08, y: -buttonSize * 0.22)
+
+                // 5. Crisp SF Symbol xmark
+                Image(systemName: "xmark")
+                    .font(.system(size: 13, weight: isPressed ? .bold : .semibold))
+                    .foregroundStyle(
+                        Color(red: 28 / 255, green: 28 / 255, blue: 30 / 255)
+                            .opacity(isPressed ? 1.0 : (isHovered ? 0.92 : 0.78))
+                    )
+                    .shadow(color: Color.white.opacity(isPressed ? 0.8 : 0.4), radius: 0.5, x: 0, y: 0.5)
+
+            } else {
+                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                // Dark Theme: Frosted Liquid Glass Optics
+                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+                // 1. Dark translucent glass backdrop
+                Circle()
+                    .fill(Color.black.opacity(isPressed ? 0.45 : 0.38))
+
+                // 2. Translucent glass fill with dynamic liquid brightness boost (0.12 -> 0.45 on press)
+                Circle()
+                    .fill(
+                        RadialGradient(
+                            colors: isPressed ? [
+                                Color.white.opacity(0.55),
+                                Color.white.opacity(0.38),
+                                Color.white.opacity(0.22),
+                            ] : [
+                                Color.white.opacity(isHovered ? 0.22 : 0.12),
+                                Color.white.opacity(isHovered ? 0.14 : 0.06),
+                                Color.white.opacity(isHovered ? 0.08 : 0.02),
+                            ],
+                            center: UnitPoint(x: 0.35, y: 0.30),
+                            startRadius: 2,
+                            endRadius: buttonSize * 0.55
+                        )
+                    )
+
+                // 3. Delicate glass outer rim (Fresnel reflection)
+                Circle()
+                    .strokeBorder(
+                        LinearGradient(
+                            stops: isPressed ? [
+                                .init(color: Color.white.opacity(0.75), location: 0.0),
+                                .init(color: Color.white.opacity(0.45), location: 0.45),
+                                .init(color: Color.white.opacity(0.25), location: 1.0),
+                            ] : [
+                                .init(color: Color.white.opacity(isHovered ? 0.45 : 0.30), location: 0.0),
+                                .init(color: Color.white.opacity(isHovered ? 0.22 : 0.14), location: 0.45),
+                                .init(color: Color.white.opacity(isHovered ? 0.10 : 0.06), location: 1.0),
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        ),
+                        lineWidth: isPressed ? 1.0 : 0.75
+                    )
+
+                // 4. Top-left specular gloss sheen
+                Ellipse()
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                Color.white.opacity(isPressed ? 0.50 : (isHovered ? 0.35 : 0.22)),
+                                Color.white.opacity(0.0),
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                    .frame(width: buttonSize * 0.55, height: buttonSize * 0.22)
+                    .offset(x: -buttonSize * 0.08, y: -buttonSize * 0.22)
+
+                // 5. Crisp SF Symbol xmark
+                Image(systemName: "xmark")
+                    .font(.system(size: 13, weight: isPressed ? .bold : .semibold))
+                    .foregroundStyle(Color.white.opacity(isPressed ? 1.0 : (isHovered ? 0.95 : 0.82)))
+                    .shadow(color: Color.black.opacity(isPressed ? 0.6 : 0.4), radius: 1, x: 0, y: 0.5)
+            }
         }
         .frame(width: buttonSize, height: buttonSize)
-        // Liquid Stretch Deformation via continuous 2D Affine Matrix
         .transformEffect(liquidStretchTransform)
-        // Pressed Expansion (1.10x) vs Hover (1.04x) vs Normal (1.0)
         .scaleEffect(isPressed ? 1.10 : (isHovered ? 1.04 : 1.0))
         .offset(clampedOffset)
         .animation(.spring(response: 0.22, dampingFraction: 0.75), value: isPressed)

--- a/Type4Me/UI/FloatingBar/LiquidGlass/LiquidGlassText.swift
+++ b/Type4Me/UI/FloatingBar/LiquidGlass/LiquidGlassText.swift
@@ -32,6 +32,7 @@ struct RecordingTextParts: Equatable {
 struct LiquidGlassText: View {
     let text: String
     let style: RecordingVisualStyle
+    var theme: RecordingTheme = .dark
     var audioEnergy: Float = 0
     var font: Font = .system(size: 14, weight: .medium)
 
@@ -79,25 +80,36 @@ struct LiquidGlassText: View {
             endPoint = UnitPoint(x: -1.7, y: 0.5)
         }
 
+        let textColor = theme == .light ? TF.floatingTextLight : Color.white
+        let gradientStops: [Gradient.Stop] = theme == .light ? [
+            .init(color: textColor, location: 0.0),
+            .init(color: textColor.opacity(0.60), location: 0.32),
+            .init(color: Color.white, location: 0.50),
+            .init(color: textColor.opacity(0.60), location: 0.68),
+            .init(color: textColor, location: 1.0),
+        ] : [
+            .init(color: Color.white.opacity(0.40), location: 0.0),
+            .init(color: Color.white.opacity(0.65), location: 0.35),
+            .init(color: Color.white, location: 0.50),
+            .init(color: Color.white.opacity(0.65), location: 0.65),
+            .init(color: Color.white.opacity(0.40), location: 1.0),
+        ]
+
         return Text(text)
             .font(font)
             .lineLimit(1)
             .foregroundStyle(
                 LinearGradient(
-                    stops: [
-                        .init(color: Color.white.opacity(0.40), location: 0.0),
-                        .init(color: Color.white.opacity(0.60), location: 0.30),
-                        .init(color: Color.white, location: 0.50),
-                        .init(color: Color.white.opacity(0.60), location: 0.70),
-                        .init(color: Color.white.opacity(0.40), location: 1.0),
-                    ],
+                    stops: gradientStops,
                     startPoint: startPoint,
                     endPoint: endPoint
                 )
             )
             .shadow(
-                color: Color.white.opacity(isSweeping ? Double(0.20 + energy * 0.30) : 0.0),
-                radius: CGFloat(1.5 + energy * 1.5)
+                color: theme == .light
+                    ? Color.white.opacity(isSweeping ? Double(0.85 + energy * 0.15) : 0.0)
+                    : Color.white.opacity(isSweeping ? Double(0.30 + energy * 0.30) : 0.0),
+                radius: CGFloat(2.0 + energy * 1.5)
             )
             .onAppear {
                 startTime = CACurrentMediaTime()

--- a/Type4Me/UI/FloatingBar/RecordingTheme.swift
+++ b/Type4Me/UI/FloatingBar/RecordingTheme.swift
@@ -1,0 +1,27 @@
+//
+//  RecordingTheme.swift
+//  Type4Me
+//
+
+import Foundation
+import SwiftUI
+
+/// Appearance theme for the floating recording indicator and related overlays.
+enum RecordingTheme: String, CaseIterable, Identifiable {
+    case dark
+    case light
+
+    var id: String { rawValue }
+
+    static let storageKey = "tf_recordingTheme"
+    static let defaultValue = RecordingTheme.dark
+
+    var displayName: String {
+        switch self {
+        case .dark:
+            L("暗色", "Dark")
+        case .light:
+            L("明亮", "Light")
+        }
+    }
+}

--- a/Type4Me/UI/FloatingBar/VisualEffectBlur.swift
+++ b/Type4Me/UI/FloatingBar/VisualEffectBlur.swift
@@ -1,9 +1,14 @@
 import AppKit
 import SwiftUI
 
-/// A SwiftUI bridge for a dark HUD material that samples behind its window.
+/// A SwiftUI bridge for native HUD / Popover frosted glass that samples behind its window.
 struct VisualEffectBlur: NSViewRepresentable {
-    let cornerRadius: CGFloat
+    var cornerRadius: CGFloat = 0
+    var material: NSVisualEffectView.Material = .hudWindow
+    var blendingMode: NSVisualEffectView.BlendingMode = .behindWindow
+    var state: NSVisualEffectView.State = .active
+    var isEmphasized: Bool = false
+    var appearanceName: NSAppearance.Name? = .darkAqua
 
     func makeNSView(context: Context) -> NSVisualEffectView {
         let view = NSVisualEffectView()
@@ -17,13 +22,17 @@ struct VisualEffectBlur: NSViewRepresentable {
     }
 
     private func configure(_ view: NSVisualEffectView) {
-        view.material = .hudWindow
-        view.blendingMode = .behindWindow
-        view.state = .active
-        view.isEmphasized = false
+        view.material = material
+        view.blendingMode = blendingMode
+        view.state = state
+        view.isEmphasized = isEmphasized
         view.layer?.cornerRadius = cornerRadius
         view.layer?.cornerCurve = .continuous
-        view.layer?.masksToBounds = true
-        view.appearance = NSAppearance(named: .darkAqua)
+        view.layer?.masksToBounds = cornerRadius > 0
+        if let appearanceName {
+            view.appearance = NSAppearance(named: appearanceName)
+        } else {
+            view.appearance = nil
+        }
     }
 }

--- a/Type4Me/UI/FloatingBar/VisualEffectBlur.swift
+++ b/Type4Me/UI/FloatingBar/VisualEffectBlur.swift
@@ -1,0 +1,29 @@
+import AppKit
+import SwiftUI
+
+/// A SwiftUI bridge for a dark HUD material that samples behind its window.
+struct VisualEffectBlur: NSViewRepresentable {
+    let cornerRadius: CGFloat
+
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.wantsLayer = true
+        configure(view)
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
+        configure(nsView)
+    }
+
+    private func configure(_ view: NSVisualEffectView) {
+        view.material = .hudWindow
+        view.blendingMode = .behindWindow
+        view.state = .active
+        view.isEmphasized = false
+        view.layer?.cornerRadius = cornerRadius
+        view.layer?.cornerCurve = .continuous
+        view.layer?.masksToBounds = true
+        view.appearance = NSAppearance(named: .darkAqua)
+    }
+}

--- a/Type4Me/UI/SelectionAsk/SelectionAskView.swift
+++ b/Type4Me/UI/SelectionAsk/SelectionAskView.swift
@@ -73,10 +73,7 @@ struct SelectionAskView: View {
             }
         }
         .id(language)
-        .coordinateSpace(name: "SettingsWindowCoordinateSpace")
-        .overlay {
-            SettingsTooltipRootHost()
-        }
+        .settingsTooltipHost(.selectionAsk)
     }
 
     private var header: some View {

--- a/Type4Me/UI/SelectionAsk/SelectionAskView.swift
+++ b/Type4Me/UI/SelectionAsk/SelectionAskView.swift
@@ -72,8 +72,11 @@ struct SelectionAskView: View {
                     .zIndex(100)
             }
         }
-        .animation(.easeOut(duration: 0.08), value: isOpenInType4MeHovered)
         .id(language)
+        .coordinateSpace(name: "SettingsWindowCoordinateSpace")
+        .overlay {
+            SettingsTooltipRootHost()
+        }
     }
 
     private var header: some View {

--- a/Type4Me/UI/Settings/AboutTab.swift
+++ b/Type4Me/UI/Settings/AboutTab.swift
@@ -21,9 +21,9 @@ struct AboutTab: View {
             Spacer().frame(height: 8)
 
             // App info rows
-            SettingsRow(label: L("版本", "Version"), value: appVersion)
+            SettingsRow(label: L("版本", "Version"), value: AppBuildInfo.current.version)
             SettingsDivider()
-            SettingsRow(label: L("构建", "Build"), value: buildNumber)
+            SettingsRow(label: L("构建", "Build"), value: AppBuildInfo.current.buildNumber)
             SettingsDivider()
             SettingsRow(label: L("平台", "Platform"), value: "macOS 14+")
             SettingsDivider()
@@ -287,14 +287,6 @@ struct AboutTab: View {
     }
 
     // MARK: - Helpers
-
-    private var appVersion: String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.1.0"
-    }
-
-    private var buildNumber: String {
-        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
-    }
 
     private func linkButton(_ text: String, icon: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {

--- a/Type4Me/UI/Settings/AppearanceSettingsTab.swift
+++ b/Type4Me/UI/Settings/AppearanceSettingsTab.swift
@@ -6,6 +6,9 @@ import SwiftUI
 
 struct AppearanceSettingsTab: View, SettingsCardHelpers {
 
+    @AppStorage(RecordingTheme.storageKey)
+    private var theme = RecordingTheme.defaultValue.rawValue
+
     @AppStorage(RecordingIndicatorStyle.storageKey)
     private var indicatorStyle = RecordingIndicatorStyle.defaultValue
 
@@ -51,6 +54,7 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
 
     private var presentation: FloatingBarPresentation {
         FloatingBarPresentation(
+            theme: RecordingTheme(rawValue: theme) ?? .dark,
             indicatorStyle: RecordingIndicatorStyle(rawValue: indicatorStyle) ?? .regular,
             visualStyle: RecordingVisualStyle(rawValue: visualStyle) ?? .siri,
             showsLiveTranscript: showLiveTranscript,
@@ -85,6 +89,8 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
             // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
             settingsGroupCard(L("录音显示", "Recording Display"), icon: "macwindow") {
+                themeRow
+                SettingsDivider()
                 indicatorStyleRow
                 SettingsDivider()
 
@@ -93,12 +99,6 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
                     SettingsDivider()
                 }
 
-                modeNameRow
-                SettingsDivider()
-                providerNameRow
-                SettingsDivider()
-                modelNameRow
-                SettingsDivider()
                 liveTranscriptRow
 
                 if !isCompact {
@@ -107,11 +107,19 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
                 }
 
                 SettingsDivider()
+                showCancelButtonRow
+                SettingsDivider()
+
                 showTooltipsRow
                 SettingsDivider()
-                showCancelButtonRow
+                modeNameRow
+                SettingsDivider()
+                providerNameRow
+                SettingsDivider()
+                modelNameRow
             }
             .animation(TF.springGentle, value: isCompact)
+            .animation(TF.springGentle, value: showTooltips)
 
             Spacer().frame(height: 16)
 
@@ -131,9 +139,24 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
 
     // MARK: - Row Builders
 
+    private var themeRow: some View {
+        settingsOptionRow(
+            L("外观主题", "Appearance Theme"),
+            controlWidth: SettingsControlWidth.inlineSegmented
+        ) {
+            settingsInlineSegmentedPicker(
+                selection: $theme,
+                options: RecordingTheme.allCases.map { ($0.rawValue, $0.displayName) }
+            )
+        }
+    }
+
     private var indicatorStyleRow: some View {
-        settingsOptionRow(L("指示条外观", "Indicator Style")) {
-            settingsDropdown(
+        settingsOptionRow(
+            L("指示条风格", "Indicator Style"),
+            controlWidth: SettingsControlWidth.inlineSegmented
+        ) {
+            settingsInlineSegmentedPicker(
                 selection: $indicatorStyle,
                 options: RecordingIndicatorStyle.allCases.map { ($0.rawValue, $0.displayName) }
             )
@@ -160,45 +183,10 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
         )
     }
 
-    private var modeNameRow: some View {
-        settingsToggleRow(
-            L("显示模式名称", "Show Mode Name"),
-            subtitle: L("在录音开始提示中显示当前模式", "Show the current mode in the recording-start tooltip"),
-            isOn: $showModeName
-        )
-    }
-
-    private var providerNameRow: some View {
-        settingsToggleRow(
-            L("显示服务商", "Show Provider"),
-            subtitle: L("在录音开始提示中显示语音识别服务商", "Show the speech provider in the recording-start tooltip"),
-            isOn: $showProviderName
-        )
-    }
-
-    private var modelNameRow: some View {
-        settingsToggleRow(
-            L("显示模型名称", "Show Model Name"),
-            subtitle: L("在录音开始提示中显示语音识别模型", "Show the speech model in the recording-start tooltip"),
-            isOn: $showModelName
-        )
-    }
-
     private var hoverPreviewRow: some View {
         settingsToggleRow(
             L("悬停文字预览", "Hover Text Preview"),
             isOn: $hoverTranscriptPreview
-        )
-    }
-
-    private var showTooltipsRow: some View {
-        settingsToggleRow(
-            L("显示 Tooltips", "Show Tooltips"),
-            subtitle: L(
-                "开启后在录音开始与悬停按钮时显示提示气泡",
-                "Show hints on recording start and button hover"
-            ),
-            isOn: $showTooltips
         )
     }
 
@@ -213,9 +201,53 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
         )
     }
 
+    private var showTooltipsRow: some View {
+        settingsToggleRow(
+            L("显示 Tooltips", "Show Tooltips"),
+            subtitle: L(
+                "开启后在录音开始与悬停按钮时显示提示气泡",
+                "Show hints on recording start and button hover"
+            ),
+            isOn: $showTooltips
+        )
+    }
+
+    private var modeNameRow: some View {
+        settingsToggleRow(
+            L("显示模式名称", "Show Mode Name"),
+            subtitle: L("在录音开始提示中显示当前模式", "Show the current mode in the recording-start tooltip"),
+            isOn: $showModeName,
+            isEnabled: showTooltips,
+            isIndented: true
+        )
+    }
+
+    private var providerNameRow: some View {
+        settingsToggleRow(
+            L("显示服务商", "Show Provider"),
+            subtitle: L("在录音开始提示中显示语音识别服务商", "Show the speech provider in the recording-start tooltip"),
+            isOn: $showProviderName,
+            isEnabled: showTooltips,
+            isIndented: true
+        )
+    }
+
+    private var modelNameRow: some View {
+        settingsToggleRow(
+            L("显示模型名称", "Show Model Name"),
+            subtitle: L("在录音开始提示中显示语音识别模型", "Show the speech model in the recording-start tooltip"),
+            isOn: $showModelName,
+            isEnabled: showTooltips,
+            isIndented: true
+        )
+    }
+
     private var stripPunctuationRow: some View {
-        settingsOptionRow(L("去句末标点", "Strip Trailing Punctuation")) {
-            settingsDropdown(
+        settingsOptionRow(
+            L("去句末标点", "Strip Trailing Punctuation"),
+            controlWidth: SettingsControlWidth.standard
+        ) {
+            settingsInlineSegmentedPicker(
                 selection: $stripTrailingPunctuation,
                 options: [
                     ("off", L("不去掉", "Off")),
@@ -232,9 +264,10 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
             subtitle: L(
                 "自动在中文与英文、数字和半角符号之间添加空格",
                 "Automatically add spaces between CJK text and half-width letters, numbers, and symbols"
-            )
+            ),
+            controlWidth: SettingsControlWidth.standard
         ) {
-            settingsDropdown(
+            settingsInlineSegmentedPicker(
                 selection: $cjkSpacingMode,
                 options: [
                     (CJKSpacingMode.pangu.rawValue, L("开启", "On")),

--- a/Type4Me/UI/Settings/DebugSettingsTab.swift
+++ b/Type4Me/UI/Settings/DebugSettingsTab.swift
@@ -56,7 +56,7 @@ struct DebugSettingsTab: View, SettingsCardHelpers {
         settingsGroupCard(L("构建与运行环境", "Build & Runtime"), icon: "hammer.fill") {
             diagnosticRow(L("构建类型", "Build Type"), value: DebugSettingsAvailability.buildLabel, emphasized: true)
             SettingsDivider()
-            diagnosticRow(L("应用版本", "App Version"), value: "\(appVersion) (\(buildNumber))")
+            diagnosticRow(L("应用版本", "App Version"), value: AppBuildInfo.current.debugLabel)
             SettingsDivider()
             diagnosticRow(L("Bundle ID", "Bundle ID"), value: Bundle.main.bundleIdentifier ?? "—")
             SettingsDivider()
@@ -200,14 +200,6 @@ struct DebugSettingsTab: View, SettingsCardHelpers {
     private func refreshLog() {
         recentLog = DebugFileLogger.recentLines(200).joined(separator: "\n")
         refreshedAt = Date()
-    }
-
-    private var appVersion: String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
-    }
-
-    private var buildNumber: String {
-        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
     }
 
     private var architecture: String {

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -100,7 +100,9 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
                 SettingsDivider()
                 dockIconRow
                 SettingsDivider()
-                preserveClipboardRow
+                keepOnNormalInputRow
+                SettingsDivider()
+                cancellationRetentionRow
                 SettingsDivider()
                 languageRow
             }
@@ -536,16 +538,57 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
         NotificationCenter.default.post(name: .reviseSettingsDidChange, object: nil)
     }
 
-    private var preserveClipboardRow: some View {
+    private var keepOnNormalInputRow: some View {
         let policy = ClipboardOutputPolicy(rawValue: clipboardOutputPolicyRaw)
             ?? ClipboardOutputPolicy.defaultValue
+        let isRetained = Binding<Bool>(
+            get: { policy.retainsNormalResult },
+            set: { newValue in
+                let currentCancelMode = policy.cancellationMode
+                let newPolicy = ClipboardOutputPolicy.policy(
+                    retainsNormal: newValue,
+                    cancellationMode: currentCancelMode
+                )
+                clipboardOutputPolicyRaw = newPolicy.rawValue
+            }
+        )
+        return settingsToggleRow(
+            L("输入完成后保留在剪贴板", "Keep in Clipboard on Input"),
+            subtitle: L(
+                "关闭时，打字完成后自动恢复录音前的剪贴板内容",
+                "When off, original clipboard content is restored after typing"
+            ),
+            isOn: isRetained
+        )
+    }
+
+    private var cancellationRetentionRow: some View {
+        let policy = ClipboardOutputPolicy(rawValue: clipboardOutputPolicyRaw)
+            ?? ClipboardOutputPolicy.defaultValue
+        let cancelBinding = Binding<String>(
+            get: { policy.cancellationMode.rawValue },
+            set: { raw in
+                guard let mode = ClipboardOutputPolicy.CancellationRetentionMode(rawValue: raw) else { return }
+                let newPolicy = ClipboardOutputPolicy.policy(
+                    retainsNormal: policy.retainsNormalResult,
+                    cancellationMode: mode
+                )
+                clipboardOutputPolicyRaw = newPolicy.rawValue
+            }
+        )
         return settingsOptionRow(
-            L("剪贴板保留", "Clipboard Retention"),
-            subtitle: policy.detail
+            L("取消录音时留存策略", "Retention on Cancellation"),
+            subtitle: L(
+                "中途按 Esc 或点击取消时，是否将说过的语音留存在剪贴板",
+                "Whether to keep spoken text in clipboard when cancelled"
+            ),
+            controlWidth: SettingsControlWidth.standard
         ) {
-            settingsDropdown(
-                selection: $clipboardOutputPolicyRaw,
-                options: ClipboardOutputPolicy.allCases.map { ($0.rawValue, $0.displayName) }
+            settingsInlineSegmentedPicker(
+                selection: cancelBinding,
+                options: ClipboardOutputPolicy.CancellationRetentionMode.allCases.map {
+                    ($0.rawValue, $0.displayName)
+                }
             )
         }
     }

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -565,6 +565,10 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
     private var cancellationRetentionRow: some View {
         let policy = ClipboardOutputPolicy(rawValue: clipboardOutputPolicyRaw)
             ?? ClipboardOutputPolicy.defaultValue
+        // When normal-completion retention is on the stored policy is `.alwaysCopy`,
+        // which already implies "processed" on cancellation. Surface that coupling
+        // instead of leaving a segmented control that silently ignores clicks.
+        let isOverriddenByNormalRetention = policy.retainsNormalResult
         let cancelBinding = Binding<String>(
             get: { policy.cancellationMode.rawValue },
             set: { raw in
@@ -578,10 +582,15 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
         )
         return settingsOptionRow(
             L("取消录音时留存策略", "Retention on Cancellation"),
-            subtitle: L(
-                "中途按 Esc 或点击取消时，是否将说过的语音留存在剪贴板",
-                "Whether to keep spoken text in clipboard when cancelled"
-            ),
+            subtitle: isOverriddenByNormalRetention
+                ? L(
+                    "上方开关打开时，取消后同样会经 AI 润色并保留在剪贴板",
+                    "While the switch above is on, cancelled results are AI processed and kept too"
+                )
+                : L(
+                    "中途按 Esc 或点击取消时，是否将说过的语音留存在剪贴板",
+                    "Whether to keep spoken text in clipboard when cancelled"
+                ),
             controlWidth: SettingsControlWidth.standard
         ) {
             settingsInlineSegmentedPicker(
@@ -590,6 +599,8 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
                     ($0.rawValue, $0.displayName)
                 }
             )
+            .disabled(isOverriddenByNormalRetention)
+            .opacity(isOverriddenByNormalRetention ? 0.5 : 1.0)
         }
     }
 

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -123,7 +123,7 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
                             .foregroundStyle(TF.settingsTextTertiary)
                     }
                     .buttonStyle(.plain)
-                    .help(L("刷新权限状态", "Refresh permission status"))
+                    .settingsTooltip(L("刷新权限状态", "Refresh permission status"))
                 )
             ) {
                 permissionRow(
@@ -291,7 +291,7 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
                         .foregroundStyle(TF.settingsTextTertiary)
                 }
                 .buttonStyle(.plain)
-                .help(L("刷新麦克风列表", "Refresh microphone list"))
+                .settingsTooltip(L("刷新麦克风列表", "Refresh microphone list"))
                 microphonePreferenceDropdown
             }
         }
@@ -425,7 +425,7 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
                         .foregroundStyle(TF.settingsTextTertiary)
                 }
                 .buttonStyle(.plain)
-                .help(L("刷新输出设备列表", "Refresh output device list"))
+                .settingsTooltip(L("刷新输出设备列表", "Refresh output device list"))
                 settingsDropdown(
                     selection: $selectedSpeakerUID,
                     options: [("", L("系统默认", "System Default"))] + availableSpeakers.map { ($0.uid, $0.name) }

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -509,9 +509,10 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
     private var reviseHotkeyStyleRow: some View {
         settingsOptionRow(
             L("触发方式", "Trigger Style"),
-            subtitle: L("长按松开结束，或单击开始/结束", "Hold to speak, or tap to toggle")
+            subtitle: L("长按松开结束，或单击开始/结束", "Hold to speak, or tap to toggle"),
+            controlWidth: SettingsControlWidth.inlineSegmented
         ) {
-            settingsSegmentedPicker(
+            settingsInlineSegmentedPicker(
                 selection: Binding(
                     get: { (reviseSettings.hotkey?.style ?? .hold).rawValue },
                     set: { rawValue in
@@ -527,7 +528,6 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
                     (HotkeyStyle.toggle.rawValue, L("单击切换", "Toggle")),
                 ]
             )
-            .frame(width: 164)
         }
     }
 
@@ -558,11 +558,13 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
     }
 
     private var languageRow: some View {
-        settingsOptionRow(L("界面语言", "Primary Language")) {
-            settingsDropdown(
+        settingsOptionRow(
+            L("界面语言", "Primary Language"),
+            controlWidth: SettingsControlWidth.inlineSegmented
+        ) {
+            settingsInlineSegmentedPicker(
                 selection: $language,
-                options: AppLanguage.allCases.map { ($0.rawValue, $0.displayName) },
-                icon: "globe"
+                options: AppLanguage.allCases.map { ($0.rawValue, $0.displayName) }
             )
         }
     }

--- a/Type4Me/UI/Settings/HistoryTab.swift
+++ b/Type4Me/UI/Settings/HistoryTab.swift
@@ -754,12 +754,16 @@ struct HistoryTab: View {
             Text(L("导出识别记录", "Export Records"))
                 .font(.system(size: 13, weight: .semibold))
 
-            Picker("", selection: $exportRangeAll) {
-                Text(L("全部记录", "All records")).tag(true)
-                Text(L("指定日期范围", "Date range")).tag(false)
-            }
-            .pickerStyle(.radioGroup)
-            .font(.system(size: 12))
+            SettingsInlineSegmentedPicker(
+                selection: Binding(
+                    get: { exportRangeAll ? "all" : "range" },
+                    set: { exportRangeAll = ($0 == "all") }
+                ),
+                options: [
+                    ("all", L("全部记录", "All records")),
+                    ("range", L("指定日期范围", "Date range")),
+                ]
+            )
 
             if !exportRangeAll {
                 HStack(spacing: 8) {

--- a/Type4Me/UI/Settings/HistoryTab.swift
+++ b/Type4Me/UI/Settings/HistoryTab.swift
@@ -126,96 +126,6 @@ enum DateFilter: Equatable, Hashable {
 
 // MARK: - History Controls
 
-/// Presents record-action tooltips in a tiny non-activating AppKit panel.
-/// Because the panel is not a child of the ScrollView, it can extend beyond
-/// the list viewport without clipping or per-frame scroll geometry work.
-@MainActor
-private final class HistoryFloatingTooltipController {
-    static let shared = HistoryFloatingTooltipController()
-
-    private var panel: NSPanel?
-    private var activeOwner: UUID?
-
-    func show(text: String, owner: UUID) {
-        hide()
-
-        let hostingView = NSHostingView(rootView: SettingsTooltipBubble(text: text))
-        hostingView.layoutSubtreeIfNeeded()
-        var size = hostingView.fittingSize
-        size.width = max(size.width, 44)
-        size.height = 34
-        hostingView.frame = NSRect(origin: .zero, size: size)
-
-        let tooltipPanel = NSPanel(
-            contentRect: NSRect(origin: .zero, size: size),
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: false
-        )
-        tooltipPanel.backgroundColor = .clear
-        tooltipPanel.isOpaque = false
-        tooltipPanel.hasShadow = true
-        tooltipPanel.level = .floating
-        tooltipPanel.ignoresMouseEvents = true
-        tooltipPanel.collectionBehavior = [.transient, .ignoresCycle]
-        tooltipPanel.contentView = hostingView
-
-        let mouse = NSEvent.mouseLocation
-        let screenFrame = NSScreen.screens
-            .first(where: { $0.frame.contains(mouse) })?
-            .visibleFrame ?? NSScreen.main?.visibleFrame ?? .zero
-        var origin = NSPoint(
-            x: mouse.x - size.width / 2,
-            y: mouse.y - size.height - 18
-        )
-        origin.x = min(max(origin.x, screenFrame.minX + 8), screenFrame.maxX - size.width - 8)
-        if origin.y < screenFrame.minY + 8 {
-            origin.y = mouse.y + 18
-        }
-        origin.y = min(
-            max(origin.y, screenFrame.minY + 8),
-            screenFrame.maxY - size.height - 8
-        )
-
-        tooltipPanel.setFrameOrigin(origin)
-        tooltipPanel.orderFrontRegardless()
-        panel = tooltipPanel
-        activeOwner = owner
-    }
-
-    func hide(owner: UUID? = nil) {
-        if let owner, owner != activeOwner { return }
-        panel?.orderOut(nil)
-        panel = nil
-        activeOwner = nil
-    }
-}
-
-private struct HistoryFloatingTooltipModifier: ViewModifier {
-    let text: String
-    @State private var owner = UUID()
-
-    func body(content: Content) -> some View {
-        content
-            .onHover { hovering in
-                if hovering {
-                    HistoryFloatingTooltipController.shared.show(text: text, owner: owner)
-                } else {
-                    HistoryFloatingTooltipController.shared.hide(owner: owner)
-                }
-            }
-            .onDisappear {
-                HistoryFloatingTooltipController.shared.hide(owner: owner)
-            }
-    }
-}
-
-private extension View {
-    func historyFloatingTooltip(_ text: String) -> some View {
-        modifier(HistoryFloatingTooltipModifier(text: text))
-    }
-}
-
 private struct HistoryToolbarButton: View {
     let icon: String
     let tooltip: String
@@ -1400,7 +1310,6 @@ struct HistoryTab: View {
         action: @escaping () -> Void
     ) -> some View {
         Button {
-            HistoryFloatingTooltipController.shared.hide()
             action()
         } label: {
             Image(systemName: icon)
@@ -1413,7 +1322,7 @@ struct HistoryTab: View {
                 )
         }
         .buttonStyle(.plain)
-        .historyFloatingTooltip(tooltip)
+        .settingsTooltip(tooltip)
     }
 
     // MARK: - Statistics UI

--- a/Type4Me/UI/Settings/HomeDashboardView.swift
+++ b/Type4Me/UI/Settings/HomeDashboardView.swift
@@ -265,7 +265,7 @@ struct HomeDashboardView: View {
                     RoundedRectangle(cornerRadius: 3, style: .continuous)
                         .fill(heatmapColor(level: level))
                         .frame(width: 12, height: 12)
-                        .help(legendTooltip(for: level))
+                        .fluidTooltip(legendTooltip(for: level))
                         .accessibilityLabel(legendTooltip(for: level))
                 }
                 Text(L("多", "More"))
@@ -505,7 +505,6 @@ struct HomeDashboardView: View {
                         .background(Circle().fill(isModesButtonHovered ? TF.settingsText : TF.settingsCardAlt))
                 }
                 .buttonStyle(.plain)
-                .help(L("管理模式与快捷键", "Manage modes and shortcuts"))
                 .onHover { hovering in
                     withAnimation(.easeOut(duration: 0.12)) { isModesButtonHovered = hovering }
                 }
@@ -604,7 +603,6 @@ struct HomeDashboardView: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .help(L("添加快捷键", "Add hotkey"))
             }
 
             if hasBindings {
@@ -632,7 +630,6 @@ struct HomeDashboardView: View {
         }
         .contentShape(Rectangle())
         .onTapGesture { openModesEditor(mode.id) }
-        .help(L("管理「\(mode.localizedDisplayName)」", "Manage \"\(mode.localizedDisplayName)\""))
         .opacity(isDragging ? 0.45 : 1)
         .onHover { hovering in
             withAnimation(.easeOut(duration: 0.1)) { hoveredModeID = hovering ? mode.id : nil }

--- a/Type4Me/UI/Settings/IntelliSenseModeDetail.swift
+++ b/Type4Me/UI/Settings/IntelliSenseModeDetail.swift
@@ -142,7 +142,7 @@ struct IntelliSenseModeDetail: View, SettingsCardHelpers {
                         .background(RoundedRectangle(cornerRadius: 8).fill(TF.settingsCardAlt))
                 }
                 .buttonStyle(.plain)
-                .help(L("添加 App", "Add App"))
+                .settingsTooltip(L("添加 App", "Add App"))
             )
         ) {
             if settings.blacklistedApps.isEmpty {

--- a/Type4Me/UI/Settings/LLMSettingsCard.swift
+++ b/Type4Me/UI/Settings/LLMSettingsCard.swift
@@ -325,7 +325,7 @@ struct LLMSettingsCard: View, SettingsCardHelpers {
                                 }
                             }
                             .buttonStyle(.plain)
-                            .help(L("从 API 获取模型列表", "Fetch models from API"))
+                            .settingsTooltip(L("从 API 获取模型列表", "Fetch models from API"))
                             .disabled(isFetchingModels || !hasLLMCredentials)
                         }
                         settingsDropdown(

--- a/Type4Me/UI/Settings/LiquidGlassTabPicker.swift
+++ b/Type4Me/UI/Settings/LiquidGlassTabPicker.swift
@@ -89,13 +89,11 @@ struct LiquidGlassTabPicker<Item: Hashable, Label: View>: View {
 
     private func select(_ item: Item) {
         guard item != selection else { return }
-        if reduceMotion {
-            onSelectionChange(item)
-        } else {
-            withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
-                onSelectionChange(item)
-            }
-        }
+        // Keep the selection-pill animation local to this control. Wrapping the
+        // navigation mutation in `withAnimation` animates the whole settings page
+        // replacement; the `.animation(_:value: selection)` on the track already
+        // drives the matched-geometry pill on its own.
+        onSelectionChange(item)
     }
 
     private func updateHover(for item: Item, isHovering: Bool) {

--- a/Type4Me/UI/Settings/LiquidGlassTabPicker.swift
+++ b/Type4Me/UI/Settings/LiquidGlassTabPicker.swift
@@ -1,0 +1,202 @@
+import SwiftUI
+
+/// An Apple-grade fluid segmented tab picker featuring liquid glass materials,
+/// continuous spring physics, instant press tactile feedback, and accessibility adaptations.
+struct LiquidGlassTabPicker<Item: Hashable, Label: View>: View {
+    let items: [Item]
+    let selection: Item
+    let onSelectionChange: (Item) -> Void
+    let spacing: CGFloat
+    @ViewBuilder let label: (Item, Bool, Bool) -> Label
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var hoveredItem: Item?
+    @Namespace private var selectionNamespace
+
+    init(
+        items: [Item],
+        selection: Item,
+        spacing: CGFloat = 2,
+        onSelectionChange: @escaping (Item) -> Void,
+        @ViewBuilder label: @escaping (Item, Bool, Bool) -> Label
+    ) {
+        self.items = items
+        self.selection = selection
+        self.spacing = spacing
+        self.onSelectionChange = onSelectionChange
+        self.label = label
+    }
+
+    var body: some View {
+        HStack(spacing: spacing) {
+            ForEach(items, id: \.self) { item in
+                tabButton(for: item)
+            }
+        }
+        .padding(3)
+        .background(trackBackground)
+        .animation(
+            reduceMotion ? .easeInOut(duration: 0.15) : .spring(response: 0.32, dampingFraction: 0.86),
+            value: selection
+        )
+    }
+
+    // MARK: - Tab Item Button
+
+    private func tabButton(for item: Item) -> some View {
+        let isSelected = selection == item
+        let isHovered = hoveredItem == item
+
+        return Button {
+            select(item)
+        } label: {
+            label(item, isSelected, isHovered)
+                .contentShape(Capsule())
+        }
+        .buttonStyle(LiquidGlassTabItemButtonStyle())
+        .background {
+            ZStack {
+                if isSelected {
+                    LiquidGlassSelectedPill(
+                        colorScheme: colorScheme,
+                        reduceTransparency: reduceTransparency
+                    )
+                    .matchedGeometryEffect(id: "liquid_glass_selected_pill", in: selectionNamespace)
+                } else if isHovered {
+                    LiquidGlassHoverPill()
+                }
+            }
+        }
+        .onHover { isHovering in
+            updateHover(for: item, isHovering: isHovering)
+        }
+    }
+
+    // MARK: - Track Background
+
+    private var trackBackground: some View {
+        Capsule()
+            .fill(TF.settingsControl)
+            .overlay {
+                Capsule()
+                    .strokeBorder(Color.black.opacity(colorScheme == .dark ? 0.15 : 0.04), lineWidth: 0.5)
+            }
+    }
+
+    // MARK: - Actions & Hover
+
+    private func select(_ item: Item) {
+        guard item != selection else { return }
+        if reduceMotion {
+            onSelectionChange(item)
+        } else {
+            withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
+                onSelectionChange(item)
+            }
+        }
+    }
+
+    private func updateHover(for item: Item, isHovering: Bool) {
+        withAnimation(.easeOut(duration: 0.12)) {
+            if isHovering {
+                hoveredItem = item
+            } else if hoveredItem == item {
+                hoveredItem = nil
+            }
+        }
+
+        if isHovering {
+            NSCursor.pointingHand.set()
+        } else if hoveredItem == nil {
+            NSCursor.arrow.set()
+        }
+    }
+}
+
+// MARK: - Selected Pill (Liquid Glass Material)
+
+private struct LiquidGlassSelectedPill: View {
+    let colorScheme: ColorScheme
+    let reduceTransparency: Bool
+
+    var body: some View {
+        Capsule()
+            .fill(pillFill)
+            .overlay {
+                // Specular light-catching rim (Fresnel reflection)
+                Capsule()
+                    .strokeBorder(specularBorderGradient, lineWidth: 0.5)
+            }
+            // Dual-layer depth: ambient dispersion shadow + micro contact shadow
+            .shadow(
+                color: colorScheme == .dark ? Color.black.opacity(0.35) : Color.black.opacity(0.06),
+                radius: 3,
+                x: 0,
+                y: 1.5
+            )
+            .shadow(
+                color: colorScheme == .dark ? Color.black.opacity(0.20) : Color.black.opacity(0.03),
+                radius: 1,
+                x: 0,
+                y: 0.5
+            )
+    }
+
+    private var pillFill: some ShapeStyle {
+        if reduceTransparency {
+            return AnyShapeStyle(colorScheme == .dark ? Color(white: 0.22) : Color.white)
+        }
+        if colorScheme == .dark {
+            return AnyShapeStyle(Color.white.opacity(0.16))
+        } else {
+            return AnyShapeStyle(Color.white.opacity(0.96))
+        }
+    }
+
+    private var specularBorderGradient: LinearGradient {
+        if colorScheme == .dark {
+            return LinearGradient(
+                stops: [
+                    .init(color: Color.white.opacity(0.28), location: 0.0),
+                    .init(color: Color.white.opacity(0.10), location: 0.5),
+                    .init(color: Color.clear, location: 1.0),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        } else {
+            return LinearGradient(
+                stops: [
+                    .init(color: Color.white.opacity(0.90), location: 0.0),
+                    .init(color: Color.white.opacity(0.40), location: 0.35),
+                    .init(color: Color.black.opacity(0.03), location: 0.80),
+                    .init(color: Color.black.opacity(0.07), location: 1.0),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        }
+    }
+}
+
+// MARK: - Hover Pill
+
+private struct LiquidGlassHoverPill: View {
+    var body: some View {
+        Capsule()
+            .fill(TF.settingsControlHover.opacity(0.9))
+            .transition(.opacity.animation(.easeOut(duration: 0.12)))
+    }
+}
+
+// MARK: - Tactile Button Style
+
+private struct LiquidGlassTabItemButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .animation(.spring(response: 0.16, dampingFraction: 0.75), value: configuration.isPressed)
+    }
+}

--- a/Type4Me/UI/Settings/ModesSettingsTab.swift
+++ b/Type4Me/UI/Settings/ModesSettingsTab.swift
@@ -320,7 +320,7 @@ struct ModesSettingsTab: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .help(L("删除模式", "Delete mode"))
+                .settingsTooltip(L("删除模式", "Delete mode"))
             }
         }
         .padding(.leading, 8)
@@ -971,7 +971,7 @@ struct HotkeySectionView: View {
                         .contentShape(Circle())
                 }
                 .buttonStyle(.plain)
-                .help(L("删除快捷键", "Delete hotkey"))
+                .settingsTooltip(L("删除", "Delete"))
                 .transition(.scale.combined(with: .opacity))
             }
         }

--- a/Type4Me/UI/Settings/ModesSettingsTab.swift
+++ b/Type4Me/UI/Settings/ModesSettingsTab.swift
@@ -1215,29 +1215,19 @@ struct HotkeyRecordingSheet: View {
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(TF.settingsTextTertiary)
 
-                HStack(spacing: 0) {
-                    ForEach([ProcessingMode.HotkeyStyle.hold, .toggle], id: \.self) { style in
-                        let selected = hotkeyStyle == style
-                        Button {
-                            withAnimation(.easeInOut(duration: 0.15)) { hotkeyStyle = style }
-                        } label: {
-                            Text(style == .hold ? L("按住录制", "Hold to record") : L("按下切换", "Toggle"))
-                                .font(.system(size: 11, weight: selected ? .semibold : .regular))
-                                .foregroundStyle(selected ? .white : TF.settingsTextSecondary)
-                                .frame(maxWidth: .infinity, minHeight: 26)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 5)
-                                        .fill(selected ? TF.settingsNavActive : .clear)
-                                )
-                                .contentShape(Rectangle())
+                SettingsInlineSegmentedPicker(
+                    selection: Binding(
+                        get: { hotkeyStyle.rawValue },
+                        set: { raw in
+                            if let s = ProcessingMode.HotkeyStyle(rawValue: raw) {
+                                hotkeyStyle = s
+                            }
                         }
-                        .buttonStyle(.plain)
-                    }
-                }
-                .padding(2)
-                .background(
-                    RoundedRectangle(cornerRadius: 7)
-                        .fill(TF.settingsBg)
+                    ),
+                    options: [
+                        (ProcessingMode.HotkeyStyle.hold.rawValue, L("按住录制", "Hold to record")),
+                        (ProcessingMode.HotkeyStyle.toggle.rawValue, L("按下切换", "Toggle")),
+                    ]
                 )
             }
 

--- a/Type4Me/UI/Settings/SettingsCardHelpers.swift
+++ b/Type4Me/UI/Settings/SettingsCardHelpers.swift
@@ -1,53 +1,158 @@
 import SwiftUI
 
-// MARK: - Shared Settings Tooltip
+// MARK: - Shared Settings Fluid Tooltip (Design System Standard)
 
-/// Immediate black tooltip used by icon-only controls throughout Settings.
-/// Keeping this separate from SwiftUI's delayed `.help` modifier makes the
-/// interaction consistent across the Vocabulary and History pages.
+/// Standard tooltip placement relative to the trigger.
+enum SettingsTooltipPlacement: Sendable {
+    case top
+    case bottom
+}
+
+/// Standard fluid tooltip bubble used across Type4Me settings.
+/// Complies with Transitions.dev open/close specification:
+/// - 80ms hover entrance delay (prevents accidental trigger while sweeping cursor)
+/// - 150ms ease-out entrance with 0.98 scale transition anchored at boundary
+/// - 0ms exit delay with instant 50ms ease-out exit transition
+/// - Clean card surface (TF.settingsCard, 1px subtle stroke, soft ambient and contact drop shadow)
+/// - Respects accessibilityReduceMotion
 struct SettingsTooltipBubble: View {
     let text: String
 
     var body: some View {
         Text(text)
-            .font(.system(size: 11, weight: .semibold))
-            .foregroundStyle(.white)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(TF.settingsText)
             .lineLimit(1)
-            .padding(.horizontal, 12)
-            .frame(height: 34)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
             .background(
-                RoundedRectangle(cornerRadius: 9, style: .continuous)
-                    .fill(Color.black.opacity(0.92))
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(TF.settingsCard)
             )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color.black.opacity(0.06), lineWidth: 1)
+            )
+            .shadow(color: Color.black.opacity(0.05), radius: 3, x: 0, y: 2)
+            .shadow(color: Color.black.opacity(0.06), radius: 16, x: 0, y: 4)
             .fixedSize(horizontal: true, vertical: false)
             .allowsHitTesting(false)
     }
 }
 
-private struct SettingsTooltipModifier: ViewModifier {
+private struct SettingsTooltipHeightPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 28
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+private struct SettingsFluidTooltipModifier: ViewModifier {
     let text: String
+    let placement: SettingsTooltipPlacement
     let isEnabled: Bool
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isHovered = false
+    @State private var isPresented = false
+    @State private var isVisible = false
+    @State private var hoverToken = 0
+    @State private var tooltipHeight: CGFloat = 28
 
     func body(content: Content) -> some View {
         content
-            .overlay(alignment: .top) {
-                if isHovered && isEnabled {
+            .overlay(alignment: overlayAlignment) {
+                if isVisible {
                     SettingsTooltipBubble(text: text)
-                        .offset(y: 40)
-                        .transition(.opacity.combined(with: .scale(scale: 0.97, anchor: .top)))
+                        .background(
+                            GeometryReader { geo in
+                                Color.clear.preference(
+                                    key: SettingsTooltipHeightPreferenceKey.self,
+                                    value: geo.size.height
+                                )
+                            }
+                        )
+                        .onPreferenceChange(SettingsTooltipHeightPreferenceKey.self) { height in
+                            if height > 0 { tooltipHeight = height }
+                        }
+                        .offset(y: verticalOffset)
+                        .scaleEffect(reduceMotion ? 1.0 : (isPresented ? 1.0 : 0.98), anchor: scaleAnchor)
+                        .opacity(isPresented ? 1.0 : 0.0)
+                        .allowsHitTesting(false)
                 }
             }
-            .zIndex(isHovered && isEnabled ? 30 : 0)
-            .onHover { isHovered = $0 }
-            .animation(.easeOut(duration: 0.08), value: isHovered)
+            .zIndex(isVisible ? 100 : 0)
+            .onHover { hovering in
+                guard isEnabled else { return }
+                handleHover(hovering)
+            }
+    }
+
+    private var overlayAlignment: Alignment {
+        switch placement {
+        case .top: return .top
+        case .bottom: return .bottom
+        }
+    }
+
+    private var verticalOffset: CGFloat {
+        switch placement {
+        case .top: return -(tooltipHeight + 8)
+        case .bottom: return tooltipHeight + 8
+        }
+    }
+
+    private var scaleAnchor: UnitPoint {
+        switch placement {
+        case .top: return .bottom
+        case .bottom: return .top
+        }
+    }
+
+    private func handleHover(_ hovering: Bool) {
+        hoverToken += 1
+        let currentToken = hoverToken
+
+        if hovering {
+            isHovered = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { // 80ms delay
+                guard currentToken == hoverToken, isHovered else { return }
+                isVisible = true
+                withAnimation(reduceMotion ? .easeInOut(duration: 0.15) : .easeOut(duration: 0.15)) {
+                    isPresented = true
+                }
+            }
+        } else {
+            isHovered = false
+            // 0ms delay on exit, 50ms easeOut animation
+            withAnimation(reduceMotion ? .easeInOut(duration: 0.05) : .easeOut(duration: 0.05)) {
+                isPresented = false
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                guard currentToken == hoverToken, !isHovered else { return }
+                isVisible = false
+            }
+        }
     }
 }
 
 extension View {
-    func settingsTooltip(_ text: String, isEnabled: Bool = true) -> some View {
-        modifier(SettingsTooltipModifier(text: text, isEnabled: isEnabled))
+    /// Standard Settings Tooltip modifier with Apple-grade fluid animation.
+    func settingsTooltip(
+        _ text: String,
+        placement: SettingsTooltipPlacement = .top,
+        isEnabled: Bool = true
+    ) -> some View {
+        modifier(SettingsFluidTooltipModifier(text: text, placement: placement, isEnabled: isEnabled))
+    }
+
+    /// Alias for `settingsTooltip`.
+    func fluidTooltip(
+        _ text: String,
+        placement: SettingsTooltipPlacement = .top,
+        isEnabled: Bool = true
+    ) -> some View {
+        settingsTooltip(text, placement: placement, isEnabled: isEnabled)
     }
 }
 

--- a/Type4Me/UI/Settings/SettingsCardHelpers.swift
+++ b/Type4Me/UI/Settings/SettingsCardHelpers.swift
@@ -100,8 +100,8 @@ struct SettingsTooltipBubble: View {
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .stroke(Color.black.opacity(0.06), lineWidth: 1)
             )
-            .shadow(color: Color.black.opacity(0.05), radius: 3, x: 0, y: 2)
-            .shadow(color: Color.black.opacity(0.06), radius: 16, x: 0, y: 4)
+            .shadow(color: Color.black.opacity(0.03), radius: 2, x: 0, y: 1)
+            .shadow(color: Color.black.opacity(0.03), radius: 8, x: 0, y: 2)
             .fixedSize(horizontal: true, vertical: false)
             .allowsHitTesting(false)
     }
@@ -262,6 +262,7 @@ protocol SettingsCardHelpers {}
 
 enum SettingsControlWidth {
     static let toggle: CGFloat = 52
+    static let inlineSegmented: CGFloat = 140
     static let standard: CGFloat = 240
     static let provider: CGFloat = 320
     static let input: CGFloat = 360
@@ -359,10 +360,12 @@ extension SettingsCardHelpers {
         _ label: String,
         subtitle: String? = nil,
         controlWidth: CGFloat = SettingsControlWidth.standard,
+        isIndented: Bool = false,
         @ViewBuilder control: () -> Control
     ) -> some View {
         SettingsOptionRowLayout(controlWidth: controlWidth) {
             settingsOptionLabel(label, subtitle: subtitle)
+                .padding(.leading, isIndented ? 18 : 0)
             control()
                 .frame(maxWidth: .infinity, alignment: .trailing)
         }
@@ -372,12 +375,14 @@ extension SettingsCardHelpers {
         _ label: String,
         subtitle: String? = nil,
         isOn: Binding<Bool>,
-        isEnabled: Bool = true
+        isEnabled: Bool = true,
+        isIndented: Bool = false
     ) -> some View {
         settingsOptionRow(
             label,
             subtitle: subtitle,
-            controlWidth: SettingsControlWidth.toggle
+            controlWidth: SettingsControlWidth.toggle,
+            isIndented: isIndented
         ) {
             Toggle("", isOn: isOn)
                 .labelsHidden()
@@ -386,6 +391,7 @@ extension SettingsCardHelpers {
                 .tint(.black)
                 .disabled(!isEnabled)
         }
+        .opacity(isEnabled ? 1.0 : 0.45)
     }
 
     private func settingsOptionLabel(_ label: String, subtitle: String?) -> some View {
@@ -577,6 +583,14 @@ extension SettingsCardHelpers {
         )
     }
 
+    /// Compact Apple-style inline segmented picker for 2 (or few) options in a settings option row.
+    func settingsInlineSegmentedPicker(
+        selection: Binding<String>,
+        options: [(value: String, label: String)]
+    ) -> some View {
+        SettingsInlineSegmentedPicker(selection: selection, options: options)
+    }
+
     func primaryButton(_ title: String, action: @escaping () -> Void) -> some View {
         Button(title, action: action)
             .buttonStyle(.plain)
@@ -667,4 +681,80 @@ extension SettingsCardHelpers {
         return "\(prefix)••••\(suffix)"
     }
 
+}
+
+/// Apple-grade inline segmented capsule picker with smooth matched-geometry sliding spring pill.
+struct SettingsInlineSegmentedPicker: View {
+    @Binding var selection: String
+    let options: [(value: String, label: String)]
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Namespace private var selectionNamespace
+    @State private var hoveredValue: String?
+
+    var body: some View {
+        HStack(spacing: 2) {
+            ForEach(options, id: \.value) { option in
+                let isSelected = selection == option.value
+                let isHovered = hoveredValue == option.value
+
+                Button {
+                    guard selection != option.value else { return }
+                    if reduceMotion {
+                        selection = option.value
+                    } else {
+                        withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
+                            selection = option.value
+                        }
+                    }
+                } label: {
+                    Text(option.label)
+                        .font(.system(size: 11, weight: isSelected ? .semibold : .medium))
+                        .foregroundStyle(isSelected ? TF.settingsText : TF.settingsTextSecondary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 5)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(SettingsSegmentedButtonStyle())
+                .background {
+                    ZStack {
+                        if isSelected {
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(Color.white)
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                        .strokeBorder(Color.black.opacity(0.04), lineWidth: 0.5)
+                                }
+                                .shadow(color: Color.black.opacity(0.08), radius: 2, x: 0, y: 1)
+                                .matchedGeometryEffect(id: "selected_segment_pill", in: selectionNamespace)
+                        } else if isHovered {
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(Color.black.opacity(0.04))
+                        }
+                    }
+                }
+                .onHover { hovering in
+                    hoveredValue = hovering ? option.value : nil
+                }
+            }
+        }
+        .padding(2)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(TF.settingsCardAlt)
+        )
+        .animation(
+            reduceMotion ? .easeInOut(duration: 0.15) : .spring(response: 0.28, dampingFraction: 0.82),
+            value: selection
+        )
+        .fixedSize(horizontal: true, vertical: false)
+    }
+}
+
+private struct SettingsSegmentedButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.96 : 1.0)
+            .animation(.spring(response: 0.18, dampingFraction: 0.8), value: configuration.isPressed)
+    }
 }

--- a/Type4Me/UI/Settings/SettingsCardHelpers.swift
+++ b/Type4Me/UI/Settings/SettingsCardHelpers.swift
@@ -8,6 +8,26 @@ enum SettingsTooltipPlacement: Sendable {
     case bottom
 }
 
+/// Identifies which window hosts a tooltip, so the process-wide coordinator never
+/// renders a Settings-relative bubble inside another window (and vice versa).
+enum SettingsTooltipHostScope: String, Sendable, Equatable {
+    case settings
+    case selectionAsk
+
+    var coordinateSpaceName: String { "TooltipHostCoordinateSpace.\(rawValue)" }
+}
+
+private struct SettingsTooltipHostScopeKey: EnvironmentKey {
+    static let defaultValue: SettingsTooltipHostScope = .settings
+}
+
+extension EnvironmentValues {
+    var settingsTooltipHostScope: SettingsTooltipHostScope {
+        get { self[SettingsTooltipHostScopeKey.self] }
+        set { self[SettingsTooltipHostScopeKey.self] = newValue }
+    }
+}
+
 /// Global coordinator for rendering tooltips at the root window layer.
 /// This completely decouples tooltips from child view hierarchies and prevents
 /// them from ever being clipped by parent ScrollViews, cards, or `.clipShape()` containers.
@@ -18,6 +38,7 @@ final class SettingsTooltipCoordinator {
 
     struct TooltipState: Equatable {
         let id: UUID
+        let scope: SettingsTooltipHostScope
         let text: String
         var targetRect: CGRect
         let placement: SettingsTooltipPlacement
@@ -30,7 +51,13 @@ final class SettingsTooltipCoordinator {
     private var hideTask: Task<Void, Never>?
     private var currentHoverID: UUID?
 
-    func show(id: UUID, text: String, targetRect: CGRect, placement: SettingsTooltipPlacement) {
+    func show(
+        id: UUID,
+        scope: SettingsTooltipHostScope,
+        text: String,
+        targetRect: CGRect,
+        placement: SettingsTooltipPlacement
+    ) {
         currentHoverID = id
         hideTask?.cancel()
         hideTask = nil
@@ -41,6 +68,7 @@ final class SettingsTooltipCoordinator {
             guard !Task.isCancelled, currentHoverID == id else { return }
             activeTooltip = TooltipState(
                 id: id,
+                scope: scope,
                 text: text,
                 targetRect: targetRect,
                 placement: placement
@@ -57,9 +85,11 @@ final class SettingsTooltipCoordinator {
     }
 
     func hide(id: UUID) {
-        if currentHoverID == id {
-            currentHoverID = nil
-        }
+        // A hover-enter for another trigger can arrive before this trigger's
+        // hover-exit. Ignore the stale exit so it cannot cancel the new owner's
+        // pending show and strand `activeTooltip` with `isPresented == false`.
+        guard currentHoverID == id || currentHoverID == nil else { return }
+        currentHoverID = nil
         showTask?.cancel()
         showTask = nil
 
@@ -109,12 +139,18 @@ struct SettingsTooltipBubble: View {
 
 /// Root host overlay mounted at the top-level window layer.
 struct SettingsTooltipRootHost: View {
+    let scope: SettingsTooltipHostScope
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private let coordinator = SettingsTooltipCoordinator.shared
 
+    init(scope: SettingsTooltipHostScope = .settings) {
+        self.scope = scope
+    }
+
     var body: some View {
         GeometryReader { windowGeo in
-            if let tooltip = coordinator.activeTooltip {
+            if let tooltip = coordinator.activeTooltip, tooltip.scope == scope {
                 SettingsTooltipBubble(text: tooltip.text)
                     .scaleEffect(
                         reduceMotion ? 1.0 : (coordinator.isPresented ? 1.0 : 0.98),
@@ -173,6 +209,7 @@ private struct SettingsFluidTooltipModifier: ViewModifier {
     let placement: SettingsTooltipPlacement
     let isEnabled: Bool
 
+    @Environment(\.settingsTooltipHostScope) private var scope
     @State private var id = UUID()
     @State private var isHovered = false
 
@@ -184,10 +221,11 @@ private struct SettingsFluidTooltipModifier: ViewModifier {
                         .onChange(of: isHovered) { _, hovering in
                             guard isEnabled else { return }
                             if hovering {
-                                let frame = geo.frame(in: .named("SettingsWindowCoordinateSpace"))
+                                let frame = geo.frame(in: .named(scope.coordinateSpaceName))
                                 if frame.width > 0 && frame.height > 0 {
                                     SettingsTooltipCoordinator.shared.show(
                                         id: id,
+                                        scope: scope,
                                         text: text,
                                         targetRect: frame,
                                         placement: placement
@@ -197,7 +235,7 @@ private struct SettingsFluidTooltipModifier: ViewModifier {
                                 SettingsTooltipCoordinator.shared.hide(id: id)
                             }
                         }
-                        .onChange(of: geo.frame(in: .named("SettingsWindowCoordinateSpace"))) { _, newFrame in
+                        .onChange(of: geo.frame(in: .named(scope.coordinateSpaceName))) { _, newFrame in
                             if isHovered && isEnabled && newFrame.width > 0 {
                                 SettingsTooltipCoordinator.shared.updateTargetRect(id: id, targetRect: newFrame)
                             }
@@ -215,6 +253,14 @@ private struct SettingsFluidTooltipModifier: ViewModifier {
 }
 
 extension View {
+    /// Mounts a window-level tooltip host and scopes every `settingsTooltip` in the
+    /// subtree to it, so concurrently visible windows never render each other's bubbles.
+    func settingsTooltipHost(_ scope: SettingsTooltipHostScope) -> some View {
+        coordinateSpace(name: scope.coordinateSpaceName)
+            .overlay { SettingsTooltipRootHost(scope: scope) }
+            .environment(\.settingsTooltipHostScope, scope)
+    }
+
     /// Standard Settings Tooltip modifier with Apple-grade fluid animation and zero-clipping window-level host.
     func settingsTooltip(
         _ text: String,

--- a/Type4Me/UI/Settings/SettingsCardHelpers.swift
+++ b/Type4Me/UI/Settings/SettingsCardHelpers.swift
@@ -8,6 +8,73 @@ enum SettingsTooltipPlacement: Sendable {
     case bottom
 }
 
+/// Global coordinator for rendering tooltips at the root window layer.
+/// This completely decouples tooltips from child view hierarchies and prevents
+/// them from ever being clipped by parent ScrollViews, cards, or `.clipShape()` containers.
+@MainActor
+@Observable
+final class SettingsTooltipCoordinator {
+    static let shared = SettingsTooltipCoordinator()
+
+    struct TooltipState: Equatable {
+        let id: UUID
+        let text: String
+        var targetRect: CGRect
+        let placement: SettingsTooltipPlacement
+    }
+
+    var activeTooltip: TooltipState?
+    var isPresented: Bool = false
+
+    private var showTask: Task<Void, Never>?
+    private var hideTask: Task<Void, Never>?
+    private var currentHoverID: UUID?
+
+    func show(id: UUID, text: String, targetRect: CGRect, placement: SettingsTooltipPlacement) {
+        currentHoverID = id
+        hideTask?.cancel()
+        hideTask = nil
+
+        showTask?.cancel()
+        showTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 80_000_000) // 80ms delay
+            guard !Task.isCancelled, currentHoverID == id else { return }
+            activeTooltip = TooltipState(
+                id: id,
+                text: text,
+                targetRect: targetRect,
+                placement: placement
+            )
+            withAnimation(.easeOut(duration: 0.15)) {
+                isPresented = true
+            }
+        }
+    }
+
+    func updateTargetRect(id: UUID, targetRect: CGRect) {
+        guard activeTooltip?.id == id else { return }
+        activeTooltip?.targetRect = targetRect
+    }
+
+    func hide(id: UUID) {
+        if currentHoverID == id {
+            currentHoverID = nil
+        }
+        showTask?.cancel()
+        showTask = nil
+
+        hideTask?.cancel()
+        hideTask = Task { @MainActor in
+            withAnimation(.easeOut(duration: 0.05)) {
+                isPresented = false
+            }
+            try? await Task.sleep(nanoseconds: 50_000_000) // 50ms exit
+            guard !Task.isCancelled, currentHoverID == nil else { return }
+            activeTooltip = nil
+        }
+    }
+}
+
 /// Standard fluid tooltip bubble used across Type4Me settings.
 /// Complies with Transitions.dev open/close specification:
 /// - 80ms hover entrance delay (prevents accidental trigger while sweeping cursor)
@@ -40,10 +107,64 @@ struct SettingsTooltipBubble: View {
     }
 }
 
-private struct SettingsTooltipHeightPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat = 28
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
+/// Root host overlay mounted at the top-level window layer.
+struct SettingsTooltipRootHost: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private let coordinator = SettingsTooltipCoordinator.shared
+
+    var body: some View {
+        GeometryReader { windowGeo in
+            if let tooltip = coordinator.activeTooltip {
+                SettingsTooltipBubble(text: tooltip.text)
+                    .scaleEffect(
+                        reduceMotion ? 1.0 : (coordinator.isPresented ? 1.0 : 0.98),
+                        anchor: scaleAnchor(for: tooltip.placement)
+                    )
+                    .opacity(coordinator.isPresented ? 1.0 : 0.0)
+                    .position(calculatedPosition(for: tooltip, in: windowGeo.size))
+                    .allowsHitTesting(false)
+            }
+        }
+        .allowsHitTesting(false)
+    }
+
+    private func scaleAnchor(for placement: SettingsTooltipPlacement) -> UnitPoint {
+        switch placement {
+        case .top: return .bottom
+        case .bottom: return .top
+        }
+    }
+
+    private func calculatedPosition(
+        for tooltip: SettingsTooltipCoordinator.TooltipState,
+        in windowSize: CGSize
+    ) -> CGPoint {
+        let target = tooltip.targetRect
+        let bubbleHeight: CGFloat = 28
+        let gap: CGFloat = 8
+
+        var y: CGFloat
+        switch tooltip.placement {
+        case .top:
+            y = target.minY - gap - (bubbleHeight / 2)
+            // Auto flip to bottom if clipped by window top
+            if y - (bubbleHeight / 2) < 8 {
+                y = target.maxY + gap + (bubbleHeight / 2)
+            }
+        case .bottom:
+            y = target.maxY + gap + (bubbleHeight / 2)
+            // Auto flip to top if clipped by window bottom
+            if y + (bubbleHeight / 2) > windowSize.height - 8 {
+                y = target.minY - gap - (bubbleHeight / 2)
+            }
+        }
+
+        var x = target.midX
+        let minX: CGFloat = 50
+        let maxX: CGFloat = max(minX, windowSize.width - 50)
+        x = min(max(x, minX), maxX)
+
+        return CGPoint(x: x, y: y)
     }
 }
 
@@ -52,92 +173,49 @@ private struct SettingsFluidTooltipModifier: ViewModifier {
     let placement: SettingsTooltipPlacement
     let isEnabled: Bool
 
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var id = UUID()
     @State private var isHovered = false
-    @State private var isPresented = false
-    @State private var isVisible = false
-    @State private var hoverToken = 0
-    @State private var tooltipHeight: CGFloat = 28
 
     func body(content: Content) -> some View {
         content
-            .overlay(alignment: overlayAlignment) {
-                if isVisible {
-                    SettingsTooltipBubble(text: text)
-                        .background(
-                            GeometryReader { geo in
-                                Color.clear.preference(
-                                    key: SettingsTooltipHeightPreferenceKey.self,
-                                    value: geo.size.height
-                                )
+            .background(
+                GeometryReader { geo in
+                    Color.clear
+                        .onChange(of: isHovered) { _, hovering in
+                            guard isEnabled else { return }
+                            if hovering {
+                                let frame = geo.frame(in: .named("SettingsWindowCoordinateSpace"))
+                                if frame.width > 0 && frame.height > 0 {
+                                    SettingsTooltipCoordinator.shared.show(
+                                        id: id,
+                                        text: text,
+                                        targetRect: frame,
+                                        placement: placement
+                                    )
+                                }
+                            } else {
+                                SettingsTooltipCoordinator.shared.hide(id: id)
                             }
-                        )
-                        .onPreferenceChange(SettingsTooltipHeightPreferenceKey.self) { height in
-                            if height > 0 { tooltipHeight = height }
                         }
-                        .offset(y: verticalOffset)
-                        .scaleEffect(reduceMotion ? 1.0 : (isPresented ? 1.0 : 0.98), anchor: scaleAnchor)
-                        .opacity(isPresented ? 1.0 : 0.0)
-                        .allowsHitTesting(false)
+                        .onChange(of: geo.frame(in: .named("SettingsWindowCoordinateSpace"))) { _, newFrame in
+                            if isHovered && isEnabled && newFrame.width > 0 {
+                                SettingsTooltipCoordinator.shared.updateTargetRect(id: id, targetRect: newFrame)
+                            }
+                        }
                 }
-            }
-            .zIndex(isVisible ? 100 : 0)
+            )
             .onHover { hovering in
                 guard isEnabled else { return }
-                handleHover(hovering)
+                isHovered = hovering
             }
-    }
-
-    private var overlayAlignment: Alignment {
-        switch placement {
-        case .top: return .top
-        case .bottom: return .bottom
-        }
-    }
-
-    private var verticalOffset: CGFloat {
-        switch placement {
-        case .top: return -(tooltipHeight + 8)
-        case .bottom: return tooltipHeight + 8
-        }
-    }
-
-    private var scaleAnchor: UnitPoint {
-        switch placement {
-        case .top: return .bottom
-        case .bottom: return .top
-        }
-    }
-
-    private func handleHover(_ hovering: Bool) {
-        hoverToken += 1
-        let currentToken = hoverToken
-
-        if hovering {
-            isHovered = true
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { // 80ms delay
-                guard currentToken == hoverToken, isHovered else { return }
-                isVisible = true
-                withAnimation(reduceMotion ? .easeInOut(duration: 0.15) : .easeOut(duration: 0.15)) {
-                    isPresented = true
-                }
+            .onDisappear {
+                SettingsTooltipCoordinator.shared.hide(id: id)
             }
-        } else {
-            isHovered = false
-            // 0ms delay on exit, 50ms easeOut animation
-            withAnimation(reduceMotion ? .easeInOut(duration: 0.05) : .easeOut(duration: 0.05)) {
-                isPresented = false
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                guard currentToken == hoverToken, !isHovered else { return }
-                isVisible = false
-            }
-        }
     }
 }
 
 extension View {
-    /// Standard Settings Tooltip modifier with Apple-grade fluid animation.
+    /// Standard Settings Tooltip modifier with Apple-grade fluid animation and zero-clipping window-level host.
     func settingsTooltip(
         _ text: String,
         placement: SettingsTooltipPlacement = .top,

--- a/Type4Me/UI/Settings/SettingsView.swift
+++ b/Type4Me/UI/Settings/SettingsView.swift
@@ -346,7 +346,7 @@ struct SettingsView: View {
                     )
             )
         }
-        .buttonStyle(.plain)
+        .buttonStyle(SidebarNavButtonStyle())
         .onHover { isHovering in
             withAnimation(.easeOut(duration: 0.12)) {
                 hoveredTab = isHovering ? tab : nil
@@ -930,5 +930,13 @@ struct SettingsDivider: View {
         Rectangle()
             .fill(Color.black.opacity(0.045))
             .frame(height: 1)
+    }
+}
+
+private struct SidebarNavButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.985 : 1.0)
+            .animation(.spring(response: 0.16, dampingFraction: 0.8), value: configuration.isPressed)
     }
 }

--- a/Type4Me/UI/Settings/SettingsView.swift
+++ b/Type4Me/UI/Settings/SettingsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 // MARK: - Navigation Item
 
-enum SettingsTab: String, CaseIterable, Identifiable {
+enum SettingsTab: String, CaseIterable, Identifiable, Hashable {
     case general
     case askAnything
     case models
@@ -109,7 +109,6 @@ struct SettingsView: View {
     @Environment(AppState.self) private var appState
     @Environment(AppNavigationModel.self) private var navigationModel
     @State private var hoveredTab: SettingsTab?
-    @State private var hoveredSettingsTab: SettingsTab?
     @State private var draftCoordinator = SettingsDraftCoordinator()
     @State private var windowBox = WeakSettingsWindowBox()
     @State private var pendingTransition: PendingTransition?
@@ -317,6 +316,13 @@ struct SettingsView: View {
                     .font(.system(size: 14, weight: isActive ? .semibold : .medium))
                     .foregroundStyle(TF.settingsText)
                 Spacer()
+                if tab == .preferences {
+                    Text(AppBuildInfo.current.compactLabel)
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .monospacedDigit()
+                        .foregroundStyle(TF.settingsTextTertiary)
+                        .lineLimit(1)
+                }
                 if showBadge {
                     Circle()
                         .fill(.red)
@@ -356,27 +362,11 @@ struct SettingsView: View {
     }
 
     private var settingsSectionPicker: some View {
-        HStack(spacing: 2) {
-            ForEach(settingsSubtabs) { tab in
-                settingsSectionButton(tab)
-            }
-        }
-        .padding(4)
-        .background(
-            Capsule()
-                .fill(TF.settingsControl)
-        )
-        .fixedSize()
-        .padding(.bottom, 24)
-    }
-
-    private func settingsSectionButton(_ tab: SettingsTab) -> some View {
-        let isSelected = selectedTab == tab
-        let isHovered = hoveredSettingsTab == tab
-
-        return Button {
-            requestNavigation(to: tab)
-        } label: {
+        LiquidGlassTabPicker(
+            items: settingsSubtabs,
+            selection: selectedTab,
+            onSelectionChange: { requestNavigation(to: $0) }
+        ) { tab, isSelected, _ in
             HStack(spacing: 6) {
                 Image(systemName: tab.icon)
                     .font(.system(size: 10, weight: .semibold))
@@ -391,32 +381,9 @@ struct SettingsView: View {
             .foregroundStyle(isSelected ? TF.settingsText : TF.settingsTextSecondary)
             .padding(.horizontal, 16)
             .frame(height: 32)
-            .background(
-                Capsule().fill(
-                    isSelected
-                        ? Color.white
-                        : (isHovered
-                           ? TF.settingsControlHover
-                           : Color.clear)
-                )
-            )
-            .contentShape(Capsule())
         }
-        .buttonStyle(.plain)
-        // Keep the selection-pill animation local to this control. Wrapping
-        // the navigation mutation in `withAnimation` animated the whole
-        // settings page replacement, including its otherwise unchanged header.
-        .animation(.easeInOut(duration: 0.16), value: isSelected)
-        .onHover { hovering in
-            withAnimation(.easeOut(duration: 0.12)) {
-                hoveredSettingsTab = hovering ? tab : nil
-            }
-            if hovering {
-                NSCursor.pointingHand.set()
-            } else {
-                NSCursor.arrow.set()
-            }
-        }
+        .fixedSize()
+        .padding(.bottom, 24)
     }
 
     private var settingsHubHeader: some View {

--- a/Type4Me/UI/Settings/SettingsView.swift
+++ b/Type4Me/UI/Settings/SettingsView.swift
@@ -153,10 +153,7 @@ struct SettingsView: View {
         }
         .id(language)
         .frame(minWidth: 900, minHeight: 600)
-        .coordinateSpace(name: "SettingsWindowCoordinateSpace")
-        .overlay {
-            SettingsTooltipRootHost()
-        }
+        .settingsTooltipHost(.settings)
         .background(SettingsWindowConfigurator(
             windowBox: windowBox,
             onVisibilityChanged: { isVisible in

--- a/Type4Me/UI/Settings/SettingsView.swift
+++ b/Type4Me/UI/Settings/SettingsView.swift
@@ -153,6 +153,10 @@ struct SettingsView: View {
         }
         .id(language)
         .frame(minWidth: 900, minHeight: 600)
+        .coordinateSpace(name: "SettingsWindowCoordinateSpace")
+        .overlay {
+            SettingsTooltipRootHost()
+        }
         .background(SettingsWindowConfigurator(
             windowBox: windowBox,
             onVisibilityChanged: { isVisible in

--- a/Type4Me/UI/Settings/VocabularyTab.swift
+++ b/Type4Me/UI/Settings/VocabularyTab.swift
@@ -762,7 +762,7 @@ struct VocabularyTab: View {
                 .contentShape(Circle())
         }
         .buttonStyle(.plain)
-        .help(help)
+        .settingsTooltip(help)
     }
 
     // MARK: - Snippet Group View

--- a/Type4Me/UI/Settings/VocabularyTab.swift
+++ b/Type4Me/UI/Settings/VocabularyTab.swift
@@ -145,7 +145,6 @@ struct VocabularyTab: View {
     }
 
     @State private var selectedSection: VocabularySection = .hotwords
-    @State private var hoveredSection: VocabularySection?
     @State private var isSearchExpanded = false
     @State private var searchQuery = ""
     @FocusState private var isSearchFocused: Bool
@@ -169,7 +168,6 @@ struct VocabularyTab: View {
     @State private var newSnippetTriggers: [String] = []
     @State private var newValue: String = ""
     @State private var hoveredSnippetGroup: String? = nil
-    @State private var hoveredAppScopeKey: String? = nil
     @State private var isAddAppHovered = false
     @State private var showBulkSnippetsSheet = false
     @State private var bulkSnippetsText = ""
@@ -311,63 +309,18 @@ struct VocabularyTab: View {
     // MARK: - Primary Section Tabs
 
     private var vocabularySectionPicker: some View {
-        HStack(spacing: 2) {
-            vocabularySectionButton(
-                .hotwords,
-                title: L("ASR 热词", "ASR Hotwords")
-            )
-            vocabularySectionButton(
-                .snippets,
-                title: L("片段替换", "Snippets")
-            )
-        }
-        .padding(4)
-        .background(
-            Capsule()
-                .fill(TF.settingsControl)
-        )
-        .fixedSize()
-    }
-
-    private func vocabularySectionButton(
-        _ section: VocabularySection,
-        title: String
-    ) -> some View {
-        let isSelected = selectedSection == section
-        let isHovered = hoveredSection == section
-
-        return Button {
-            withAnimation(.easeInOut(duration: 0.16)) {
-                selectedSection = section
-            }
-        } label: {
-            Text(title)
+        LiquidGlassTabPicker(
+            items: [.hotwords, .snippets],
+            selection: selectedSection,
+            onSelectionChange: { selectedSection = $0 }
+        ) { section, isSelected, _ in
+            Text(section == .hotwords ? L("ASR 热词", "ASR Hotwords") : L("片段替换", "Snippets"))
                 .font(.system(size: 12, weight: isSelected ? .semibold : .medium))
                 .foregroundStyle(isSelected ? TF.settingsText : TF.settingsTextSecondary)
                 .padding(.horizontal, 18)
                 .frame(height: 32)
-                .background(
-                    Capsule().fill(
-                        isSelected
-                            ? Color.white
-                            : (isHovered
-                               ? TF.settingsControlHover
-                               : Color.clear)
-                    )
-                )
-                .contentShape(Capsule())
         }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            withAnimation(.easeOut(duration: 0.12)) {
-                hoveredSection = hovering ? section : nil
-            }
-            if hovering {
-                NSCursor.pointingHand.set()
-            } else {
-                NSCursor.arrow.set()
-            }
-        }
+        .fixedSize()
     }
 
     private var vocabularySectionDescription: String {
@@ -1053,34 +1006,40 @@ struct VocabularyTab: View {
     private func appScopeBar() -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
-                HStack(spacing: 2) {
-                    appScopeTab(
-                        label: L("全局生效", "Global"),
-                        bundleId: nil,
-                        icon: nil,
-                        systemIcon: "globe"
-                    )
-
-                    ForEach(registeredApps) { app in
-                        appScopeTab(
-                            label: app.name,
-                            bundleId: app.bundleId,
-                            icon: appIcon(for: app.bundleId)
-                        )
-                        .contextMenu {
+                LiquidGlassTabPicker(
+                    items: appScopeBundleIDs,
+                    selection: selectedAppScope,
+                    onSelectionChange: switchScope(to:)
+                ) { bundleId, isSelected, _ in
+                    let app = bundleId.flatMap { id in
+                        registeredApps.first(where: { $0.bundleId == id })
+                    }
+                    HStack(spacing: 6) {
+                        if bundleId == nil {
+                            Image(systemName: "globe")
+                                .font(.system(size: 11, weight: .medium))
+                        } else if let bundleId, let icon = appIcon(for: bundleId) {
+                            Image(nsImage: icon)
+                                .resizable()
+                                .frame(width: 14, height: 14)
+                        }
+                        Text(app?.name ?? L("全局生效", "Global"))
+                            .font(.system(size: 12, weight: isSelected ? .semibold : .medium))
+                            .lineLimit(1)
+                    }
+                    .foregroundStyle(isSelected ? TF.settingsText : TF.settingsTextSecondary)
+                    .padding(.horizontal, 14)
+                    .frame(height: 30)
+                    .contextMenu {
+                        if let bundleId {
                             Button(role: .destructive) {
-                                removeAppScope(bundleId: app.bundleId)
+                                removeAppScope(bundleId: bundleId)
                             } label: {
                                 Label(L("移除", "Remove"), systemImage: "trash")
                             }
                         }
                     }
                 }
-                .padding(4)
-                .background(
-                    Capsule()
-                        .fill(TF.settingsControl)
-                )
 
                 Button { pickApp() } label: {
                     Image(systemName: "plus")
@@ -1126,57 +1085,8 @@ struct VocabularyTab: View {
         }
     }
 
-    private func appScopeTab(
-        label: String,
-        bundleId: String?,
-        icon: NSImage?,
-        systemIcon: String? = nil
-    ) -> some View {
-        let isSelected = selectedAppScope == bundleId
-        let scopeKey = bundleId ?? "__global__"
-        let isHovered = hoveredAppScopeKey == scopeKey
-
-        return Button {
-            switchScope(to: bundleId)
-        } label: {
-            HStack(spacing: 6) {
-                if let systemIcon {
-                    Image(systemName: systemIcon)
-                        .font(.system(size: 11, weight: .medium))
-                } else if let icon {
-                    Image(nsImage: icon)
-                        .resizable()
-                        .frame(width: 14, height: 14)
-                }
-                Text(label)
-                    .font(.system(size: 12, weight: isSelected ? .semibold : .medium))
-                    .lineLimit(1)
-            }
-            .foregroundStyle(isSelected ? TF.settingsText : TF.settingsTextSecondary)
-            .padding(.horizontal, 14)
-            .frame(height: 30)
-            .background(
-                Capsule().fill(
-                    isSelected
-                        ? Color.white
-                        : (isHovered
-                           ? TF.settingsControlHover
-                           : Color.clear)
-                )
-            )
-            .contentShape(Capsule())
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            withAnimation(.easeOut(duration: 0.1)) {
-                hoveredAppScopeKey = hovering ? scopeKey : nil
-            }
-            if hovering {
-                NSCursor.pointingHand.set()
-            } else {
-                NSCursor.arrow.set()
-            }
-        }
+    private var appScopeBundleIDs: [String?] {
+        [nil] + registeredApps.map { Optional($0.bundleId) }
     }
 
     private func appIcon(for bundleId: String) -> NSImage? {

--- a/Type4MeTests/AppBuildInfoTests.swift
+++ b/Type4MeTests/AppBuildInfoTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import Type4Me
+
+final class AppBuildInfoTests: XCTestCase {
+    func testCompactLabelUsesVersionAndBuildNumber() {
+        let info = AppBuildInfo(version: "2.3.0", buildNumber: "136")
+
+        XCTAssertEqual(info.compactLabel, "v2.3.0(136)")
+        XCTAssertEqual(info.debugLabel, "2.3.0 (136)")
+    }
+
+    func testMissingBundleValuesUseDisplaySafeFallbacks() {
+        let info = AppBuildInfo(infoDictionary: ["CFBundleVersion": ""])
+
+        XCTAssertEqual(info.version, "—")
+        XCTAssertEqual(info.buildNumber, "—")
+        XCTAssertEqual(info.compactLabel, "v—(—)")
+    }
+}

--- a/Type4MeTests/AppearancePreviewTests.swift
+++ b/Type4MeTests/AppearancePreviewTests.swift
@@ -4,10 +4,26 @@ import XCTest
 @MainActor
 final class AppearancePreviewTests: XCTestCase {
 
-    // MARK: - FloatingBarPresentation Override & Fallback Tests
+    func testRecordingTheme_allCases() {
+        XCTAssertEqual(RecordingTheme.allCases.count, 2)
+        XCTAssertEqual(RecordingTheme.dark.rawValue, "dark")
+        XCTAssertEqual(RecordingTheme.light.rawValue, "light")
+        XCTAssertEqual(RecordingTheme.storageKey, "tf_recordingTheme")
+        XCTAssertEqual(RecordingTheme.defaultValue, .dark)
+
+        XCTAssertEqual(RecordingTheme.dark.displayName, L("暗色", "Dark"))
+        XCTAssertEqual(RecordingTheme.light.displayName, L("明亮", "Light"))
+    }
+
+    func testRecordingIndicatorStyle_allCases() {
+        XCTAssertEqual(RecordingIndicatorStyle.allCases.count, 2)
+        XCTAssertEqual(RecordingIndicatorStyle.regular.displayName, L("常规", "Regular"))
+        XCTAssertEqual(RecordingIndicatorStyle.compact.displayName, L("紧凑", "Compact"))
+    }
 
     func testFloatingBarPresentationInit() {
         let presentation = FloatingBarPresentation(
+            theme: .light,
             indicatorStyle: .regular,
             visualStyle: .voiceWave,
             showsLiveTranscript: false,
@@ -19,6 +35,7 @@ final class AppearancePreviewTests: XCTestCase {
             showsModelName: true
         )
 
+        XCTAssertEqual(presentation.theme, .light)
         XCTAssertEqual(presentation.indicatorStyle, .regular)
         XCTAssertEqual(presentation.visualStyle, .voiceWave)
         XCTAssertFalse(presentation.showsLiveTranscript)
@@ -33,6 +50,7 @@ final class AppearancePreviewTests: XCTestCase {
 
     func testFloatingBarPresentation_defaults() {
         let presentation = FloatingBarPresentation()
+        XCTAssertEqual(presentation.theme, .dark)
         XCTAssertEqual(presentation.indicatorStyle, .regular)
         XCTAssertEqual(presentation.visualStyle, .siri)
         XCTAssertTrue(presentation.showsLiveTranscript)

--- a/Type4MeTests/ClipboardOutputPolicyTests.swift
+++ b/Type4MeTests/ClipboardOutputPolicyTests.swift
@@ -106,4 +106,32 @@ final class ClipboardOutputPolicyTests: XCTestCase {
             ClipboardOutputPolicy.cancelProcessed.rawValue
         )
     }
+
+    func testCancellationRetentionModeAndPolicyMapping() {
+        XCTAssertEqual(ClipboardOutputPolicy.alwaysCopy.cancellationMode, .processed)
+        XCTAssertEqual(ClipboardOutputPolicy.cancelProcessed.cancellationMode, .processed)
+        XCTAssertEqual(ClipboardOutputPolicy.cancelRawTranscript.cancellationMode, .raw)
+        XCTAssertEqual(ClipboardOutputPolicy.neverCopy.cancellationMode, .none)
+
+        XCTAssertEqual(
+            ClipboardOutputPolicy.policy(retainsNormal: true, cancellationMode: .processed),
+            .alwaysCopy
+        )
+        XCTAssertEqual(
+            ClipboardOutputPolicy.policy(retainsNormal: true, cancellationMode: .raw),
+            .alwaysCopy
+        )
+        XCTAssertEqual(
+            ClipboardOutputPolicy.policy(retainsNormal: false, cancellationMode: .processed),
+            .cancelProcessed
+        )
+        XCTAssertEqual(
+            ClipboardOutputPolicy.policy(retainsNormal: false, cancellationMode: .raw),
+            .cancelRawTranscript
+        )
+        XCTAssertEqual(
+            ClipboardOutputPolicy.policy(retainsNormal: false, cancellationMode: .none),
+            .neverCopy
+        )
+    }
 }


### PR DESCRIPTION
## Overview

Introduces a **Light recording theme** alongside the existing dark one, and rebuilds the floating indicator on native macOS behind-window material so both themes read as real frosted glass rather than a flat fill. Ships with a broader UI pass across the floating bar and Settings: a liquid glass tab picker, one unified fluid tooltip standard, inline segmented pickers, and a Thinking-state text swap animation.

<img width="956" height="524" alt="image" src="https://github.com/user-attachments/assets/63e0bd41-3d79-482f-a0e0-e48c6037dbf0" />

## Changes

- **Recording Theme (new)**: Added `RecordingTheme` (`dark` / `light`) persisted under `tf_recordingTheme`, defaulting to `dark` so existing installs are unchanged. Selectable from Settings > Appearance with live preview, and threaded through `FloatingBarView`, `CompactAudioIndicator`, `CompactLiveTranscriptRow`, `LiquidGlassText`, and `LiquidGlassCancelButton`. `FloatingBarPanel` reads the same key so the very first show already paints in the right theme.
- **Design Tokens**: Added the light palette (`floatingBackgroundLight` `#F6F6F8`, `floatingBorderLight` `#DADADE`, `floatingTextLight` `#1C1C1E`, `floatingTextSecondaryLight`) and two specular rim gradients (`recordingGlassRim`, `recordingLightGlassRim`) that pick up the material beneath instead of reading as a flat white rule.
- **Native Frosted Glass**: New `VisualEffectBlur` bridges `NSVisualEffectView` with `.hudWindow` material and `.behindWindow` blending, so the floating bar samples the desktop behind it and gains a genuine specular rim.
- **Liquid Glass Tab Picker**: New `LiquidGlassTabPicker` with a `matchedGeometryEffect` selection pill, spring physics, hover pill, and reduce-motion / reduce-transparency adaptations. The spring is scoped to the control via `.animation(_:value: selection)`, so switching tabs does not animate the whole page replacement.
- **Unified Fluid Tooltips**: Replaced the scattered per-view tooltips (including `HistoryFloatingTooltipController`, which spawned an NSPanel per hover) with a window-level `SettingsTooltipCoordinator`. Bubbles render in a root overlay host, so no parent ScrollView, card, or `.clipShape()` can clip them. One spec everywhere: 80ms hover delay, 150ms ease-out entrance, 50ms exit, reduce-motion aware. `TooltipState` carries a `SettingsTooltipHostScope` so the Settings window and the Selection Ask panel never render each other's bubbles.
- **Thinking States**: Added a text swap animation for the processing to done transition on the floating bar.
- **Settings Polish**: Added `settingsInlineSegmentedPicker` for inline three-way controls, a secondary tooltip hierarchy, and a light theme pass over the settings surfaces. New `AppBuildInfo` renders the version/build label next to the sidebar Settings item with safe fallbacks for test hosts, and fixes the sidebar button flicker.
- **Clipboard Retention**: Split the single four-state clipboard picker into a "keep on input" toggle plus a three-way cancellation retention control. `tf_clipboardOutputPolicy` and `ClipboardOutputPolicy` are untouched and the UI maps bidirectionally onto the existing four states, so there is no migration and old builds interoperate. The mapping is intentionally asymmetric: turning the toggle on resolves to `.alwaysCopy`, which already implies processed retention on cancel, so the cancellation control is disabled and dimmed in that state with a bilingual subtitle explaining the coupling.

## Verification

- `swift build` ✅
- All **963 automated tests** pass (958 XCTest + 5 Swift Testing, 0 failures, 2 skipped).
- Verified on a signed Dev App build (build 203): both themes against light and dark desktops, tooltip isolation with Settings and Selection Ask visible at once, tab switching with and without reduce motion, all four resolved clipboard states, and zh/en live switching across the floating bar, menu bar, and settings window.
