### PR TITLE
Refine floating bar glass appearance and spatial depth

### DIFF
--- a/Type4Me/Type4MeApp.swift
+++ b/Type4Me/Type4MeApp.swift
@@ -176,6 +176,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         CJKSpacingMode.migrateIfNeeded()
         ClipboardOutputPolicy.migrateIfNeeded()
         RecordingVisualStyle.migrateLegacyPreferenceIfNeeded()
+        RecordingGlassTuning.migrateLegacyPreferencesIfNeeded()
+        LiquidGlassOrb.prewarmRenderer()
 
         // Sync hotwords to Volcengine cloud table (async, non-blocking)
         VolcHotwordSyncManager.syncIfNeeded()

--- a/Type4Me/UI/DesignSystem.swift
+++ b/Type4Me/UI/DesignSystem.swift
@@ -124,12 +124,29 @@ enum TF {
     static let barHeight: CGFloat = 55
     static let barBottomOffset: CGFloat = 48
     static let floatingPanelShadowInset: CGFloat = 8
+    /// The floating panel disables AppKit's rectangular window shadow, so the
+    /// capsule needs its own shape-aware depth. Keep the ambient shadow inside
+    /// `floatingPanelShadowInset` to avoid clipping at the panel boundary.
+    static let recordingCapsuleRimWidth: CGFloat = 0.8
+    static let recordingCapsuleContactShadowRadius: CGFloat = 2
+    static let recordingCapsuleContactShadowYOffset: CGFloat = 1
+    static let recordingCapsuleAmbientShadowRadius: CGFloat = 7
+    static let recordingCapsuleAmbientShadowYOffset: CGFloat = 1
     static let recordingFinishControlSize: CGFloat = 45
     static let recordingCancelControlSize: CGFloat = 35
-    static let recordingLeadingInset: CGFloat = 5
-    static let recordingTrailingInset: CGFloat = 10
+    /// The regular recording row uses equal outer insets and equal control
+    /// slots. The cancel artwork remains smaller, but its slot mirrors the orb
+    /// so the middle text lane is truly centered when both controls are shown.
+    static let recordingLeadingInset: CGFloat = 8
+    static let recordingTrailingInset: CGFloat = 8
     static let recordingEdgeInset: CGFloat = recordingTrailingInset
     static let recordingControlGap: CGFloat = 8
+    static let recordingControlSlotSize: CGFloat = recordingFinishControlSize
+    static let recordingTranscriptFadeWidth: CGFloat = 14
+    /// Mirrors the orb-to-text gap and the text fade guard on the otherwise
+    /// empty trailing side of the one-button recording capsule.
+    static let recordingSingleButtonMirroredTextBuffer: CGFloat = recordingControlGap
+        + recordingTranscriptFadeWidth
     static let recordingTooltipGap: CGFloat = 5
     static let recordingTooltipMaxWidth: CGFloat = 180
     static let recordingCapsuleSpringResponse = 0.3
@@ -140,24 +157,23 @@ enum TF {
     )
     static let recordingTooltipOverhang: CGFloat = max(
         0,
-        recordingTooltipMaxWidth / 2 - recordingLeadingInset - recordingFinishControlSize / 2
+        recordingTooltipMaxWidth / 2 - recordingLeadingInset - recordingControlSlotSize / 2
     )
-    static let recordingChromeWidth: CGFloat = recordingFinishControlSize
-        + recordingCancelControlSize
-        + recordingLeadingInset
-        + recordingTrailingInset
+    static let recordingChromeWidth: CGFloat = recordingControlSlotSize * 2
+        + recordingEdgeInset * 2
         + recordingControlGap * 2
         + 16
-    static let recordingSingleButtonChromeWidth: CGFloat = recordingFinishControlSize
-        + recordingLeadingInset
-        + recordingTrailingInset
+    /// With no cancel button, reserve only the controls that actually exist.
+    /// The final 16pt is breathing room shared by the two outer edges.
+    static let recordingSingleButtonChromeWidth: CGFloat = recordingControlSlotSize
+        + recordingEdgeInset * 2
         + recordingControlGap
         + 16
+        + recordingSingleButtonMirroredTextBuffer
+    static let recordingSingleButtonMinimumWidth: CGFloat = barHeight * 2
 
     // MARK: Transcript Popup (hover preview above bar)
 
-    static let transcriptPopupWidth: CGFloat = 350
-    static let transcriptPopupMaxHeight: CGFloat = 120
     static let transcriptPopupCorner: CGFloat = cornerLG
     static let transcriptPopupGap: CGFloat = 10
 

--- a/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarPanel.swift
@@ -70,8 +70,12 @@ final class FloatingBarPanel: NSPanel {
 
     func updateAppearance() {
         let themeRaw = UserDefaults.standard.string(forKey: RecordingTheme.storageKey) ?? RecordingTheme.defaultValue.rawValue
-        let theme = RecordingTheme(rawValue: themeRaw) ?? .dark
-        appearance = theme == .light ? NSAppearance(named: .aqua) : NSAppearance(named: .darkAqua)
+        let theme = RecordingTheme(rawValue: themeRaw) ?? RecordingTheme.defaultValue
+        let solidHex = UserDefaults.standard.string(forKey: RecordingSolidColor.storageKey)
+            ?? RecordingSolidColor.defaultHex
+        let usesLightAppearance = theme.usesGlass
+            || RecordingSolidColor(hex: solidHex).usesDarkForeground
+        appearance = NSAppearance(named: usesLightAppearance ? .aqua : .darkAqua)
     }
 
     override var canBecomeKey: Bool { false }
@@ -114,6 +118,7 @@ final class FloatingBarController {
     private var anchorDisplayID: CGDirectDisplayID?
     private var panelGeneration = 0
     private var panelShrinkTask: Task<Void, Never>?
+    private var panelShowTask: Task<Void, Never>?
 
     init(state: AppState) {
         self.state = state
@@ -136,9 +141,36 @@ final class FloatingBarController {
 
         panel.contentView = hosting
         panel.setFrame(frame, display: false)
+        hosting.layoutSubtreeIfNeeded()
+
+        // Ordering the transparent, non-activating panel once gives AppKit,
+        // WindowServer, the glass compositor, and MTKView a chance to allocate
+        // their first resources before the user starts recording.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
+            self?.prewarmPanelCompositionIfIdle()
+        }
 
         state.onShowPanel = { [weak self] in self?.show() }
         state.onHidePanel = { [weak self] in self?.hide() }
+    }
+
+    private func prewarmPanelCompositionIfIdle() {
+        guard panelGeneration == 0,
+              state.barPhase == .hidden,
+              !panel.isVisible else { return }
+
+        panel.ignoresMouseEvents = true
+        panel.alphaValue = 0
+        panel.orderFrontRegardless()
+        panel.contentView?.layoutSubtreeIfNeeded()
+        panel.displayIfNeeded()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            guard let self,
+                  self.panelGeneration == 0,
+                  self.state.barPhase == .hidden else { return }
+            self.panel.orderOut(nil)
+        }
     }
 
     func updatePanelLayout(_ layout: FloatingBarPanelLayout) {
@@ -167,6 +199,8 @@ final class FloatingBarController {
 
     func show() {
         panelGeneration &+= 1
+        let expectedGeneration = panelGeneration
+        panelShowTask?.cancel()
         panel.updateAppearance()
 
         if anchorDisplayID == nil || state.barPhase == .preparing {
@@ -174,6 +208,41 @@ final class FloatingBarController {
                 .flatMap(FloatingBarPanel.displayID)
         }
 
+        // A recording start mutates AppState and invokes this controller in the
+        // same main-thread turn. At that moment SwiftUI still reports the old
+        // hidden/narrow layout; the full metadata tooltip is calculated on the
+        // following layout pass. Keep the already-prewarmed panel transparent
+        // for that pass so users never see a narrow fallback window expand from
+        // one side before the centered tooltip is ready.
+        if panel.isVisible && panel.alphaValue > 0 {
+            presentPanel(expectedGeneration: expectedGeneration)
+            return
+        }
+
+        panel.ignoresMouseEvents = true
+        panel.alphaValue = 0
+        panel.orderFrontRegardless()
+        panelShowTask = Task { @MainActor [weak self] in
+            await Task.yield()
+            guard !Task.isCancelled, let self,
+                  self.panelGeneration == expectedGeneration,
+                  self.state.barPhase != .hidden
+            else { return }
+
+            self.panel.contentView?.layoutSubtreeIfNeeded()
+            await Task.yield()
+            guard !Task.isCancelled,
+                  self.panelGeneration == expectedGeneration,
+                  self.state.barPhase != .hidden
+            else { return }
+
+            self.presentPanel(expectedGeneration: expectedGeneration)
+            self.panelShowTask = nil
+        }
+    }
+
+    private func presentPanel(expectedGeneration: Int) {
+        guard panelGeneration == expectedGeneration else { return }
         let layout = layoutForShow()
         guard layout.hasVisibleContent else {
             panel.ignoresMouseEvents = true
@@ -181,9 +250,9 @@ final class FloatingBarController {
             return
         }
 
-        resizePanel(from: currentLayout, to: layout, display: panel.isVisible)
+        resizePanel(from: currentLayout, to: layout, display: false)
+        panel.contentView?.layoutSubtreeIfNeeded()
         panel.ignoresMouseEvents = false
-
         panel.contentView?.layer?.removeAllAnimations()
         panel.alphaValue = 0
         panel.orderFrontRegardless()
@@ -196,6 +265,8 @@ final class FloatingBarController {
 
     func hide() {
         guard panel.isVisible else { return }
+        panelShowTask?.cancel()
+        panelShowTask = nil
         cancelPendingPanelShrink()
         panel.ignoresMouseEvents = true
 

--- a/Type4Me/UI/FloatingBar/FloatingBarView.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarView.swift
@@ -3,6 +3,35 @@ import SwiftUI
 /// Cached font for text measurement (module-level to avoid generic-type static restriction).
 private let floatingBarFont = NSFont.systemFont(ofSize: 14, weight: .medium)
 
+/// Natural popup height for the complete transcript. Deliberately has no cap:
+/// the hover preview grows with its text instead of becoming a second scroller.
+func transcriptPopupContentHeight(for text: String, width: CGFloat) -> CGFloat {
+    let textWidth = max(1, width - 24)
+    let bounds = (text as NSString).boundingRect(
+        with: NSSize(width: textWidth, height: .greatestFiniteMagnitude),
+        options: [.usesLineFragmentOrigin, .usesFontLeading],
+        attributes: [.font: floatingBarFont]
+    )
+    return max(1, ceil(bounds.height) + 24)
+}
+
+func recordingBaseCapsuleWidth(textWidth: CGFloat, showsCancelButton: Bool) -> CGFloat {
+    let minimumWidth = showsCancelButton
+        ? TF.barWidthCompact
+        : TF.recordingSingleButtonMinimumWidth
+    let chromeWidth = showsCancelButton
+        ? TF.recordingChromeWidth
+        : TF.recordingSingleButtonChromeWidth
+    return max(minimumWidth, textWidth + chromeWidth)
+}
+
+func recordingModeHintWidth(textWidth: CGFloat) -> CGFloat {
+    min(
+        TF.barWidth + TF.recordingTooltipOverhang * 2,
+        max(24, textWidth + 24)
+    )
+}
+
 private enum FloatingBarTopOverlay: Equatable {
     case transcript
     case action(RecordingControlAction)
@@ -56,11 +85,11 @@ func recordingActionHorizontalOffset(
     } else if action == .finish {
         distanceFromCenter = capsuleWidth / 2
             - TF.recordingLeadingInset
-            - TF.recordingFinishControlSize / 2
+            - TF.recordingControlSlotSize / 2
     } else {
         distanceFromCenter = capsuleWidth / 2
             - TF.recordingTrailingInset
-            - TF.recordingCancelControlSize / 2
+            - TF.recordingControlSlotSize / 2
     }
     return action == .finish ? -distanceFromCenter : distanceFromCenter
 }
@@ -91,7 +120,7 @@ protocol FloatingBarState: AnyObject, Observable {
 }
 
 struct FloatingBarPresentation: Equatable {
-    var theme: RecordingTheme = .dark
+    var theme: RecordingTheme = RecordingTheme.defaultValue
     var indicatorStyle: RecordingIndicatorStyle = .regular
     var visualStyle: RecordingVisualStyle = .siri
     var showsLiveTranscript: Bool = true
@@ -101,13 +130,14 @@ struct FloatingBarPresentation: Equatable {
     var showsModeName: Bool = RecordingMetadataDisplayPreference.showModeNameDefault
     var showsProviderName: Bool = RecordingMetadataDisplayPreference.showProviderNameDefault
     var showsModelName: Bool = RecordingMetadataDisplayPreference.showModelNameDefault
+    var samplesGlassWithinWindow: Bool = false
 
     var showsRecordingIndicator: Bool {
         true
     }
 }
 
-/// Dark or Light themed floating transcription bar.
+/// Frosted-glass or solid-color floating transcription bar.
 ///
 /// Design: state changes are immediate; recording starts directly in the full
 /// listening UI even while the audio service is still preparing internally.
@@ -144,7 +174,10 @@ struct FloatingBarView<S: FloatingBarState>: View {
     @State private var showsModeHint = false
     @State private var modeHintTask: Task<Void, Never>?
     @State private var recordingActionLocked = false
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @AppStorage(RecordingTheme.storageKey) private var theme = RecordingTheme.defaultValue
+    @AppStorage(RecordingSolidColor.storageKey)
+    private var solidColorHex = RecordingSolidColor.defaultHex
     @AppStorage(RecordingIndicatorStyle.storageKey) private var indicatorStyle = RecordingIndicatorStyle.defaultValue
     @AppStorage(LiveTranscriptDisplayPreference.storageKey) private var showLiveTranscript = LiveTranscriptDisplayPreference.defaultValue
     @AppStorage("tf_hoverTranscriptPreview") private var hoverTranscriptPreview = true
@@ -161,10 +194,20 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
     // MARK: - Presentation Resolution
 
-    private var effectiveTheme: RecordingTheme {
+    private var selectedTheme: RecordingTheme {
         presentationOverride?.theme
             ?? RecordingTheme(rawValue: theme.rawValue)
-            ?? .dark
+            ?? RecordingTheme.defaultValue
+    }
+
+    /// Components still use the existing light/dark palette contract, while
+    /// the selected theme now describes surface type (glass or solid). For a
+    /// custom solid color, derive foreground contrast from its luminance.
+    private var effectiveTheme: RecordingTheme {
+        guard !selectedTheme.usesGlass else { return .light }
+        return RecordingSolidColor(hex: solidColorHex).usesDarkForeground
+            ? .light
+            : .dark
     }
 
     private var effectiveIndicatorStyle: RecordingIndicatorStyle {
@@ -324,7 +367,10 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
     private var baseRecordingWidth: CGFloat {
         let placeholder = state.activityKind == .revise ? L("说说你想怎么改", "Say how to revise") : L("倾听中", "Listening")
-        return max(TF.barWidthCompact, measureText(placeholder) + currentRecordingChromeWidth)
+        return recordingBaseCapsuleWidth(
+            textWidth: measureText(placeholder),
+            showsCancelButton: effectiveShowsCancelButton
+        )
     }
 
     /// Monotonic target width for the recording capsule during a live-transcript
@@ -428,10 +474,14 @@ struct FloatingBarView<S: FloatingBarState>: View {
                 topOverlay(overlay)
             }
 
-            if shouldRenderCapsule {
-                capsuleBar
-                    .id("floating_capsule_bar")
-            }
+            // Keep the capsule subtree mounted while the panel is ordered out.
+            // This lets SwiftUI, AppKit glass, and the Metal orb initialize at
+            // launch instead of competing for the first visible recording frame.
+            capsuleBar
+                .id("floating_capsule_bar")
+                .opacity(shouldRenderCapsule ? 1 : 0)
+                .allowsHitTesting(shouldRenderCapsule)
+                .frame(maxWidth: .infinity, alignment: .center)
         }
         .padding(TF.floatingPanelShadowInset)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
@@ -460,6 +510,12 @@ struct FloatingBarView<S: FloatingBarState>: View {
             } else {
                 recordingPeakWidth = baseRecordingWidth
             }
+        }
+        .onChange(of: effectiveShowsCancelButton) { _, _ in
+            // Keep the Settings preview and a currently visible recording in
+            // sync with the symmetric one-/two-button geometry.
+            recordingPeakWidth = baseRecordingWidth
+            updateRecordingPeakWidthIfNeeded()
         }
         .onChange(of: effectiveIndicatorStyle) { _, newStyle in
             if newStyle == .regular {
@@ -490,13 +546,46 @@ struct FloatingBarView<S: FloatingBarState>: View {
         barContent
             .frame(width: capsuleWidth, height: capsuleHeight)
             .clipShape(barShape)
-            .background {
-                capsuleBackground
+            .modifier(
+                RecordingSurfaceModifier(
+                    cornerRadius: barCornerRadius,
+                    theme: selectedTheme,
+                    blendingMode: presentationOverride?.samplesGlassWithinWindow == true
+                        ? .withinWindow
+                        : .behindWindow
+                )
+            )
+            .overlay {
+                if state.barPhase == .error {
+                    LinearGradient(
+                        colors: [TF.settingsAccentRed.opacity(0.16), .clear],
+                        startPoint: .leading,
+                        endPoint: UnitPoint(x: 0.45, y: 0.5)
+                    )
                     .clipShape(barShape)
+                    .allowsHitTesting(false)
+                }
             }
             .overlay {
                 capsuleBorder
             }
+            // AppKit's panel shadow is intentionally disabled because it would
+            // follow the rectangular NSPanel rather than the animated capsule.
+            // A tight contact shadow defines the glass edge; the wider ambient
+            // shadow separates the translucent surface from bright content
+            // underneath without turning the rim into a heavy outline.
+            .shadow(
+                color: capsuleContactShadowColor,
+                radius: TF.recordingCapsuleContactShadowRadius,
+                x: 0,
+                y: TF.recordingCapsuleContactShadowYOffset
+            )
+            .shadow(
+                color: capsuleAmbientShadowColor,
+                radius: TF.recordingCapsuleAmbientShadowRadius,
+                x: 0,
+                y: TF.recordingCapsuleAmbientShadowYOffset
+            )
             // Critically damped (dampingFraction 1.0) so the width never
             // overshoots and settles back leftward between characters. An
             // underdamped spring makes the right edge/cancel button wiggle
@@ -556,10 +645,15 @@ struct FloatingBarView<S: FloatingBarState>: View {
     @ViewBuilder
     private var regularPhaseContent: some View {
         ZStack {
+            // Deliberately unconditional: the MTKView stays alive across phase
+            // changes and is already prepared before the first visible frame.
+            recordingContent
+                .opacity(state.barPhase == .preparing || state.barPhase == .recording ? 1 : 0)
+                .allowsHitTesting(state.barPhase == .preparing || state.barPhase == .recording)
+
             switch state.barPhase {
-            case .preparing, .recording:
-                recordingContent
-                    .transition(.opacity.animation(.easeInOut(duration: 0.18)))
+            case .preparing, .recording, .hidden:
+                EmptyView()
             case .processing:
                 processingContent
                     .transition(.textSwap.animation(.easeInOut(duration: 0.15)))
@@ -572,8 +666,6 @@ struct FloatingBarView<S: FloatingBarState>: View {
             case .error:
                 errorContent
                     .transition(.opacity.animation(.easeInOut(duration: 0.18)))
-            case .hidden:
-                EmptyView()
             }
         }
         .animation(.easeInOut(duration: 0.15), value: state.barPhase)
@@ -749,16 +841,25 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
     private var recordingContent: some View {
         HStack(spacing: TF.recordingControlGap) {
+            // Match the 1.8/1.9 layout model: only controls that are actually
+            // visible participate in the row. Equal slots keep the text lane
+            // centered with two controls; removing cancel also removes its
+            // entire slot instead of leaving a large blank area on the right.
             recordingButton(.finish)
+                .frame(width: TF.recordingControlSlotSize)
 
             recordingText
+                .padding(
+                    .trailing,
+                    effectiveShowsCancelButton ? 0 : TF.recordingSingleButtonMirroredTextBuffer
+                )
 
             if effectiveShowsCancelButton {
                 recordingButton(.cancel)
+                    .frame(width: TF.recordingControlSlotSize)
             }
         }
-        .padding(.leading, TF.recordingLeadingInset)
-        .padding(.trailing, TF.recordingTrailingInset)
+        .padding(.horizontal, TF.recordingEdgeInset)
     }
 
     private var isLiveTranscriptTrailingAligned: Bool {
@@ -766,11 +867,9 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 
     private var recordingText: some View {
-        // The text is an overlay on a flexible Color.clear so it never
-        // participates in the HStack layout: it can never push the cancel
-        // button, and the cancel button can never overlap it. The clear region
-        // is exactly the space between the two controls; the text is masked to
-        // it, so overflow only fades on the leading edge.
+        // The text stays inside a flexible lane between the controls. This is
+        // the spatial model used by the stable 1.8/1.9 bar: the row's real
+        // contents determine the available lane instead of phantom controls.
         Color.clear
             .overlay(alignment: isLiveTranscriptTrailingAligned ? .trailing : .center) {
                 recordingTextContent
@@ -785,8 +884,14 @@ struct FloatingBarView<S: FloatingBarState>: View {
                             startPoint: .leading,
                             endPoint: .trailing
                         )
-                        .frame(width: 14)
+                        .frame(width: TF.recordingTranscriptFadeWidth)
                         Rectangle()
+                        LinearGradient(
+                            colors: [.white, .clear],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                        .frame(width: TF.recordingTranscriptFadeWidth)
                     }
                 } else {
                     Rectangle()
@@ -831,7 +936,8 @@ struct FloatingBarView<S: FloatingBarState>: View {
                     style: recordingVisualStyle,
                     audioEnergy: state.audioLevel.current,
                     isHovered: hoveredAction == .finish,
-                    isPressed: pressedAction == .finish || recordingActionLocked
+                    isPressed: pressedAction == .finish || recordingActionLocked,
+                    isActive: state.barPhase == .preparing || state.barPhase == .recording
                 )
                 .id("recording_orb_button")
             } else {
@@ -999,31 +1105,29 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
     // MARK: - Background & Border
 
-    private var capsuleBackground: some View {
-        RecordingGlassSurface(
-            cornerRadius: barCornerRadius,
-            theme: effectiveTheme,
-            tintOpacity: effectiveTheme == .light ? 0.68 : 0.32
-        )
-        .overlay {
-            if state.barPhase == .error {
-                LinearGradient(
-                    colors: [TF.settingsAccentRed.opacity(0.16), .clear],
-                    startPoint: .leading,
-                    endPoint: UnitPoint(x: 0.45, y: 0.5)
-                )
-            }
-        }
-    }
-
     @ViewBuilder
     private var capsuleBorder: some View {
         switch state.barPhase {
         case .preparing, .recording, .processing, .recovering:
-            barShape.strokeBorder(
-                effectiveTheme == .light ? TF.recordingLightGlassRim : TF.recordingGlassRim,
-                lineWidth: 0.8
-            )
+            ZStack {
+                // Neutral separation remains visible when the glass is over a
+                // white window, where the highlight portion of the rim alone
+                // would disappear.
+                barShape.strokeBorder(
+                    Color.black.opacity(effectiveTheme == .light ? 0.10 : 0.16),
+                    lineWidth: TF.recordingCapsuleRimWidth
+                )
+
+                barShape.strokeBorder(
+                    effectiveTheme == .light ? TF.recordingLightGlassRim : TF.recordingGlassRim,
+                    lineWidth: TF.recordingCapsuleRimWidth
+                )
+                .opacity(
+                    reduceTransparency
+                        ? 1.0
+                        : (effectiveTheme == .light ? 0.72 : 0.52)
+                )
+            }
         case .done:
             barShape.strokeBorder(feedbackBorderColor, lineWidth: 0.5)
         case .error:
@@ -1031,6 +1135,14 @@ struct FloatingBarView<S: FloatingBarState>: View {
         case .hidden:
             EmptyView()
         }
+    }
+
+    private var capsuleContactShadowColor: Color {
+        Color.black.opacity(effectiveTheme == .light ? 0.18 : 0.30)
+    }
+
+    private var capsuleAmbientShadowColor: Color {
+        Color.black.opacity(effectiveTheme == .light ? 0.18 : 0.26)
     }
 
     private var feedbackBorderColor: Color {
@@ -1115,15 +1227,13 @@ struct FloatingBarView<S: FloatingBarState>: View {
         switch overlay {
         case .transcript:
             return NSSize(
-                width: TF.transcriptPopupWidth,
+                width: capsuleWidth,
                 height: transcriptPopupHeight
             )
         case .mode:
-            let font = NSFont.systemFont(ofSize: 14, weight: .semibold)
-            let maxWidth = TF.barWidth + TF.recordingTooltipOverhang * 2
             return NSSize(
-                width: min(maxWidth, measureText(recordingMetadataText ?? "", font: font) + 24),
-                height: ceil(font.boundingRectForFont.height) + 18
+                width: modeHintWidth,
+                height: ceil(modeHintFont.boundingRectForFont.height) + 18
             )
         case .action(let action):
             return actionHintSize(action)
@@ -1131,15 +1241,10 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 
     private var transcriptPopupHeight: CGFloat {
-        let textWidth = TF.transcriptPopupWidth - 24
-        let bounds = (state.transcriptionText as NSString).boundingRect(
-            with: NSSize(width: textWidth, height: .greatestFiniteMagnitude),
-            options: [.usesLineFragmentOrigin, .usesFontLeading],
-            attributes: [.font: floatingBarFont]
+        transcriptPopupContentHeight(
+            for: state.transcriptionText,
+            width: capsuleWidth
         )
-        // TranscriptPopup adds 12 pt vertical padding on both sides and a
-        // one-point scroll anchor after the text.
-        return min(TF.transcriptPopupMaxHeight, max(1, ceil(bounds.height) + 25))
     }
 
     private func actionHintSize(_ action: RecordingControlAction) -> NSSize {
@@ -1186,13 +1291,13 @@ struct FloatingBarView<S: FloatingBarState>: View {
         case .transcript:
             TranscriptPopup(
                 text: state.transcriptionText,
-                height: transcriptPopupHeight,
-                theme: effectiveTheme,
+                width: capsuleWidth,
+                theme: selectedTheme,
+                foregroundTheme: effectiveTheme,
                 onHoverChanged: updateTranscriptHover
             )
         case .mode:
             hintBubble(text: recordingMetadataText ?? "")
-                .transaction { $0.animation = nil }
         case .action(.finish):
             alignedActionHint(.finish)
         case .action(.cancel):
@@ -1266,7 +1371,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
         .lineLimit(1)
         .padding(.horizontal, 12)
         .padding(.vertical, 9)
-        .background(FrostedGlassBubbleBackground(theme: effectiveTheme))
+        .background(RecordingSurfaceBubbleBackground(theme: selectedTheme))
         .frame(maxWidth: TF.recordingTooltipMaxWidth)
         .fixedSize(horizontal: true, vertical: false)
         .shadow(color: Color.black.opacity(effectiveTheme == .light ? 0.05 : 0.20), radius: 3, x: 0, y: 1.5)
@@ -1278,12 +1383,25 @@ struct FloatingBarView<S: FloatingBarState>: View {
             .foregroundStyle(effectiveTheme == .light ? TF.floatingTextLight : TF.floatingText)
             .lineLimit(1)
             .truncationMode(.tail)
+            .frame(width: max(1, modeHintWidth - 24), alignment: .center)
             .padding(.horizontal, 12)
             .padding(.vertical, 9)
-            .frame(maxWidth: TF.barWidth + TF.recordingTooltipOverhang * 2)
-            .background(FrostedGlassBubbleBackground(theme: effectiveTheme))
-            .fixedSize(horizontal: true, vertical: false)
+            .background(RecordingSurfaceBubbleBackground(theme: selectedTheme))
             .shadow(color: Color.black.opacity(effectiveTheme == .light ? 0.05 : 0.20), radius: 3, x: 0, y: 1.5)
+            .animation(
+                .spring(response: TF.recordingCapsuleSpringResponse, dampingFraction: 1.0),
+                value: modeHintWidth
+            )
+    }
+
+    private var modeHintFont: NSFont {
+        NSFont.systemFont(ofSize: 14, weight: .semibold)
+    }
+
+    private var modeHintWidth: CGFloat {
+        recordingModeHintWidth(
+            textWidth: measureText(recordingMetadataText ?? "", font: modeHintFont)
+        )
     }
 
     private func showModeHint() {
@@ -1348,41 +1466,71 @@ struct FloatingBarView<S: FloatingBarState>: View {
     }
 }
 
-/// A dark or light HUD material that samples behind the transparent panel.
-private struct RecordingGlassSurface: View {
+/// Selects either native AppKit glass or the user-defined solid surface without
+/// changing the content hierarchy, so live theme changes remain immediate.
+private struct RecordingSurfaceModifier: ViewModifier {
     let cornerRadius: CGFloat
     var theme: RecordingTheme = .dark
-    let tintOpacity: Double
+    var blendingMode: NSVisualEffectView.BlendingMode = .behindWindow
 
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @AppStorage(RecordingGlassTuning.transparencyKey)
+    private var transparency = RecordingGlassTuning.defaultTransparency
+    @AppStorage(RecordingSolidColor.storageKey)
+    private var solidColorHex = RecordingSolidColor.defaultHex
 
     private var shape: RoundedRectangle {
         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
     }
 
-    var body: some View {
-        if reduceTransparency {
-            theme == .light ? TF.floatingBackgroundLight : TF.floatingBackground
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if !theme.usesGlass {
+            content.background(
+                RecordingSolidColor(hex: solidColorHex).color,
+                in: shape
+            )
+        } else if reduceTransparency {
+            content.background(
+                TF.floatingBackgroundLight,
+                in: shape
+            )
         } else {
-            ZStack {
-                VisualEffectBlur(
-                    cornerRadius: cornerRadius,
-                    appearanceName: theme == .light ? .aqua : .darkAqua
-                )
-                .allowsHitTesting(false)
-
-                if theme == .light {
-                    Color.white.opacity(tintOpacity)
-                } else {
-                    Color.black.opacity(tintOpacity)
+            content.background {
+                ZStack {
+                    VisualEffectBlur(
+                        cornerRadius: cornerRadius,
+                        blendingMode: blendingMode,
+                        appearanceName: .aqua,
+                        blurEffect: .frosted,
+                        transparency: transparency,
+                        tintColor: nil
+                    )
                 }
+                .clipShape(shape)
+                .allowsHitTesting(false)
             }
-            .clipShape(shape)
         }
     }
 }
 
-private struct FrostedGlassBubbleBackground: View {
+/// Background-only adapter for transient bubbles using the same stable material.
+private struct RecordingSurface: View {
+    let cornerRadius: CGFloat
+    var theme: RecordingTheme = .dark
+
+    var body: some View {
+        Color.clear
+            .modifier(
+                RecordingSurfaceModifier(
+                    cornerRadius: cornerRadius,
+                    theme: theme
+                )
+            )
+    }
+}
+
+private struct RecordingSurfaceBubbleBackground: View {
     let cornerRadius: CGFloat = TF.transcriptPopupCorner
     var theme: RecordingTheme = .dark
 
@@ -1390,15 +1538,24 @@ private struct FrostedGlassBubbleBackground: View {
         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
     }
 
+    @AppStorage(RecordingSolidColor.storageKey)
+    private var solidColorHex = RecordingSolidColor.defaultHex
+
+    private var borderColor: Color {
+        guard !theme.usesGlass else { return TF.floatingBorderLight }
+        return RecordingSolidColor(hex: solidColorHex).usesDarkForeground
+            ? Color.black.opacity(0.14)
+            : Color.white.opacity(0.18)
+    }
+
     var body: some View {
-        RecordingGlassSurface(
+        RecordingSurface(
             cornerRadius: cornerRadius,
-            theme: theme,
-            tintOpacity: theme == .light ? 0.75 : 0.40
+            theme: theme
         )
         .overlay {
             shape.strokeBorder(
-                theme == .light ? TF.floatingBorderLight : TF.floatingBorder,
+                borderColor,
                 lineWidth: 0.5
             )
         }
@@ -1407,36 +1564,24 @@ private struct FrostedGlassBubbleBackground: View {
 
 private struct TranscriptPopup: View {
     let text: String
-    let height: CGFloat
+    let width: CGFloat
     var theme: RecordingTheme = .dark
+    var foregroundTheme: RecordingTheme = .dark
     let onHoverChanged: (Bool) -> Void
 
     var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView(.vertical) {
-                Text(text)
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(theme == .light ? TF.floatingTextLight : TF.floatingText)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(12)
-
-                Color.clear
-                    .frame(height: 1)
-                    .id("transcript-end")
-            }
-            .scrollIndicators(.hidden)
-            .frame(width: TF.transcriptPopupWidth, height: height)
-            .background(FrostedGlassBubbleBackground(theme: theme))
+        Text(text)
+            .font(.system(size: 14, weight: .medium))
+            .foregroundStyle(foregroundTheme == .light ? TF.floatingTextLight : TF.floatingText)
+            .frame(width: max(1, width - 24), alignment: .leading)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(12)
+            .background(RecordingSurfaceBubbleBackground(theme: theme))
             .overlay {
                 FloatingBarHoverTracker(onHoverChanged: onHoverChanged)
             }
             .clipShape(RoundedRectangle(cornerRadius: TF.transcriptPopupCorner, style: .continuous))
-            .shadow(color: Color.black.opacity(theme == .light ? 0.05 : 0.20), radius: 4, x: 0, y: 2)
-            .onAppear { proxy.scrollTo("transcript-end", anchor: .bottom) }
-            .onChange(of: text) { _, _ in
-                proxy.scrollTo("transcript-end", anchor: .bottom)
-            }
-        }
+            .shadow(color: Color.black.opacity(foregroundTheme == .light ? 0.05 : 0.20), radius: 4, x: 0, y: 2)
     }
 }
 

--- a/Type4Me/UI/FloatingBar/LiquidGlass/LiquidGlassOrb.swift
+++ b/Type4Me/UI/FloatingBar/LiquidGlass/LiquidGlassOrb.swift
@@ -19,14 +19,17 @@ private final class LiquidOrbPipelineManager {
 
     let device: MTLDevice?
     let pipeline: MTLRenderPipelineState?
+    let commandQueue: MTLCommandQueue?
 
     private init() {
         guard let device = MTLCreateSystemDefaultDevice() else {
             self.device = nil
             self.pipeline = nil
+            self.commandQueue = nil
             return
         }
         self.device = device
+        self.commandQueue = device.makeCommandQueue()
         do {
             let library = try device.makeLibrary(source: orbMetalShaderSource, options: nil)
             guard let vertex = library.makeFunction(name: "vs_main"),
@@ -51,6 +54,16 @@ private final class LiquidOrbPipelineManager {
     }
 }
 
+extension LiquidGlassOrb {
+    /// Compile the embedded shader and create its render pipeline after launch,
+    /// before the first recording indicator needs to draw it on the main thread.
+    static func prewarmRenderer() {
+        DispatchQueue.global(qos: .userInitiated).async {
+            _ = LiquidOrbPipelineManager.shared.pipeline
+        }
+    }
+}
+
 // MARK: - Metal MTKView Renderer
 
 private final class LiquidOrbRenderer: NSObject, MTKViewDelegate {
@@ -68,7 +81,7 @@ private final class LiquidOrbRenderer: NSObject, MTKViewDelegate {
     init?(view: MTKView, preset: OrbPreset) {
         guard let device = LiquidOrbPipelineManager.shared.device,
               let pipeline = LiquidOrbPipelineManager.shared.pipeline,
-              let queue = device.makeCommandQueue() else {
+              let queue = LiquidOrbPipelineManager.shared.commandQueue else {
             return nil
         }
         self.commandQueue = queue
@@ -200,6 +213,7 @@ struct LiquidGlassOrb: View {
     let audioEnergy: Float
     var isHovered: Bool = false
     var isPressed: Bool = false
+    var isActive: Bool = true
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -210,7 +224,7 @@ struct LiquidGlassOrb: View {
             LiquidOrbMetalSurface(
                 preset: style.preset,
                 audioEnergy: max(0.0, min(1.0, audioEnergy)),
-                isAnimated: style.isAnimated && !reduceMotion
+                isAnimated: isActive && style.isAnimated && !reduceMotion
             )
             .frame(width: orbSize, height: orbSize)
             .clipShape(Circle())

--- a/Type4Me/UI/FloatingBar/RecordingGlassTuning.swift
+++ b/Type4Me/UI/FloatingBar/RecordingGlassTuning.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+enum RecordingGlassBlurEffect: String, CaseIterable, Sendable {
+    case clear
+    case frosted
+}
+
+/// Resolved, clamped glass parameters shared by the Settings preview and live panel.
+///
+/// The accepted light theme fixes native style and tint, leaving transparency
+/// as its sole user-facing calibration axis.
+struct RecordingGlassTuning: Equatable, Sendable {
+    static let transparencyKey = "tf_recordingGlassTransparency"
+
+    // Read-only compatibility key used to migrate the first debug build.
+    private static let legacyMaterialOpacityKey = "tf_recordingGlassMaterialOpacity"
+
+    /// Calibrated from the accepted light-glass configuration. Existing users
+    /// keep their exact saved value; new installs start at a clean 10%.
+    static let defaultTransparency = 0.10
+    let transparency: Double
+
+    init(
+        transparency: Double = defaultTransparency
+    ) {
+        self.transparency = Self.clamp(transparency)
+    }
+
+    /// The native material view uses opacity, while the UI intentionally exposes
+    /// the more intuitive inverse value: 0% transparency is fully materialized.
+    var materialOpacity: Double {
+        1 - transparency
+    }
+
+    /// Preserve values from the first calibration build without keeping its
+    /// redundant controls in the current data model.
+    static func migrateLegacyPreferencesIfNeeded(
+        userDefaults: UserDefaults = .standard
+    ) {
+        if userDefaults.object(forKey: transparencyKey) == nil,
+           let legacyOpacity = userDefaults.object(forKey: legacyMaterialOpacityKey) as? NSNumber {
+            userDefaults.set(
+                1 - clamp(legacyOpacity.doubleValue),
+                forKey: transparencyKey
+            )
+        }
+    }
+
+    private static func clamp(_ value: Double) -> Double {
+        min(max(value, 0), 1)
+    }
+}

--- a/Type4Me/UI/FloatingBar/RecordingTheme.swift
+++ b/Type4Me/UI/FloatingBar/RecordingTheme.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import SwiftUI
+import AppKit
 
 /// Appearance theme for the floating recording indicator and related overlays.
 enum RecordingTheme: String, CaseIterable, Identifiable {
@@ -14,14 +15,93 @@ enum RecordingTheme: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 
     static let storageKey = "tf_recordingTheme"
-    static let defaultValue = RecordingTheme.dark
+    /// New installations start with the translucent material. An explicit
+    /// user selection remains stored under `storageKey` and takes precedence.
+    static let defaultValue = RecordingTheme.light
 
     var displayName: String {
         switch self {
         case .dark:
-            L("暗色", "Dark")
+            L("纯色", "Solid")
         case .light:
-            L("明亮", "Light")
+            L("毛玻璃版本", "Frosted Glass")
         }
+    }
+
+    var usesGlass: Bool {
+        self == .light
+    }
+}
+
+/// User-editable background for the non-glass recording theme.
+/// Solid surfaces start from white and remain independently user-editable.
+struct RecordingSolidColor: Equatable, Sendable {
+    static let storageKey = "tf_recordingSolidColor"
+    static let defaultHex = "#FFFFFF"
+
+    let red: Double
+    let green: Double
+    let blue: Double
+
+    init(hex: String) {
+        let cleaned = hex
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "#", with: "")
+        guard cleaned.count == 6,
+              let value = UInt64(cleaned, radix: 16) else {
+            self.init(red: 1, green: 1, blue: 1)
+            return
+        }
+        self.init(
+            red: Double((value >> 16) & 0xFF) / 255,
+            green: Double((value >> 8) & 0xFF) / 255,
+            blue: Double(value & 0xFF) / 255
+        )
+    }
+
+    var color: Color {
+        Color(red: red, green: green, blue: blue)
+    }
+
+    var hex: String {
+        String(
+            format: "#%02X%02X%02X",
+            Int((red * 255).rounded()),
+            Int((green * 255).rounded()),
+            Int((blue * 255).rounded())
+        )
+    }
+
+    /// Select content contrast independently from the selected surface type.
+    var usesDarkForeground: Bool {
+        relativeLuminance > 0.43
+    }
+
+    static func hex(from color: Color) -> String {
+        guard let converted = NSColor(color).usingColorSpace(.sRGB) else {
+            return defaultHex
+        }
+        return RecordingSolidColor(
+            red: converted.redComponent,
+            green: converted.greenComponent,
+            blue: converted.blueComponent
+        ).hex
+    }
+
+    private init(red: Double, green: Double, blue: Double) {
+        self.red = min(max(red, 0), 1)
+        self.green = min(max(green, 0), 1)
+        self.blue = min(max(blue, 0), 1)
+    }
+
+    private var relativeLuminance: Double {
+        func linearize(_ component: Double) -> Double {
+            component <= 0.04045
+                ? component / 12.92
+                : pow((component + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * linearize(red)
+            + 0.7152 * linearize(green)
+            + 0.0722 * linearize(blue)
     }
 }

--- a/Type4Me/UI/FloatingBar/VisualEffectBlur.swift
+++ b/Type4Me/UI/FloatingBar/VisualEffectBlur.swift
@@ -1,38 +1,137 @@
 import AppKit
 import SwiftUI
 
-/// A SwiftUI bridge for native HUD / Popover frosted glass that samples behind its window.
+/// Hosts the system compositor's glass implementation.
+///
+/// A `CALayer.backgroundFilters` Gaussian blur only processes pixels already in
+/// the same layer tree. It cannot reliably blur windows belonging to other apps,
+/// so using one here produces a costly opacity-like effect instead of a spatial
+/// backdrop blur. On macOS 26 we use `NSGlassEffectView` directly; older systems
+/// fall back to the supported behind-window `NSVisualEffectView` material.
+final class RecordingGlassEffectHostView: NSView {
+    private(set) var appliedBlurEffect = RecordingGlassBlurEffect.frosted
+    private(set) var appliedTintColor: NSColor?
+
+    @available(macOS 26.0, *)
+    private var nativeGlassView: NSGlassEffectView? {
+        subviews.first as? NSGlassEffectView
+    }
+
+    private var fallbackVisualEffectView: NSVisualEffectView? {
+        subviews.first as? NSVisualEffectView
+    }
+
+    var usesNativeLiquidGlass: Bool {
+        if #available(macOS 26.0, *) {
+            return nativeGlassView != nil
+        }
+        return false
+    }
+
+    @available(macOS 26.0, *)
+    var nativeGlassStyle: NSGlassEffectView.Style? {
+        nativeGlassView?.style
+    }
+
+    @available(macOS 26.0, *)
+    var nativeGlassTintColor: NSColor? {
+        nativeGlassView?.tintColor
+    }
+
+    override func layout() {
+        super.layout()
+        subviews.first?.frame = bounds
+    }
+
+    func configure(
+        cornerRadius: CGFloat,
+        blendingMode: NSVisualEffectView.BlendingMode,
+        appearanceName: NSAppearance.Name?,
+        blurEffect: RecordingGlassBlurEffect,
+        transparency: Double,
+        tintColor: NSColor?
+    ) {
+        wantsLayer = true
+        let resolvedOpacity = 1 - min(max(transparency, 0), 1)
+        if alphaValue != resolvedOpacity {
+            alphaValue = resolvedOpacity
+        }
+
+        let resolvedAppearance = appearanceName.flatMap(NSAppearance.init(named:))
+        if appearance?.name != resolvedAppearance?.name {
+            appearance = resolvedAppearance
+        }
+
+        if #available(macOS 26.0, *) {
+            let glass: NSGlassEffectView
+            if let existing = nativeGlassView {
+                glass = existing
+            } else {
+                subviews.forEach { $0.removeFromSuperview() }
+                glass = NSGlassEffectView(frame: bounds)
+                glass.autoresizingMask = [.width, .height]
+                addSubview(glass)
+            }
+            glass.cornerRadius = cornerRadius
+            glass.style = blurEffect == .frosted ? .regular : .clear
+            glass.tintColor = tintColor
+        } else {
+            let effect: NSVisualEffectView
+            if let existing = fallbackVisualEffectView {
+                effect = existing
+            } else {
+                subviews.forEach { $0.removeFromSuperview() }
+                effect = NSVisualEffectView(frame: bounds)
+                effect.autoresizingMask = [.width, .height]
+                addSubview(effect)
+            }
+            effect.material = blurEffect == .frosted ? .popover : .menu
+            effect.blendingMode = blendingMode
+            effect.state = .active
+            effect.isEmphasized = false
+            effect.wantsLayer = true
+            effect.layer?.cornerRadius = cornerRadius
+            effect.layer?.cornerCurve = .continuous
+            effect.layer?.masksToBounds = cornerRadius > 0
+            effect.layer?.backgroundColor = tintColor?.cgColor
+        }
+
+        layer?.cornerRadius = cornerRadius
+        layer?.cornerCurve = .continuous
+        layer?.masksToBounds = cornerRadius > 0
+        appliedBlurEffect = blurEffect
+        appliedTintColor = tintColor
+    }
+}
+
+/// AppKit-backed Control Center-style glass. The public system API intentionally
+/// exposes semantic styles rather than an arbitrary pixel blur radius.
 struct VisualEffectBlur: NSViewRepresentable {
     var cornerRadius: CGFloat = 0
-    var material: NSVisualEffectView.Material = .hudWindow
     var blendingMode: NSVisualEffectView.BlendingMode = .behindWindow
-    var state: NSVisualEffectView.State = .active
-    var isEmphasized: Bool = false
     var appearanceName: NSAppearance.Name? = .darkAqua
+    var blurEffect: RecordingGlassBlurEffect = .frosted
+    var transparency: Double = 0
+    var tintColor: NSColor?
 
-    func makeNSView(context: Context) -> NSVisualEffectView {
-        let view = NSVisualEffectView()
-        view.wantsLayer = true
+    func makeNSView(context: Context) -> RecordingGlassEffectHostView {
+        let view = RecordingGlassEffectHostView()
         configure(view)
         return view
     }
 
-    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
+    func updateNSView(_ nsView: RecordingGlassEffectHostView, context: Context) {
         configure(nsView)
     }
 
-    private func configure(_ view: NSVisualEffectView) {
-        view.material = material
-        view.blendingMode = blendingMode
-        view.state = state
-        view.isEmphasized = isEmphasized
-        view.layer?.cornerRadius = cornerRadius
-        view.layer?.cornerCurve = .continuous
-        view.layer?.masksToBounds = cornerRadius > 0
-        if let appearanceName {
-            view.appearance = NSAppearance(named: appearanceName)
-        } else {
-            view.appearance = nil
-        }
+    func configure(_ view: RecordingGlassEffectHostView) {
+        view.configure(
+            cornerRadius: cornerRadius,
+            blendingMode: blendingMode,
+            appearanceName: appearanceName,
+            blurEffect: blurEffect,
+            transparency: transparency,
+            tintColor: tintColor
+        )
     }
 }

--- a/Type4Me/UI/Settings/AppearancePreviewStage.swift
+++ b/Type4Me/UI/Settings/AppearancePreviewStage.swift
@@ -20,6 +20,7 @@ struct AppearancePreviewStage: View {
 
     let presentation: FloatingBarPresentation
     let formattingOptions: TextOutputFormattingOptions
+    var showsGlassCalibrationBackdrop = false
 
     @State private var demoState = DemoState()
     @State private var previewPhase: PreviewPhase = .recording
@@ -92,8 +93,7 @@ struct AppearancePreviewStage: View {
             VStack(spacing: 0) {
                 // Recording Canvas
                 ZStack {
-                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .fill(TF.settingsCardAlt.opacity(0.6))
+                    recordingCanvasBackdrop
 
                     if presentation.showsRecordingIndicator {
                         FloatingBarView(
@@ -108,6 +108,7 @@ struct AppearancePreviewStage: View {
                 }
                 .frame(height: 210)
                 .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .animation(.easeInOut(duration: 0.2), value: showsGlassCalibrationBackdrop)
 
                 SettingsDivider()
                     .padding(.vertical, 10)
@@ -164,6 +165,75 @@ struct AppearancePreviewStage: View {
         }
         .onDisappear {
             demoState.stop()
+        }
+    }
+
+    @ViewBuilder
+    private var recordingCanvasBackdrop: some View {
+        if showsGlassCalibrationBackdrop {
+            HStack(spacing: 0) {
+                calibrationPanel(
+                    label: L("深色", "Dark"),
+                    foreground: .white.opacity(0.55),
+                    background: AnyShapeStyle(
+                        LinearGradient(
+                            colors: [Color(red: 0.03, green: 0.04, blue: 0.06), Color(red: 0.10, green: 0.12, blue: 0.17)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                )
+                calibrationPanel(
+                    label: L("彩色", "Color"),
+                    foreground: .white.opacity(0.62),
+                    background: AnyShapeStyle(
+                        LinearGradient(
+                            colors: [Color(red: 0.14, green: 0.43, blue: 0.94), Color(red: 0.72, green: 0.22, blue: 0.63)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                )
+                calibrationPanel(
+                    label: L("浅色", "Light"),
+                    foreground: .black.opacity(0.42),
+                    background: AnyShapeStyle(
+                        LinearGradient(
+                            colors: [Color.white, Color(red: 0.88, green: 0.91, blue: 0.95)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                )
+            }
+            .transition(.opacity)
+        } else {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(TF.settingsCardAlt.opacity(0.6))
+                .transition(.opacity)
+        }
+    }
+
+    private func calibrationPanel(
+        label: String,
+        foreground: Color,
+        background: AnyShapeStyle
+    ) -> some View {
+        ZStack {
+            Rectangle().fill(background)
+
+            VStack(spacing: 12) {
+                Text(label)
+                    .font(.system(size: 12, weight: .semibold))
+                HStack(spacing: 5) {
+                    ForEach(0..<3, id: \.self) { index in
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(foreground.opacity(index == 1 ? 0.7 : 0.35))
+                            .frame(width: index == 1 ? 28 : 18, height: 4)
+                    }
+                }
+            }
+            .foregroundStyle(foreground)
         }
     }
 

--- a/Type4Me/UI/Settings/AppearanceSettingsTab.swift
+++ b/Type4Me/UI/Settings/AppearanceSettingsTab.swift
@@ -45,6 +45,11 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
     @AppStorage(CornerQuotePreference.storageKey)
     private var useCornerQuotes = CornerQuotePreference.defaultValue
 
+    @AppStorage(RecordingGlassTuning.transparencyKey)
+    private var glassTransparency = RecordingGlassTuning.defaultTransparency
+    @AppStorage(RecordingSolidColor.storageKey)
+    private var solidColorHex = RecordingSolidColor.defaultHex
+
     @AppStorage("tf_language")
     private var language = AppLanguage.systemDefault
 
@@ -52,9 +57,20 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
         indicatorStyle == RecordingIndicatorStyle.compact.rawValue
     }
 
+    private var showsGlassCalibrationBackdrop: Bool {
+        theme == RecordingTheme.light.rawValue
+    }
+
+    private var solidColorBinding: Binding<Color> {
+        Binding(
+            get: { RecordingSolidColor(hex: solidColorHex).color },
+            set: { solidColorHex = RecordingSolidColor.hex(from: $0) }
+        )
+    }
+
     private var presentation: FloatingBarPresentation {
         FloatingBarPresentation(
-            theme: RecordingTheme(rawValue: theme) ?? .dark,
+            theme: RecordingTheme(rawValue: theme) ?? RecordingTheme.defaultValue,
             indicatorStyle: RecordingIndicatorStyle(rawValue: indicatorStyle) ?? .regular,
             visualStyle: RecordingVisualStyle(rawValue: visualStyle) ?? .siri,
             showsLiveTranscript: showLiveTranscript,
@@ -63,7 +79,8 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
             showsCancelButton: showCancelButton,
             showsModeName: showModeName,
             showsProviderName: showProviderName,
-            showsModelName: showModelName
+            showsModelName: showModelName,
+            samplesGlassWithinWindow: true
         )
     }
 
@@ -79,7 +96,8 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
         VStack(alignment: .leading, spacing: 0) {
             AppearancePreviewStage(
                 presentation: presentation,
-                formattingOptions: formattingOptions
+                formattingOptions: formattingOptions,
+                showsGlassCalibrationBackdrop: showsGlassCalibrationBackdrop
             )
 
             Spacer().frame(height: 16)
@@ -90,6 +108,8 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
 
             settingsGroupCard(L("录音显示", "Recording Display"), icon: "macwindow") {
                 themeRow
+                SettingsDivider()
+                themeDetailRow
                 SettingsDivider()
                 indicatorStyleRow
                 SettingsDivider()
@@ -120,6 +140,7 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
             }
             .animation(TF.springGentle, value: isCompact)
             .animation(TF.springGentle, value: showTooltips)
+            .animation(TF.springGentle, value: theme)
 
             Spacer().frame(height: 16)
 
@@ -138,6 +159,61 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
     }
 
     // MARK: - Row Builders
+
+    @ViewBuilder
+    private var themeDetailRow: some View {
+        if theme == RecordingTheme.light.rawValue {
+            glassTransparencyRow
+        } else {
+            solidColorRow
+        }
+    }
+
+    private var glassTransparencyRow: some View {
+        glassSliderRow(
+            L("玻璃透明度", "Glass Transparency"),
+            subtitle: L("只调整毛玻璃版本的透明程度", "Adjusts transparency for the Frosted Glass theme only"),
+            value: $glassTransparency
+        )
+    }
+
+    private var solidColorRow: some View {
+        settingsOptionRow(
+            L("背景颜色", "Background Color"),
+            subtitle: L("纯色不使用毛玻璃", "Solid does not use glass"),
+            controlWidth: 150
+        ) {
+            HStack(spacing: 10) {
+                ColorPicker(
+                    L("背景颜色", "Background Color"),
+                    selection: solidColorBinding,
+                    supportsOpacity: false
+                )
+                .labelsHidden()
+                Text(RecordingSolidColor(hex: solidColorHex).hex)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(TF.settingsTextSecondary)
+                    .frame(width: 62, alignment: .trailing)
+            }
+        }
+    }
+
+    private func glassSliderRow(
+        _ label: String,
+        subtitle: String,
+        value: Binding<Double>
+    ) -> some View {
+        settingsOptionRow(label, subtitle: subtitle, controlWidth: 260) {
+            HStack(spacing: 10) {
+                Slider(value: value, in: 0...1)
+                    .controlSize(.small)
+                Text(value.wrappedValue.formatted(.percent.precision(.fractionLength(0))))
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(TF.settingsTextSecondary)
+                    .frame(width: 42, alignment: .trailing)
+            }
+        }
+    }
 
     private var themeRow: some View {
         settingsOptionRow(

--- a/Type4MeTests/AppStateTests.swift
+++ b/Type4MeTests/AppStateTests.swift
@@ -234,16 +234,35 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(TF.barWidthCompact, 180)
         XCTAssertEqual(TF.barWidth, 400)
         XCTAssertEqual(TF.floatingPanelShadowInset, 8)
+        XCTAssertEqual(TF.recordingCapsuleRimWidth, 0.8)
+        XCTAssertEqual(TF.recordingCapsuleContactShadowRadius, 2)
+        XCTAssertEqual(TF.recordingCapsuleContactShadowYOffset, 1)
+        XCTAssertEqual(TF.recordingCapsuleAmbientShadowRadius, 7)
+        XCTAssertEqual(TF.recordingCapsuleAmbientShadowYOffset, 1)
+        XCTAssertLessThanOrEqual(
+            TF.recordingCapsuleAmbientShadowRadius + TF.recordingCapsuleAmbientShadowYOffset,
+            TF.floatingPanelShadowInset
+        )
         XCTAssertEqual(TF.recordingFinishControlSize, 45)
         XCTAssertEqual(TF.recordingCancelControlSize, 35)
-        XCTAssertEqual(TF.recordingLeadingInset, 5)
-        XCTAssertEqual(TF.recordingTrailingInset, 10)
-        XCTAssertEqual(TF.recordingEdgeInset, 10)
+        XCTAssertEqual(TF.recordingLeadingInset, 8)
+        XCTAssertEqual(TF.recordingTrailingInset, 8)
+        XCTAssertEqual(TF.recordingEdgeInset, 8)
         XCTAssertEqual(TF.recordingTooltipGap, 5)
-        XCTAssertEqual(TF.transcriptPopupWidth, 350)
-        XCTAssertEqual(TF.transcriptPopupMaxHeight, 120)
         XCTAssertEqual(TF.transcriptPopupCorner, TF.cornerLG)
         XCTAssertEqual(TF.transcriptPopupGap, 10)
+    }
+
+    func testTranscriptPopupUsesFullNaturalHeightWithoutScrollCap() {
+        let longText = String(
+            repeating: "This transcript should remain fully visible without an internal scrollbar. ",
+            count: 18
+        )
+        let wideHeight = transcriptPopupContentHeight(for: longText, width: TF.barWidth)
+        let narrowHeight = transcriptPopupContentHeight(for: longText, width: TF.barWidthCompact)
+
+        XCTAssertGreaterThan(wideHeight, 120)
+        XCTAssertGreaterThan(narrowHeight, wideHeight)
     }
 
     func testFloatingPanelLayoutTracksOnlyVisibleBounds() {
@@ -269,11 +288,11 @@ final class AppStateTests: XCTestCase {
 
         let transcript = FloatingBarPanelLayout(
             contentSize: NSSize(
-                width: TF.transcriptPopupWidth,
+                width: TF.barWidth,
                 height: TF.barHeight + TF.transcriptPopupGap + 60
             )
         )
-        XCTAssertEqual(transcript.panelSize, NSSize(width: 366, height: 141))
+        XCTAssertEqual(transcript.panelSize, NSSize(width: 416, height: 141))
 
         let action = FloatingBarPanelLayout(
             contentSize: NSSize(width: TF.barWidthCompact, height: TF.barHeight + 5 + 35),
@@ -300,6 +319,9 @@ final class AppStateTests: XCTestCase {
             visibleFrame: visibleFrame
         )
         XCTAssertEqual(expandedFrame.minY, frame.minY)
+        XCTAssertEqual(expandedFrame.midX, frame.midX)
+        XCTAssertLessThan(expandedFrame.minX, frame.minX)
+        XCTAssertGreaterThan(expandedFrame.maxX, frame.maxX)
     }
 
     func testRecordingActionHintsAreCenteredOverTheirControls() {
@@ -315,8 +337,8 @@ final class AppStateTests: XCTestCase {
             usesCompactLayout: false
         )
 
-        XCTAssertEqual(width / 2 + finishOffset, TF.recordingLeadingInset + TF.recordingFinishControlSize / 2)
-        XCTAssertEqual(width / 2 + cancelOffset, width - TF.recordingTrailingInset - TF.recordingCancelControlSize / 2)
+        XCTAssertEqual(width / 2 + finishOffset, TF.recordingLeadingInset + TF.recordingControlSlotSize / 2)
+        XCTAssertEqual(width / 2 + cancelOffset, width - TF.recordingTrailingInset - TF.recordingControlSlotSize / 2)
         XCTAssertEqual(
             width / 2 + recordingActionHorizontalOffset(.finish, capsuleWidth: width, usesCompactLayout: true),
             16
@@ -345,8 +367,8 @@ final class AppStateTests: XCTestCase {
 
         let previewLayout = FloatingBarPanelLayout(
             contentSize: NSSize(
-                width: TF.transcriptPopupWidth,
-                height: TF.barHeight + TF.transcriptPopupGap + TF.transcriptPopupMaxHeight
+                width: TF.barWidth,
+                height: TF.barHeight + TF.transcriptPopupGap + 180
             ),
             capsuleSize: NSSize(width: TF.barWidthCompact, height: TF.barHeight)
         )
@@ -363,7 +385,7 @@ final class AppStateTests: XCTestCase {
         let wideCapsuleLayout = FloatingBarPanelLayout(
             contentSize: NSSize(
                 width: TF.barWidth,
-                height: TF.barHeight + TF.transcriptPopupGap + TF.transcriptPopupMaxHeight
+                height: TF.barHeight + TF.transcriptPopupGap + 240
             ),
             capsuleSize: NSSize(width: TF.barWidth, height: TF.barHeight)
         )

--- a/Type4MeTests/AppearancePreviewTests.swift
+++ b/Type4MeTests/AppearancePreviewTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 @testable import Type4Me
 
@@ -9,10 +10,12 @@ final class AppearancePreviewTests: XCTestCase {
         XCTAssertEqual(RecordingTheme.dark.rawValue, "dark")
         XCTAssertEqual(RecordingTheme.light.rawValue, "light")
         XCTAssertEqual(RecordingTheme.storageKey, "tf_recordingTheme")
-        XCTAssertEqual(RecordingTheme.defaultValue, .dark)
+        XCTAssertEqual(RecordingTheme.defaultValue, .light)
 
-        XCTAssertEqual(RecordingTheme.dark.displayName, L("暗色", "Dark"))
-        XCTAssertEqual(RecordingTheme.light.displayName, L("明亮", "Light"))
+        XCTAssertEqual(RecordingTheme.dark.displayName, L("纯色", "Solid"))
+        XCTAssertEqual(RecordingTheme.light.displayName, L("毛玻璃版本", "Frosted Glass"))
+        XCTAssertFalse(RecordingTheme.dark.usesGlass)
+        XCTAssertTrue(RecordingTheme.light.usesGlass)
     }
 
     func testRecordingIndicatorStyle_allCases() {
@@ -50,7 +53,7 @@ final class AppearancePreviewTests: XCTestCase {
 
     func testFloatingBarPresentation_defaults() {
         let presentation = FloatingBarPresentation()
-        XCTAssertEqual(presentation.theme, .dark)
+        XCTAssertEqual(presentation.theme, .light)
         XCTAssertEqual(presentation.indicatorStyle, .regular)
         XCTAssertEqual(presentation.visualStyle, .siri)
         XCTAssertTrue(presentation.showsLiveTranscript)
@@ -70,6 +73,117 @@ final class AppearancePreviewTests: XCTestCase {
         XCTAssertTrue(AppearancePreferenceDefaults.showCancelButtonDefault)
     }
 
+    func testRecordingGlassTuning_defaultsMatchCurrentSurface() {
+        let tuning = RecordingGlassTuning()
+
+        XCTAssertEqual(tuning.transparency, 0.10)
+        XCTAssertEqual(tuning.materialOpacity, 0.90)
+    }
+
+    func testRecordingGlassTuning_clampsCompositingValues() {
+        let tuning = RecordingGlassTuning(transparency: 1.4)
+
+        XCTAssertEqual(tuning.transparency, 1)
+        XCTAssertEqual(tuning.materialOpacity, 0)
+    }
+
+    func testRecordingSolidColorDefaultsToWhiteAndAdaptsContrast() {
+        let defaultColor = RecordingSolidColor(hex: RecordingSolidColor.defaultHex)
+        XCTAssertEqual(defaultColor.hex, "#FFFFFF")
+        XCTAssertTrue(defaultColor.usesDarkForeground)
+
+        let light = RecordingSolidColor(hex: "#F6F6F8")
+        XCTAssertEqual(light.hex, "#F6F6F8")
+        XCTAssertTrue(light.usesDarkForeground)
+
+        XCTAssertEqual(
+            RecordingSolidColor(hex: "not-a-color").hex,
+            RecordingSolidColor.defaultHex
+        )
+    }
+
+    func testRecordingGlassTuning_migratesLegacyOpacityToTransparency() throws {
+        let suiteName = "Type4MeTests.RecordingGlassTuning.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(0.7, forKey: "tf_recordingGlassMaterialOpacity")
+
+        RecordingGlassTuning.migrateLegacyPreferencesIfNeeded(userDefaults: defaults)
+
+        XCTAssertEqual(
+            defaults.double(forKey: RecordingGlassTuning.transparencyKey),
+            0.3,
+            accuracy: 0.001
+        )
+    }
+
+    func testVisualEffectBlurConfigurationAppliesNativeGlassControls() {
+        let visualEffect = VisualEffectBlur(
+            cornerRadius: 17,
+            blendingMode: .withinWindow,
+            appearanceName: .aqua,
+            blurEffect: .frosted,
+            transparency: 0.58,
+            tintColor: NSColor(white: 0.25, alpha: 0.4)
+        )
+        let view = RecordingGlassEffectHostView()
+
+        visualEffect.configure(view)
+
+        XCTAssertEqual(view.alphaValue, 0.42, accuracy: 0.001)
+        XCTAssertEqual(view.layer?.cornerRadius, 17)
+        XCTAssertEqual(view.appearance?.name, .aqua)
+        XCTAssertEqual(view.appliedBlurEffect, .frosted)
+        XCTAssertEqual(view.appliedTintColor, NSColor(white: 0.25, alpha: 0.4))
+        if #available(macOS 26.0, *) {
+            XCTAssertTrue(view.usesNativeLiquidGlass)
+            XCTAssertEqual(view.nativeGlassStyle, .regular)
+            XCTAssertEqual(view.nativeGlassTintColor, NSColor(white: 0.25, alpha: 0.4))
+        }
+
+        VisualEffectBlur(
+            blurEffect: .clear,
+            transparency: 0.58
+        ).configure(view)
+        XCTAssertEqual(view.appliedBlurEffect, .clear)
+        XCTAssertEqual(view.alphaValue, 0.42, accuracy: 0.001)
+        XCTAssertNil(view.appliedTintColor)
+        XCTAssertEqual(view.subviews.count, 1)
+        if #available(macOS 26.0, *) {
+            XCTAssertEqual(view.nativeGlassStyle, .clear)
+            XCTAssertNil(view.nativeGlassTintColor)
+        }
+    }
+
+    func testNativeGlassStyleUpdatesReuseHostAndPreserveCompositorInputs() {
+        guard #available(macOS 26.0, *) else { return }
+
+        let view = RecordingGlassEffectHostView()
+        let combinations: [(RecordingGlassBlurEffect, Double, CGFloat, CGFloat)] = [
+            (.clear, 0.15, 0.2, 0.35),
+            (.frosted, 0.65, 0.8, 0.75),
+        ]
+
+        for (blurEffect, transparency, luminance, tintStrength) in combinations {
+            let tint = NSColor(white: luminance, alpha: tintStrength)
+            VisualEffectBlur(
+                cornerRadius: 22,
+                blurEffect: blurEffect,
+                transparency: transparency,
+                tintColor: tint
+            ).configure(view)
+
+            XCTAssertEqual(
+                view.nativeGlassStyle,
+                blurEffect == .frosted ? .regular : .clear
+            )
+            XCTAssertEqual(view.alphaValue, 1 - transparency, accuracy: 0.001)
+            XCTAssertEqual(view.nativeGlassTintColor, tint)
+            XCTAssertEqual(view.layer?.cornerRadius, 22)
+            XCTAssertEqual(view.subviews.count, 1)
+        }
+    }
+
     func testRecordingMetadataDisplayPreferenceDefaults() {
         XCTAssertTrue(RecordingMetadataDisplayPreference.showModeNameDefault)
         XCTAssertFalse(RecordingMetadataDisplayPreference.showProviderNameDefault)
@@ -77,14 +191,64 @@ final class AppearancePreviewTests: XCTestCase {
     }
 
     func testRecordingChromeWidthDesignTokens() {
-        // Dual-button chrome: Finish(45) + Cancel(35) + LeadingInset(5) + TrailingInset(10) + Gap*2(16) + Safety(16) = 127
-        XCTAssertEqual(TF.recordingChromeWidth, 127)
-        // Single-button chrome: Finish(45) + LeadingInset(5) + TrailingInset(10) + Gap(8) + Safety(16) = 84
-        XCTAssertEqual(TF.recordingSingleButtonChromeWidth, 84)
-        // Difference is exactly one cancel control size (35) plus one control gap (8)
+        // Both controls use 45pt layout slots, even though cancel draws a 35pt
+        // circle. Equal slots keep the middle text lane centered.
+        XCTAssertEqual(TF.recordingControlSlotSize, 45)
+        XCTAssertEqual(TF.recordingChromeWidth, 138)
+        // With cancel hidden, its slot disappears; a 22pt trailing buffer
+        // mirrors the orb-side gap plus the 14pt text fade guard.
+        XCTAssertEqual(TF.recordingSingleButtonMirroredTextBuffer, 22)
+        XCTAssertEqual(TF.recordingSingleButtonChromeWidth, 107)
+        XCTAssertEqual(TF.recordingSingleButtonMinimumWidth, 110)
+        XCTAssertEqual(TF.recordingTranscriptFadeWidth, 14)
+    }
+
+    func testSingleButtonRecordingWidthRemovesTheMissingControlsSlot() {
+        let listeningTextWidth: CGFloat = 42
+        let dualButtonWidth = recordingBaseCapsuleWidth(
+            textWidth: listeningTextWidth,
+            showsCancelButton: true
+        )
+        let singleButtonWidth = recordingBaseCapsuleWidth(
+            textWidth: listeningTextWidth,
+            showsCancelButton: false
+        )
+
+        XCTAssertEqual(dualButtonWidth, 180)
+        XCTAssertEqual(singleButtonWidth, 149)
+        XCTAssertLessThan(singleButtonWidth, dualButtonWidth)
         XCTAssertEqual(
-            TF.recordingChromeWidth - TF.recordingSingleButtonChromeWidth,
-            TF.recordingCancelControlSize + TF.recordingControlGap
+            singleButtonWidth - listeningTextWidth,
+            TF.recordingSingleButtonChromeWidth
+        )
+
+        let textLaneWidth = singleButtonWidth
+            - TF.recordingEdgeInset * 2
+            - TF.recordingControlSlotSize
+            - TF.recordingControlGap
+            - TF.recordingSingleButtonMirroredTextBuffer
+        let laneSlack = (textLaneWidth - listeningTextWidth) / 2
+        XCTAssertEqual(laneSlack, 8)
+
+        // The reserved trailing area remains outside the text lane even after
+        // the capsule reaches its 400pt maximum width.
+        let maximumTextLaneWidth = TF.barWidth
+            - TF.recordingEdgeInset * 2
+            - TF.recordingControlSlotSize
+            - TF.recordingControlGap
+            - TF.recordingSingleButtonMirroredTextBuffer
+        XCTAssertEqual(maximumTextLaneWidth, 309)
+        XCTAssertEqual(
+            TF.recordingEdgeInset + TF.recordingSingleButtonMirroredTextBuffer,
+            30
+        )
+    }
+
+    func testRecordingModeHintWidthExpandsAroundAClampedCenter() {
+        XCTAssertEqual(recordingModeHintWidth(textWidth: 100), 124)
+        XCTAssertEqual(
+            recordingModeHintWidth(textWidth: 1_000),
+            TF.barWidth + TF.recordingTooltipOverhang * 2
         )
     }
 


### PR DESCRIPTION
## Summary

- replace the floating bar global color approximation with native spatial glass that samples content beneath the window
- expose live frosted-glass transparency, blur style, grayscale tint, and tint-strength tuning in Appearance settings
- keep a user-editable solid-color theme while making frosted glass the new default
- refine recording geometry, centered expansion, hover transcript sizing, long-text trailing space, and symmetric tooltip placement
- prewarm panel composition and the Metal orb to reduce first-show hitches
- restore shape-aware rim depth with contact and ambient shadows

## Validation

- swift test: 969 tests passed, 2 skipped, 0 failures
- git diff checks passed
- pure universal app packaged and exercised locally for this UI iteration