### PR TITLE
Fix bilingual settings sidebar label wrapping

### DIFF
--- a/Type4Me/UI/Settings/SettingsView.swift
+++ b/Type4Me/UI/Settings/SettingsView.swift
@@ -273,6 +273,8 @@ struct SettingsView: View {
                 Text(tab.displayName)
                     .font(.system(size: 14, weight: isActive ? .semibold : .medium))
                     .foregroundStyle(TF.settingsText)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
                 Spacer()
                 if tab == .preferences {
                     Text(AppBuildInfo.current.compactLabel)


### PR DESCRIPTION
## Summary
- Keep sidebar navigation labels on one line in both English and Chinese.
- Preserve the version label as an independently truncated value.

## Verification
- swift build -c release: passed

## Screenshots

Current release
English
<img width="214" height="66" alt="image" src="https://github.com/user-attachments/assets/b0926a6d-ead8-4d24-9345-1cf5a512a067" />

Chinese is okay
<img width="235" height="76" alt="image" src="https://github.com/user-attachments/assets/7232484e-7af5-4dce-8e15-7550583cf647" />


With this PR
English
<img width="243" height="47" alt="image" src="https://github.com/user-attachments/assets/9914d81c-8a74-4208-aff2-218de54117c6" />

Chinese
<img width="245" height="65" alt="image" src="https://github.com/user-attachments/assets/c7775843-09ce-4aea-9a12-d5b4c0bdaf19" />


Closes #275.