### PR TITLE
fix(injection): prevent false-negative injection detection for terminal emulators

### DIFF
--- a/Type4Me/Injection/TextInjectionEngine.swift
+++ b/Type4Me/Injection/TextInjectionEngine.swift
@@ -745,20 +745,20 @@ final class TextInjectionEngine: @unchecked Sendable {
         case restoreOriginal
     }
 
-    private struct FocusedElementSnapshot {
-        let element: AXUIElement?
-        let processIdentifier: pid_t?
-        let bundleIdentifier: String?
-        let role: String?
-        let subrole: String?
-        let value: String?
-        let placeholder: String?
-        let accessibilityDescription: String?
-        let selectedRange: NSRange?
-        let isEditable: Bool
+    struct FocusedElementSnapshot {
+        var element: AXUIElement? = nil
+        var processIdentifier: pid_t? = nil
+        var bundleIdentifier: String? = nil
+        var role: String? = nil
+        var subrole: String? = nil
+        var value: String? = nil
+        var placeholder: String? = nil
+        var accessibilityDescription: String? = nil
+        var selectedRange: NSRange? = nil
+        var isEditable: Bool = false
         /// true when AX successfully found a focused UI element; false when
         /// no element was found (e.g. desktop, no focused window).
-        let hasFocusedElement: Bool
+        var hasFocusedElement: Bool = true
     }
 
     typealias ClipboardSnapshot = Type4Me.ClipboardSnapshot
@@ -1510,7 +1510,7 @@ final class TextInjectionEngine: @unchecked Sendable {
             // result remains in the clipboard. Never claim `.inserted` here.
             outcome = .pasteAttemptedClipboardRetained
         } else {
-            let detectedOutcome = inferInjectionOutcome(
+            let detectedOutcome = Self.inferInjectionOutcome(
                 before: before,
                 after: after,
                 pastedText: text
@@ -1869,7 +1869,60 @@ final class TextInjectionEngine: @unchecked Sendable {
         return NSRange(location: prefixLength, length: pastedLength)
     }
 
-    private func inferInjectionOutcome(
+    /// Standard macOS Accessibility roles representing static UI elements or
+    /// controls that do not accept text input when focused.
+    static let knownNonEditableRoles: Set<String> = [
+        "AXApplication",
+        "AXWindow",
+        "AXSheet",
+        "AXDialog",
+        "AXAlert",
+        "AXDrawer",
+        "AXPopover",
+        "AXGroup",
+        "AXSplitGroup",
+        "AXScrollArea",
+        "AXButton",
+        "AXPopUpButton",
+        "AXMenuButton",
+        "AXMenu",
+        "AXMenuItem",
+        "AXMenuBar",
+        "AXMenuBarItem",
+        "AXCheckBox",
+        "AXRadioButton",
+        "AXRadioGroup",
+        "AXTabGroup",
+        "AXSlider",
+        "AXColorWell",
+        "AXImage",
+        "AXStaticText",
+        "AXProgressIndicator",
+        "AXScrollBar",
+        "AXToolbar",
+        "AXTable",
+        "AXOutline",
+        "AXRow",
+        "AXColumn",
+        "AXCell",
+        "AXList",
+        "AXHeading",
+        "AXLink",
+        "AXDisclosureTriangle",
+        "AXIncrementor",
+        "AXLevelIndicator",
+        "AXPage",
+        "AXRuler",
+        "AXRulerMarker",
+        "AXSplitter",
+        "AXValueIndicator",
+    ]
+    static func isKnownNonEditableRole(_ role: String?) -> Bool {
+        guard let role else { return false }
+        return knownNonEditableRoles.contains(role)
+    }
+
+    static func inferInjectionOutcome(
         before: FocusedElementSnapshot?,
         after: FocusedElementSnapshot?,
         pastedText: String
@@ -1903,8 +1956,15 @@ final class TextInjectionEngine: @unchecked Sendable {
             return .inserted
         }
 
-        // Not editable and value didn't change → paste had nowhere to go
-        return .copiedToClipboard
+        // Standard non-editable controls (buttons, images, static labels, etc.)
+        // where pasting has nowhere to go.
+        if isKnownNonEditableRole(before.role) || isKnownNonEditableRole(after.role) {
+            return .copiedToClipboard
+        }
+
+        // Opaque, terminal, or custom rendering surfaces (e.g. AXUnknown, nil,
+        // or custom canvas) that possess focus in an active application: assume Cmd+V worked.
+        return .inserted
     }
 
 

--- a/Type4MeTests/TextInjectionOutcomeTests.swift
+++ b/Type4MeTests/TextInjectionOutcomeTests.swift
@@ -1,0 +1,273 @@
+import XCTest
+@testable import Type4Me
+
+final class TextInjectionOutcomeTests: XCTestCase {
+
+    func testTerminalWithAXUnknownRoleIsInferredAsInserted() {
+        // Reproduce real kooky terminal scenario from debug.log:
+        // bundle=com.iamcorey.kooky role=AXUnknown editable=false hasFocus=true valueLength=-1
+        let before = TextInjectionEngine.FocusedElementSnapshot(
+            bundleIdentifier: "com.iamcorey.kooky",
+            role: "AXUnknown",
+            value: nil,
+            isEditable: false,
+            hasFocusedElement: true
+        )
+        let after = TextInjectionEngine.FocusedElementSnapshot(
+            bundleIdentifier: "com.iamcorey.kooky",
+            role: "AXUnknown",
+            value: nil,
+            isEditable: false,
+            hasFocusedElement: true
+        )
+
+        let outcome = TextInjectionEngine.inferInjectionOutcome(
+            before: before,
+            after: after,
+            pastedText: "echo hello"
+        )
+
+        XCTAssertEqual(outcome, .inserted)
+    }
+
+    func testTerminalWithNilRoleIsInferredAsInserted() {
+        let before = TextInjectionEngine.FocusedElementSnapshot(
+            bundleIdentifier: "com.mitchellh.ghostty",
+            role: nil,
+            value: nil,
+            isEditable: false,
+            hasFocusedElement: true
+        )
+        let after = TextInjectionEngine.FocusedElementSnapshot(
+            bundleIdentifier: "com.mitchellh.ghostty",
+            role: nil,
+            value: nil,
+            isEditable: false,
+            hasFocusedElement: true
+        )
+
+        let outcome = TextInjectionEngine.inferInjectionOutcome(
+            before: before,
+            after: after,
+            pastedText: "git status"
+        )
+
+        XCTAssertEqual(outcome, .inserted)
+    }
+
+    func testStandardEditableFieldIsInferredAsInserted() {
+        let before = TextInjectionEngine.FocusedElementSnapshot(
+            bundleIdentifier: "ru.keepcoder.Telegram",
+            role: "AXTextArea",
+            value: "existing",
+            isEditable: true,
+            hasFocusedElement: true
+        )
+        let after = TextInjectionEngine.FocusedElementSnapshot(
+            bundleIdentifier: "ru.keepcoder.Telegram",
+            role: "AXTextArea",
+            value: "existing pasted",
+            isEditable: true,
+            hasFocusedElement: true
+        )
+
+        let outcome = TextInjectionEngine.inferInjectionOutcome(
+            before: before,
+            after: after,
+            pastedText: " pasted"
+        )
+
+        XCTAssertEqual(outcome, .inserted)
+    }
+
+    func testValueChangedIsInferredAsInserted() {
+        let before = TextInjectionEngine.FocusedElementSnapshot(
+            bundleIdentifier: "com.apple.TextEdit",
+            role: "AXTextArea",
+            value: "before",
+            isEditable: false,
+            hasFocusedElement: true
+        )
+        let after = TextInjectionEngine.FocusedElementSnapshot(
+            bundleIdentifier: "com.apple.TextEdit",
+            role: "AXTextArea",
+            value: "before after",
+            isEditable: false,
+            hasFocusedElement: true
+        )
+
+        let outcome = TextInjectionEngine.inferInjectionOutcome(
+            before: before,
+            after: after,
+            pastedText: " after"
+        )
+
+        XCTAssertEqual(outcome, .inserted)
+    }
+
+    func testBlindAppWithoutFocusedElementIsInferredAsInserted() {
+        // WeChat AX blind case: hasFocusedElement = false
+        let before = TextInjectionEngine.FocusedElementSnapshot(
+            bundleIdentifier: "com.tencent.xinWeChat",
+            role: nil,
+            value: nil,
+            isEditable: false,
+            hasFocusedElement: false
+        )
+        let after = TextInjectionEngine.FocusedElementSnapshot(
+            bundleIdentifier: "com.tencent.xinWeChat",
+            role: nil,
+            value: nil,
+            isEditable: false,
+            hasFocusedElement: false
+        )
+
+        let outcome = TextInjectionEngine.inferInjectionOutcome(
+            before: before,
+            after: after,
+            pastedText: "微信消息"
+        )
+
+        XCTAssertEqual(outcome, .inserted)
+    }
+
+    func testKnownNonEditableControlIsInferredAsCopiedToClipboard() {
+        // When focused on a standard non-editable button or static label
+        let before = TextInjectionEngine.FocusedElementSnapshot(
+            bundleIdentifier: "com.apple.finder",
+            role: "AXButton",
+            value: nil,
+            isEditable: false,
+            hasFocusedElement: true
+        )
+        let after = TextInjectionEngine.FocusedElementSnapshot(
+            bundleIdentifier: "com.apple.finder",
+            role: "AXButton",
+            value: nil,
+            isEditable: false,
+            hasFocusedElement: true
+        )
+
+        let outcome = TextInjectionEngine.inferInjectionOutcome(
+            before: before,
+            after: after,
+            pastedText: "test"
+        )
+
+        XCTAssertEqual(outcome, .copiedToClipboard)
+    }
+    func testDesktopWithoutBundleIdentifierIsInferredAsCopiedToClipboard() {
+        let before = TextInjectionEngine.FocusedElementSnapshot(
+            bundleIdentifier: nil,
+            role: nil,
+            value: nil,
+            isEditable: false,
+            hasFocusedElement: false
+        )
+        let after = TextInjectionEngine.FocusedElementSnapshot(
+            bundleIdentifier: nil,
+            role: nil,
+            value: nil,
+            isEditable: false,
+            hasFocusedElement: false
+        )
+
+        let outcome = TextInjectionEngine.inferInjectionOutcome(
+            before: before,
+            after: after,
+            pastedText: "test"
+        )
+
+        XCTAssertEqual(outcome, .copiedToClipboard)
+    }
+
+    func testOpaqueNilSnapshotIsInferredAsInserted() {
+        let outcome1 = TextInjectionEngine.inferInjectionOutcome(
+            before: nil,
+            after: nil,
+            pastedText: "test"
+        )
+        XCTAssertEqual(outcome1, .inserted)
+
+        let snapshot = TextInjectionEngine.FocusedElementSnapshot(
+            bundleIdentifier: "com.iamcorey.kooky",
+            role: "AXUnknown",
+            hasFocusedElement: true
+        )
+        let outcome2 = TextInjectionEngine.inferInjectionOutcome(
+            before: snapshot,
+            after: nil,
+            pastedText: "test"
+        )
+        XCTAssertEqual(outcome2, .inserted)
+    }
+
+    func testVariousKnownNonEditableRolesAreInferredAsCopiedToClipboard() {
+        let nonEditableRoles = [
+            "AXApplication",
+            "AXWindow",
+            "AXGroup",
+            "AXScrollArea",
+            "AXSheet",
+            "AXButton",
+            "AXStaticText",
+            "AXImage",
+            "AXProgressIndicator",
+            "AXSlider",
+            "AXCheckBox",
+            "AXRadioButton",
+            "AXTable",
+            "AXOutline",
+        ]
+        for role in nonEditableRoles {
+            let before = TextInjectionEngine.FocusedElementSnapshot(
+                bundleIdentifier: "com.apple.finder",
+                role: role,
+                value: nil,
+                isEditable: false,
+                hasFocusedElement: true
+            )
+            let after = TextInjectionEngine.FocusedElementSnapshot(
+                bundleIdentifier: "com.apple.finder",
+                role: role,
+                value: nil,
+                isEditable: false,
+                hasFocusedElement: true
+            )
+
+            let outcome = TextInjectionEngine.inferInjectionOutcome(
+                before: before,
+                after: after,
+                pastedText: "test"
+            )
+            XCTAssertEqual(
+                outcome,
+                .copiedToClipboard,
+                "Role \(role) should be classified as copiedToClipboard when non-editable"
+            )
+        }
+    }
+
+    func testFinalizeOutcomeBehaviorMatrix() {
+        XCTAssertEqual(
+            TextInjectionEngine.finalizeOutcome(.inserted, retention: .restoreOriginal),
+            .inserted
+        )
+        XCTAssertEqual(
+            TextInjectionEngine.finalizeOutcome(.inserted, retention: .retainResult),
+            .inserted
+        )
+        XCTAssertEqual(
+            TextInjectionEngine.finalizeOutcome(.copiedToClipboard, retention: .restoreOriginal),
+            .notInserted
+        )
+        XCTAssertEqual(
+            TextInjectionEngine.finalizeOutcome(.copiedToClipboard, retention: .retainResult),
+            .copiedToClipboard
+        )
+        XCTAssertEqual(
+            TextInjectionEngine.finalizeOutcome(.pasteAttemptedClipboardRetained, retention: .restoreOriginal),
+            .pasteAttemptedClipboardRetained
+        )
+    }
+}


### PR DESCRIPTION
## 背景与问题

在终端模拟器（如 Kooky、Ghostty、Alacritty 等）或部分 Metal / 自定义渲染应用中进行语音录音输入时，`Cmd+V` 实际上已经成功将文字粘贴至终端缓冲区，但浮动条会提示「未找到可输入的位置」（`No editable field found`）。

### 根因分析

在 `TextInjectionEngine.swift` 的 `inferInjectionOutcome` 中：
1. 终端模拟器在获得焦点时，macOS Accessibility (AX) 返回的节点属性通常为 `role=AXUnknown` 或 `role=nil`，且 `isEditable=false`、`value=nil`（终端不暴露标准 AX 文本值）。
2. 旧的判定逻辑将「拿到了焦点元素（`hasFocusedElement == true`）但 `isEditable == false` 且内容未变」全部归类为「无法粘贴」（`.copiedToClipboard`），在默认的 `.restoreOriginal` 剪贴板策略下进一步转换为 `.notInserted`（触发「未找到可输入的位置」提示）。

## 修复方案

1. **精确定义标准非编辑角色集合 (`knownNonEditableRoles`)**：
   - 包含明确不能接收文本输入的标准控件（`AXButton`, `AXImage`, `AXStaticText`, `AXSlider`, `AXTable` 等）以及标准窗口容器（`AXWindow`, `AXApplication`, `AXGroup`, `AXScrollArea`, `AXSheet`, `AXDialog` 等）。
   - 当且仅当焦点处于这些明确的不可编辑角色时，才判定为无法粘贴（`.copiedToClipboard` / `.notInserted`）。
2. **信任盲区与终端/自定义渲染表面**：
   - 对 `AXUnknown`、`nil` 或非标准自渲染角色，视同盲区应用（如微信），信任前台 `Cmd+V` 事件，判定为 `.inserted`（展示「已完成」）。
3. **单元测试覆盖**：
   - 新增 `Type4MeTests/TextInjectionOutcomeTests.swift`，覆盖了 Kooky（`AXUnknown`）、Ghostty（`nil`）、微信盲区、标准文本框、容器类与标准不可编辑控件等 10 个测试用例。

## 验证

- `swift test`：1024 个 XCTest + 5 个 Swift Testing 全部通过。
- 实机验证：在 Kooky 终端中进行实机录音测试，文字正常输入且浮动指示条正确展示「已完成」。