### PR TITLE
feat: Graceful permission onboarding, 2-step setup wizard, and floating model alerts

### DIFF
--- a/Type4Me/Input/HotkeyManager.swift
+++ b/Type4Me/Input/HotkeyManager.swift
@@ -324,11 +324,9 @@ final class HotkeyManager: NSObject {
 
     // MARK: - Configuration
 
-    /// Global keyboard shortcuts must be observed before app-level consumers such as
-    /// Feishu/Lark can consume a bare Fn event. Always prefer the HID tap and retain the
-    /// session tap as a compatibility fallback when HID access is unavailable.
+    /// Session-level tap ensures global shortcuts work reliably without intercepting
+    /// hardware IOHID streams, preventing kernel-level input freezes upon runtime permission changes.
     internal static let tapLocationPriority: [CGEventTapLocation] = [
-        .cghidEventTap,
         .cgSessionEventTap,
     ]
 

--- a/Type4Me/Input/HotkeyManager.swift
+++ b/Type4Me/Input/HotkeyManager.swift
@@ -324,11 +324,9 @@ final class HotkeyManager: NSObject {
 
     // MARK: - Configuration
 
-    /// Global keyboard shortcuts must be observed before app-level consumers such as
-    /// Feishu/Lark can consume a bare Fn event. Always prefer the HID tap and retain the
-    /// session tap as a compatibility fallback when HID access is unavailable.
+    /// Session-level tap ensures global shortcuts work without intercepting hardware
+    /// IOHID streams, preventing kernel-level input freezes upon runtime permission changes.
     internal static let tapLocationPriority: [CGEventTapLocation] = [
-        .cghidEventTap,
         .cgSessionEventTap,
     ]
 
@@ -526,18 +524,9 @@ final class HotkeyManager: NSObject {
             (1 << CGEventType.keyDown.rawValue)
             | (1 << CGEventType.keyUp.rawValue)
             | (1 << CGEventType.flagsChanged.rawValue)
-            | (1 << CGEventType.leftMouseDown.rawValue)
-            | (1 << CGEventType.leftMouseUp.rawValue)
-            | (1 << CGEventType.rightMouseDown.rawValue)
-            | (1 << CGEventType.rightMouseUp.rawValue)
             | (1 << CGEventType.otherMouseDown.rawValue)
             | (1 << CGEventType.otherMouseUp.rawValue)
-            | (1 << CGEventType.leftMouseDragged.rawValue)
-            | (1 << CGEventType.rightMouseDragged.rawValue)
-            | (1 << CGEventType.otherMouseDragged.rawValue)
-            | (1 << CGEventType.scrollWheel.rawValue)
             | (hasMediaKeyBindings ? (1 << 14) : 0)  // kCGEventSystemDefined (NX_SYSDEFINED) for media/headphone keys
-
         let userInfo = Unmanaged.passUnretained(self).toOpaque()
 
         var tap: CFMachPort?

--- a/Type4Me/Input/HotkeyManager.swift
+++ b/Type4Me/Input/HotkeyManager.swift
@@ -524,8 +524,16 @@ final class HotkeyManager: NSObject {
             (1 << CGEventType.keyDown.rawValue)
             | (1 << CGEventType.keyUp.rawValue)
             | (1 << CGEventType.flagsChanged.rawValue)
+            | (1 << CGEventType.leftMouseDown.rawValue)
+            | (1 << CGEventType.leftMouseUp.rawValue)
+            | (1 << CGEventType.rightMouseDown.rawValue)
+            | (1 << CGEventType.rightMouseUp.rawValue)
             | (1 << CGEventType.otherMouseDown.rawValue)
             | (1 << CGEventType.otherMouseUp.rawValue)
+            | (1 << CGEventType.leftMouseDragged.rawValue)
+            | (1 << CGEventType.rightMouseDragged.rawValue)
+            | (1 << CGEventType.otherMouseDragged.rawValue)
+            | (1 << CGEventType.scrollWheel.rawValue)
             | (hasMediaKeyBindings ? (1 << 14) : 0)  // kCGEventSystemDefined (NX_SYSDEFINED) for media/headphone keys
         let userInfo = Unmanaged.passUnretained(self).toOpaque()
 

--- a/Type4Me/Input/HotkeyManager.swift
+++ b/Type4Me/Input/HotkeyManager.swift
@@ -689,6 +689,14 @@ final class HotkeyManager: NSObject {
         lastEventTime = Date()
         didDispatchBindingCallback = false
 
+        // Immediate fail-open guard: if Accessibility permission was revoked at runtime,
+        // tear down the active tap immediately and pass the event untouched to the system.
+        guard PermissionManager.hasAccessibilityPermission else {
+            TextInjectionEngine.globalInputMonitorDidStop()
+            DebugFileLogger.log("hotkey event tap untrusted during event handling, tearing down immediately")
+            tearDownEventTap(finalState: .revoked)
+            return Unmanaged.passUnretained(event)
+        }
         let recovery = Self.recoveryAction(
             for: type,
             isAccessibilityTrusted: PermissionManager.hasAccessibilityPermission

--- a/Type4Me/Input/HotkeyManager.swift
+++ b/Type4Me/Input/HotkeyManager.swift
@@ -417,6 +417,62 @@ final class HotkeyManager: NSObject {
     /// false if the app is not actually in an active session (ESC should pass through).
     var onESCAbort: (() -> Bool)?
 
+    internal enum EventTapRecoveryAction: Equatable {
+        case reenable
+        case revoke
+        case passThrough
+    }
+
+    private enum EventTapLifecycleState: Equatable {
+        case stopped
+        case starting
+        case running
+        case stopping
+        case revoked
+    }
+
+    private var eventTapLifecycleState: EventTapLifecycleState = .stopped
+    private var eventTapRunLoop: CFRunLoop?
+    private var hasEmittedAccessibilityRevoked = false
+    var onAccessibilityRevoked: (() -> Void)?
+
+    internal var eventTapLifecycleStateDescription: String {
+        switch eventTapLifecycleState {
+        case .stopped: return "stopped"
+        case .starting: return "starting"
+        case .running: return "running"
+        case .stopping: return "stopping"
+        case .revoked: return "revoked"
+        }
+    }
+
+    internal static func recoveryAction(
+        for type: CGEventType,
+        isAccessibilityTrusted: Bool
+    ) -> EventTapRecoveryAction {
+        if !isAccessibilityTrusted {
+            if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+                return .revoke
+            }
+        } else {
+            if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+                return .reenable
+            }
+        }
+        return .passThrough
+    }
+    internal func simulateRevocationForTesting() {
+        if eventTapLifecycleState != .running && eventTapLifecycleState != .revoked {
+            eventTapLifecycleState = .running
+        }
+        tearDownEventTap(finalState: .revoked)
+    }
+
+    internal func resetRevocationGenerationForTesting() {
+        hasEmittedAccessibilityRevoked = false
+        eventTapLifecycleState = .running
+    }
+
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var healthCheckTimer: Timer?
@@ -429,7 +485,6 @@ final class HotkeyManager: NSObject {
     /// Tokens for MPRemoteCommandCenter handlers (prevents Apple Music from auto-launching).
     private var mediaCommandTokens: [(command: MPRemoteCommand, token: Any)] = []
     private var isMediaSessionActive = false
-
     // MARK: - Registration
 
     func registerBindings(_ newBindings: [ModeBinding]) {
@@ -450,6 +505,21 @@ final class HotkeyManager: NSObject {
 
     @discardableResult
     func start() -> Bool {
+        if eventTapLifecycleState == .running,
+           let tap = eventTap,
+           CFMachPortIsValid(tap),
+           CGEvent.tapIsEnabled(tap: tap) {
+            return true
+        }
+
+        guard PermissionManager.hasAccessibilityPermission else {
+            tearDownEventTap(finalState: .revoked)
+            return false
+        }
+
+        tearDownEventTap(finalState: .stopped)
+        eventTapLifecycleState = .starting
+
         let hasMediaKeyBindings = bindings.contains { $0.isMediaKey }
 
         let eventMask: CGEventMask =
@@ -487,7 +557,7 @@ final class HotkeyManager: NSObject {
         }
 
         guard let tap = tap else {
-            TextInjectionEngine.globalInputMonitorDidStop()
+            tearDownEventTap(finalState: .stopped)
             return false
         }
 
@@ -499,18 +569,19 @@ final class HotkeyManager: NSObject {
         eventTap = tap
         lastEventTime = nil
 
+        let currentRunLoop = CFRunLoopGetCurrent()
+        eventTapRunLoop = currentRunLoop
         let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
         runLoopSource = source
-        CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
+        CFRunLoopAddSource(currentRunLoop, source, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
         guard CGEvent.tapIsEnabled(tap: tap) else {
-            TextInjectionEngine.globalInputMonitorDidStop()
-            CGEvent.tapEnable(tap: tap, enable: false)
-            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
-            eventTap = nil
-            runLoopSource = nil
+            tearDownEventTap(finalState: .stopped)
             return false
         }
+
+        eventTapLifecycleState = .running
+        hasEmittedAccessibilityRevoked = false
         TextInjectionEngine.globalInputMonitorDidStart(eventTap: tap)
 
         startHealthCheck()
@@ -519,19 +590,36 @@ final class HotkeyManager: NSObject {
     }
 
     func stop() {
-        TextInjectionEngine.globalInputMonitorDidStop()
-        deactivateMediaKeySession()
+        tearDownEventTap(finalState: .stopped)
+    }
+
+    private func tearDownEventTap(finalState: EventTapLifecycleState) {
+        let previousState = eventTapLifecycleState
+        eventTapLifecycleState = .stopping
+
         healthCheckTimer?.invalidate()
         healthCheckTimer = nil
+
+        deactivateMediaKeySession()
+        TextInjectionEngine.globalInputMonitorDidStop()
+
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: false)
         }
         if let source = runLoopSource {
-            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+            let runLoop = eventTapRunLoop ?? CFRunLoopGetCurrent()
+            CFRunLoopRemoveSource(runLoop, source, .commonModes)
+            CFRunLoopSourceInvalidate(source)
         }
+        if let tap = eventTap {
+            CFMachPortInvalidate(tap)
+        }
+
         eventTap = nil
         runLoopSource = nil
+        eventTapRunLoop = nil
         lastEventTime = nil
+
         holdState = [:]
         wasModifierDown = [:]
         clearActiveRecordingState()
@@ -541,16 +629,35 @@ final class HotkeyManager: NSObject {
         gestureState = .idle
         previousModifierFlags = []
         heldModifierKeyCodes.removeAll()
+
+        eventTapLifecycleState = finalState
+
+        if finalState == .revoked {
+            if previousState == .running && !hasEmittedAccessibilityRevoked {
+                hasEmittedAccessibilityRevoked = true
+                DispatchQueue.main.async { [weak self] in
+                    self?.onAccessibilityRevoked?()
+                }
+            }
+        }
     }
 
     // MARK: - Health check
 
-    /// Periodically verify the event tap is actually alive.
-    /// Detects the "silent disable" race where tapCreate succeeds but the tap is dead.
+    /// Periodically verify the event tap is actually alive and permission has not been lost.
     private func startHealthCheck() {
         healthCheckTimer?.invalidate()
-        healthCheckTimer = Timer.scheduledTimer(withTimeInterval: 10.0, repeats: true) { [weak self] _ in
-            guard let self, let tap = self.eventTap else { return }
+        let timer = Timer(timeInterval: 0.5, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            guard self.eventTapLifecycleState == .running else { return }
+
+            guard PermissionManager.hasAccessibilityPermission else {
+                DebugFileLogger.log("hotkey watchdog detected accessibility permission loss")
+                self.tearDownEventTap(finalState: .revoked)
+                return
+            }
+
+            guard let tap = self.eventTap else { return }
 
             // Check 1: Is the tap port still valid? Only recreate the tap for real invalidation,
             // not for normal idle periods with no keyboard/mouse input.
@@ -573,10 +680,15 @@ final class HotkeyManager: NSObject {
                 }
             }
         }
+        RunLoop.current.add(timer, forMode: .common)
+        healthCheckTimer = timer
     }
-
     /// Tear down and recreate the event tap from scratch.
     private func reinstallTap() {
+        guard PermissionManager.hasAccessibilityPermission else {
+            tearDownEventTap(finalState: .revoked)
+            return
+        }
         stop()
         let ok = start()
         NSLog("[Type4Me] Tap reinstall: %@", ok ? "OK" : "FAILED")
@@ -588,10 +700,17 @@ final class HotkeyManager: NSObject {
         lastEventTime = Date()
         didDispatchBindingCallback = false
 
-        // Re-enable tap if system disabled it, and recover any stuck hold states.
-        // When macOS disables the tap (main thread blocked >1s), keyUp events are lost.
-        // We must check if held keys are still physically down; if not, fire onStop.
-        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+        let recovery = Self.recoveryAction(
+            for: type,
+            isAccessibilityTrusted: PermissionManager.hasAccessibilityPermission
+        )
+        switch recovery {
+        case .revoke:
+            TextInjectionEngine.globalInputMonitorDidStop()
+            DebugFileLogger.log("hotkey event tap revoked on disabled event type=\(type.rawValue)")
+            tearDownEventTap(finalState: .revoked)
+            return Unmanaged.passUnretained(event)
+        case .reenable:
             TextInjectionEngine.globalInputMonitorDidStop()
             DebugFileLogger.log(
                 "hotkey event tap disabled type=\(type.rawValue) recording=\(activeRecordingBindingId != nil)"
@@ -600,13 +719,19 @@ final class HotkeyManager: NSObject {
             // Keep the monitor unavailable while a stuck hold is recovered so
             // that recovery-triggered stops cannot capture an opaque target.
             recoverStuckHolds()
-            if let tap = eventTap {
+            if let tap = eventTap, CFMachPortIsValid(tap) {
                 CGEvent.tapEnable(tap: tap, enable: true)
                 if CGEvent.tapIsEnabled(tap: tap) {
                     TextInjectionEngine.globalInputMonitorDidStart(eventTap: tap)
+                } else {
+                    reinstallTap()
                 }
+            } else {
+                reinstallTap()
             }
             return Unmanaged.passUnretained(event)
+        case .passThrough:
+            break
         }
 
         // Record the event before a matching stop hotkey invokes its callback.

--- a/Type4Me/Input/HotkeyManager.swift
+++ b/Type4Me/Input/HotkeyManager.swift
@@ -324,9 +324,11 @@ final class HotkeyManager: NSObject {
 
     // MARK: - Configuration
 
-    /// Session-level tap ensures global shortcuts work without intercepting hardware
-    /// IOHID streams, preventing kernel-level input freezes upon runtime permission changes.
+    /// Global keyboard shortcuts must be observed before app-level consumers such as
+    /// Feishu/Lark can consume a bare Fn event. Always prefer the HID tap and retain the
+    /// session tap as a compatibility fallback when HID access is unavailable.
     internal static let tapLocationPriority: [CGEventTapLocation] = [
+        .cghidEventTap,
         .cgSessionEventTap,
     ]
 

--- a/Type4Me/Permissions/PermissionDragOverlay.swift
+++ b/Type4Me/Permissions/PermissionDragOverlay.swift
@@ -156,8 +156,8 @@ final class PermissionDragOverlayController {
     private var panel: PermissionDragPanel?
     private var followTimer: Timer?
     private var permissionPollTimer: Timer?
+    private var timeoutTimer: Timer?
     private var onGranted: (() -> Void)?
-
     /// Show the overlay pinned to the System Settings window.
     ///
     /// - Parameters:
@@ -207,7 +207,9 @@ final class PermissionDragOverlayController {
         // is actively dragging the System Settings window, macOS puts the
         // main runloop into `.eventTracking` mode, and a default-mode timer
         // would pause exactly when we need it most. `.common` fires in both.
-        let followInterval: TimeInterval = 1.0 / 60.0
+        // Follow System Settings window motion at a throttled ~10Hz (100ms) interval
+        // to avoid saturating WindowServer IPC with high-frequency CGWindowList queries.
+        let followInterval: TimeInterval = 0.1
         let follow = Timer(timeInterval: followInterval, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated {
                 self?.reposition()
@@ -222,6 +224,13 @@ final class PermissionDragOverlayController {
                 self?.checkGranted()
             }
         }
+
+        // Auto-dismiss safety watchdog after 60 seconds of inactivity
+        timeoutTimer = Timer.scheduledTimer(withTimeInterval: 60.0, repeats: false) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.dismiss()
+            }
+        }
     }
 
     func dismiss() {
@@ -229,6 +238,8 @@ final class PermissionDragOverlayController {
         followTimer = nil
         permissionPollTimer?.invalidate()
         permissionPollTimer = nil
+        timeoutTimer?.invalidate()
+        timeoutTimer = nil
         panel?.orderOut(nil)
         panel = nil
         onGranted = nil

--- a/Type4Me/Permissions/PermissionGuideModel.swift
+++ b/Type4Me/Permissions/PermissionGuideModel.swift
@@ -1,5 +1,6 @@
 import AppKit
 import AVFoundation
+import Speech
 import Observation
 
 /// Coordinates the state + side-effects of the unified permission guide
@@ -22,8 +23,31 @@ final class PermissionGuideModel {
     /// macOS accepts a fresh drop even when a conflicting entry exists.
     var accessibilityGranted: Bool = false
 
+    /// Speech recognition authorization (optional, used when Apple Speech ASR is selected).
+    var speechGranted: Bool = false
+
+    /// True if the currently selected ASR provider is Apple Speech.
+    var isAppleASRSelected: Bool = false
+
+    /// True when Accessibility is granted by TCC, but the kernel-level event tap
+    /// fails and requires an application relaunch to activate global hotkeys.
+    var needsRestart: Bool = false
+
     /// True while the drag overlay is visible.
     var isDragOverlayShown: Bool = false
+
+    /// Computed requirement: both Microphone and Accessibility must be granted.
+    var requiredPermissionsGranted: Bool {
+        micGranted && accessibilityGranted
+    }
+
+    // MARK: - Injected Probes & Callbacks
+
+    /// Real event-tap probe provided by AppDelegate/HotkeyManager.
+    var hotkeyProbe: (() -> Bool)?
+
+    /// Origin-aware host raise callback (distinguishes embedded wizard vs standalone guide window).
+    var onFlowCompleteOrRaise: (() -> Void)?
 
     // MARK: - Dependencies
 
@@ -31,9 +55,6 @@ final class PermissionGuideModel {
     private var appActiveObserver: NSObjectProtocol?
 
     // MARK: - Lifecycle
-
-    // Lifetime is pinned to AppDelegate, so we don't clean up the activation
-    // observer on deinit (which would need @MainActor hops under Swift 6).
 
     init() {
         refresh()
@@ -45,6 +66,19 @@ final class PermissionGuideModel {
     func refresh() {
         micGranted = PermissionManager.hasMicrophonePermission
         accessibilityGranted = PermissionManager.hasAccessibilityPermission
+        speechGranted = PermissionManager.hasSpeechRecognitionPermission
+        isAppleASRSelected = (KeychainService.selectedASRProvider == .apple)
+
+        if accessibilityGranted {
+            if let probe = hotkeyProbe {
+                let tapOk = probe()
+                needsRestart = !tapOk
+            } else {
+                needsRestart = false
+            }
+        } else {
+            needsRestart = false
+        }
     }
 
     /// Request microphone access via the standard system prompt. If the user
@@ -71,15 +105,38 @@ final class PermissionGuideModel {
         }
     }
 
+    /// Request Speech Recognition access (for Apple Speech ASR).
+    func requestSpeechRecognition() {
+        let status = SFSpeechRecognizer.authorizationStatus()
+        switch status {
+        case .authorized:
+            speechGranted = true
+        case .notDetermined:
+            Task { @MainActor in
+                let granted = await PermissionManager.requestSpeechRecognitionPermission()
+                self.speechGranted = granted
+            }
+        case .denied, .restricted:
+            if let url = URL(
+                string: "x-apple.systempreferences:com.apple.preference.security?Privacy_SpeechRecognition"
+            ) {
+                NSWorkspace.shared.open(url)
+            }
+        @unknown default:
+            break
+        }
+    }
+
     /// Open System Settings to Accessibility and surface the drag overlay
     /// pinned under its window.
     ///
     /// When the overlay's poll detects `AXIsProcessTrusted()` flipping to
-    /// true (i.e. the drop landed and TCC granted the permission), we
-    /// dismiss the overlay, refresh state, and **bring the main guide
-    /// window back to the front** so the user lands on an obvious "next
-    /// step" surface instead of being stranded inside System Settings.
-    func beginAccessibilityFlow() {
+    /// true, we dismiss the overlay, refresh state, and bring the host
+    /// window back to the front.
+    func beginAccessibilityFlow(hostRaiseCallback: (() -> Void)? = nil) {
+        if let hostRaiseCallback {
+            self.onFlowCompleteOrRaise = hostRaiseCallback
+        }
         PermissionManager.openAccessibilitySettings()
         isDragOverlayShown = true
         dragOverlay.show(
@@ -91,10 +148,11 @@ final class PermissionGuideModel {
                 self.isDragOverlayShown = false
                 self.refresh()
                 NSApp.activate(ignoringOtherApps: true)
-                // Re-invoking the SwiftUI openWindow action for an already-
-                // open Window scene raises it to the front. If the user
-                // closed the guide window mid-flow, this reopens it.
-                AppDelegate.openPermissionGuideAction?()
+                if let raise = self.onFlowCompleteOrRaise {
+                    raise()
+                } else {
+                    AppDelegate.openPermissionGuideAction?()
+                }
             }
         }
     }
@@ -102,6 +160,18 @@ final class PermissionGuideModel {
     func dismissDragOverlay() {
         dragOverlay.dismiss()
         isDragOverlayShown = false
+    }
+
+    /// Relaunches the application to refresh macOS kernel-level event tap permissions.
+    /// Executes optional persistence logic (such as marking setup complete) before spawning.
+    func relaunchApp(persistSetup: (() -> Void)? = nil) {
+        persistSetup?()
+        let url = Bundle.main.bundleURL
+        let task = Process()
+        task.launchPath = "/usr/bin/open"
+        task.arguments = ["-n", url.path]
+        try? task.run()
+        NSApp.terminate(nil)
     }
 
     // MARK: - Helpers

--- a/Type4Me/Permissions/PermissionGuideModel.swift
+++ b/Type4Me/Permissions/PermissionGuideModel.swift
@@ -70,6 +70,9 @@ final class PermissionGuideModel {
         isAppleASRSelected = (KeychainService.selectedASRProvider == .apple)
 
         if accessibilityGranted {
+            if isDragOverlayShown {
+                dismissDragOverlay()
+            }
             if let probe = hotkeyProbe {
                 let tapOk = probe()
                 needsRestart = !tapOk
@@ -162,9 +165,8 @@ final class PermissionGuideModel {
         isDragOverlayShown = false
     }
 
-    /// Relaunches the application to refresh macOS kernel-level event tap permissions.
-    /// Executes optional persistence logic (such as marking setup complete) before spawning.
     func relaunchApp(persistSetup: (() -> Void)? = nil) {
+        dismissDragOverlay()
         persistSetup?()
         let url = Bundle.main.bundleURL
         let task = Process()

--- a/Type4Me/Permissions/PermissionGuideView.swift
+++ b/Type4Me/Permissions/PermissionGuideView.swift
@@ -1,19 +1,12 @@
 import SwiftUI
 import AppKit
 
-// `dismissWindow` action came in macOS 14.
-
 /// Unified permission guide presented both at first launch (inside the setup
 /// wizard) and when the main app detects a missing authorization.
 ///
-/// Visually aligned with the Settings window: amber accent, warm cream
-/// background, Settings-style permission cards (icon tile + title + green
-/// "已授权" / amber "授权" pill). The shared look keeps the two surfaces
-/// feeling like the same app rather than two disconnected dialogs.
-///
-/// When `embedded` is true the view runs inside the setup wizard, so the
-/// cream background and forced light scheme are skipped to blend with the
-/// wizard's own framing.
+/// Designed in Screenflare style: dark translucent material, grouped card layout,
+/// clear "Required" vs "Optional" badge hierarchy, dynamic restart detection,
+/// and integrated drag-to-authorize assistance for Accessibility.
 struct PermissionGuideView: View {
 
     @Bindable var model: PermissionGuideModel
@@ -21,35 +14,50 @@ struct PermissionGuideView: View {
     @Environment(\.openWindow) private var openWindow
 
     let embedded: Bool
+    var onFinish: (() -> Void)?
 
-    init(model: PermissionGuideModel, embedded: Bool = false) {
+    init(
+        model: PermissionGuideModel,
+        embedded: Bool = false,
+        onFinish: (() -> Void)? = nil
+    ) {
         self.model = model
         self.embedded = embedded
-    }
-
-    private var allGranted: Bool {
-        model.micGranted && model.accessibilityGranted
+        self.onFinish = onFinish
     }
 
     var body: some View {
-        Group {
-            if embedded {
-                content
-            } else {
-                content
-                    .background(TF.settingsBg)
-                    .preferredColorScheme(.light)
-            }
+        VStack(spacing: 20) {
+            // Header
+            headerSection
+
+            // Grouped Permissions Container
+            permissionGroupContainer
+
+            // Footer Privacy Note
+            Text(L(
+                "随时可以在 macOS「系统设置」中更改这些权限。",
+                "You can change any of these later in System Settings."
+            ))
+            .font(.system(size: 11))
+            .foregroundStyle(Color.white.opacity(0.5))
+            .multilineTextAlignment(.center)
+
+            // Bottom Actions Bar
+            bottomBar
         }
-        .onAppear { model.refresh() }
-        .onDisappear { model.dismissDragOverlay() }
-        // Poll state while the guide is on screen. AX is covered by the
-        // drag-overlay's own 0.5s poll, but microphone state can change
-        // from System Settings *without* Type4Me becoming active (user
-        // never switches back), so the normal `didBecomeActive` refresh
-        // misses it. 1s poll is lightweight and makes the cards light up
-        // as soon as the user toggles the switch, without requiring a
-        // relaunch.
+        .padding(.horizontal, 28)
+        .padding(.vertical, 24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(screenflareBackground)
+        .preferredColorScheme(.dark)
+        .onAppear {
+            model.refresh()
+        }
+        .onDisappear {
+            model.dismissDragOverlay()
+        }
+        // Periodically refresh permissions to catch external System Settings toggles
         .onReceive(
             Timer.publish(every: 1, on: .main, in: .common).autoconnect()
         ) { _ in
@@ -57,62 +65,264 @@ struct PermissionGuideView: View {
         }
     }
 
-    // MARK: - Content
+    // MARK: - Header Section
 
-    private var content: some View {
-        VStack(spacing: 16) {
-            if !embedded {
-                headerArtwork
-            }
+    private var headerSection: some View {
+        VStack(spacing: 8) {
+            Text(L("几项系统权限", "A few permissions"))
+                .font(.system(size: 20, weight: .bold))
+                .foregroundStyle(Color.white)
 
             Text(L(
-                "请授权以下权限,以允许 Type4Me 使用你的麦克风并监听快捷键和完成输入",
-                "Please grant the permissions below so Type4Me can use your microphone and listen for hotkeys to type for you."
+                "Type4Me 需要以下权限以录制语音并自动打字。录音数据仅在听写期间使用，绝不会离开你的 Mac。",
+                "macOS asks before Type4Me can record your voice and type for you. Nothing leaves your Mac."
             ))
-            .font(.system(size: 13, weight: .medium))
-            .foregroundStyle(textPrimary)
+            .font(.system(size: 12))
+            .foregroundStyle(Color.white.opacity(0.65))
             .multilineTextAlignment(.center)
-            .frame(maxWidth: 440)
-
-            VStack(spacing: 10) {
-                microphoneCard
-                accessibilityCard
-            }
-            .frame(maxWidth: 440)
-
-            if !embedded {
-                launchButton
-            }
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: 460)
         }
-        .padding(.horizontal, 32)
-        .padding(.vertical, embedded ? 16 : 28)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.top, embedded ? 0 : 6)
     }
 
-    // MARK: - Launch Button
+    // MARK: - Grouped Permission Container
 
-    @ViewBuilder
-    private var launchButton: some View {
-        Button(action: dismissGuide) {
-            Text(L("启动 Type4Me", "Launch Type4Me"))
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(.white)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 10)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(allGranted ? TF.settingsAccentAmber : TF.settingsTextTertiary.opacity(0.4))
-                )
+    private var permissionGroupContainer: some View {
+        VStack(spacing: 0) {
+            // 1. Microphone Row
+            microphoneRow
+
+            dividerLine
+
+            // 2. Accessibility Row
+            accessibilityRow
+
+            // 3. Apple Speech Recognition (only when Apple Speech is selected)
+            if model.isAppleASRSelected {
+                dividerLine
+                speechRecognitionRow
+            }
         }
-        .buttonStyle(.plain)
-        .disabled(!allGranted)
-        .frame(maxWidth: 440)
+        .background(Color.white.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(Color.white.opacity(0.1), lineWidth: 1)
+        )
+        .frame(maxWidth: 480)
     }
 
-    /// Close the guide window, surface the Settings window as the user's
-    /// next destination (so "launch" produces a visible window instead of
-    /// silently parking the app in the menu bar), and bring Type4Me to the
-    /// front.
+    // MARK: - Permission Rows
+
+    private var microphoneRow: some View {
+        permissionRow(
+            icon: "mic.fill",
+            iconColor: Color(red: 1.0, green: 0.35, blue: 0.35),
+            title: L("麦克风", "Microphone"),
+            isRequired: true,
+            description: L("录制你的语音以进行文字识别。", "Records your voice for speech-to-text."),
+            isGranted: model.micGranted,
+            action: { model.requestMicrophone() }
+        )
+    }
+
+    private var accessibilityRow: some View {
+        permissionRow(
+            icon: "accessibility",
+            iconColor: Color(red: 0.35, green: 0.65, blue: 1.0),
+            title: L("辅助功能", "Accessibility"),
+            isRequired: true,
+            description: L("监听全局快捷键，并将文字直接输入到目标 App。", "Listens for hotkeys and types text into your active app."),
+            statusHint: (model.accessibilityGranted && model.needsRestart)
+                ? L("已开启？macOS 可能需要在重启应用后生效。", "Switched it on? macOS applies this on the next launch.")
+                : nil,
+            isGranted: model.accessibilityGranted,
+            action: {
+                model.beginAccessibilityFlow {
+                    if embedded {
+                        onFinish?()
+                    } else {
+                        AppDelegate.openPermissionGuideAction?()
+                    }
+                }
+            }
+        )
+    }
+
+    private var speechRecognitionRow: some View {
+        permissionRow(
+            icon: "waveform",
+            iconColor: Color(red: 0.3, green: 0.8, blue: 0.6),
+            title: L("Apple 语音识别", "Apple Speech Recognition"),
+            isRequired: false,
+            description: L("使用系统内置语音引擎（使用云端或本地模型可跳过）。", "Transcribes via Apple Speech (can be skipped if using other ASR)."),
+            isGranted: model.speechGranted,
+            action: { model.requestSpeechRecognition() }
+        )
+    }
+
+    // MARK: - Generic Row Builder
+
+    private func permissionRow(
+        icon: String,
+        iconColor: Color,
+        title: String,
+        isRequired: Bool,
+        description: String,
+        statusHint: String? = nil,
+        isGranted: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+            // Icon square
+            ZStack {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(iconColor.opacity(0.18))
+                    .frame(width: 34, height: 34)
+
+                Image(systemName: icon)
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(iconColor)
+            }
+
+            // Texts
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(title)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color.white)
+
+                    if isRequired {
+                        Text(L("必需", "Required"))
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(Color(red: 1.0, green: 0.45, blue: 0.45))
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color(red: 1.0, green: 0.3, blue: 0.3).opacity(0.18))
+                            .clipShape(Capsule())
+                    } else {
+                        Text(L("可选", "Optional"))
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundStyle(Color.white.opacity(0.6))
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.white.opacity(0.12))
+                            .clipShape(Capsule())
+                    }
+                }
+
+                Text(description)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Color.white.opacity(0.6))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let hint = statusHint {
+                    Text(hint)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Color(red: 1.0, green: 0.8, blue: 0.35))
+                        .padding(.top, 2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            // Status or Action Button
+            if isGranted {
+                HStack(spacing: 5) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 13))
+                        .foregroundStyle(TF.settingsAccentGreen)
+                    Text(L("已允许", "Allowed"))
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(TF.settingsAccentGreen)
+                }
+                .padding(.vertical, 5)
+            } else {
+                Button(action: action) {
+                    Text(L("允许", "Allow"))
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Color.white)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 5)
+                        .background(
+                            Capsule()
+                                .fill(Color(red: 0.22, green: 0.52, blue: 0.98))
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(14)
+    }
+
+    // MARK: - Bottom Actions Bar
+
+    private var bottomBar: some View {
+        HStack {
+            if embedded {
+                // Step Indicator Dots
+                HStack(spacing: 6) {
+                    Circle().fill(Color.white.opacity(0.25)).frame(width: 6, height: 6)
+                    Circle().fill(TF.amber).frame(width: 6, height: 6)
+                }
+            }
+
+            Spacer()
+
+            if model.needsRestart {
+                Button(action: handleRelaunch) {
+                    Text(L("重启 Type4Me", "Relaunch Type4Me"))
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color.white)
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 8)
+                        .background(
+                            Capsule()
+                                .fill(Color(red: 0.22, green: 0.52, blue: 0.98))
+                        )
+                }
+                .buttonStyle(.plain)
+            } else {
+                Button(action: handlePrimaryAction) {
+                    Text(embedded ? L("进入应用", "Launch Type4Me") : L("完成", "Done"))
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color.white)
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 8)
+                        .background(
+                            Capsule()
+                                .fill(model.requiredPermissionsGranted
+                                      ? TF.settingsAccentAmber
+                                      : Color.white.opacity(0.18))
+                        )
+                }
+                .buttonStyle(.plain)
+                .disabled(!model.requiredPermissionsGranted)
+            }
+        }
+        .frame(maxWidth: 480)
+    }
+
+    // MARK: - Actions
+
+    private func handlePrimaryAction() {
+        if let onFinish {
+            onFinish()
+        } else {
+            dismissGuide()
+        }
+    }
+
+    private func handleRelaunch() {
+        model.relaunchApp(persistSetup: {
+            if embedded {
+                onFinish?()
+            }
+        })
+    }
+
     private func dismissGuide() {
         model.dismissDragOverlay()
         dismissWindow(id: "permission-guide")
@@ -120,109 +330,33 @@ struct PermissionGuideView: View {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    // MARK: - Header
-
-    private var headerArtwork: some View {
-        Image(nsImage: NSApp.applicationIconImage ?? NSImage())
-            .resizable()
-            .interpolation(.high)
-            .frame(width: 80, height: 80)
-            .shadow(color: .black.opacity(0.12), radius: 10, x: 0, y: 4)
+    private var dividerLine: some View {
+        Rectangle()
+            .fill(Color.white.opacity(0.08))
+            .frame(height: 1)
+            .padding(.horizontal, 14)
     }
 
-    // MARK: - Cards
+    // MARK: - Screenflare Style Background
 
-    private var microphoneCard: some View {
-        permissionBlock(
-            icon: "mic.fill",
-            name: L("麦克风", "Microphone"),
-            subtitle: L("录制你的语音", "Captures your voice"),
-            granted: model.micGranted,
-            action: { model.requestMicrophone() }
-        )
-    }
-
-    private var accessibilityCard: some View {
-        permissionBlock(
-            icon: "accessibility",
-            name: L("辅助功能", "Accessibility"),
-            subtitle: L("监听全局快捷键并把文字打到其它 App",
-                        "Global hotkeys + inject text into other apps"),
-            granted: model.accessibilityGranted,
-            action: { model.beginAccessibilityFlow() }
-        )
-    }
-
-    // MARK: - Permission Block (aligned with SettingsTab permissionBlock)
-
-    private func permissionBlock(
-        icon: String,
-        name: String,
-        subtitle: String,
-        granted: Bool,
-        action: @escaping () -> Void
-    ) -> some View {
-        HStack(spacing: 12) {
-            Image(systemName: icon)
-                .font(.system(size: 18))
-                .foregroundStyle(.white)
-                .frame(width: 36, height: 36)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(granted ? TF.settingsAccentGreen : TF.settingsTextTertiary)
+    @ViewBuilder
+    private var screenflareBackground: some View {
+        if embedded {
+            Color.clear
+        } else {
+            ZStack {
+                Color(red: 0.11, green: 0.12, blue: 0.14)
+                RadialGradient(
+                    gradient: Gradient(colors: [
+                        Color(red: 0.2, green: 0.22, blue: 0.26).opacity(0.6),
+                        Color.clear
+                    ]),
+                    center: .top,
+                    startRadius: 20,
+                    endRadius: 360
                 )
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(name)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(textPrimary)
-                Text(subtitle)
-                    .font(.system(size: 11))
-                    .foregroundStyle(textTertiary)
-                    .fixedSize(horizontal: false, vertical: true)
             }
-
-            Spacer(minLength: 8)
-
-            if granted {
-                HStack(spacing: 4) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 12))
-                        .foregroundStyle(TF.settingsAccentGreen)
-                    Text(L("已授权", "Authorized"))
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(TF.settingsAccentGreen)
-                }
-            } else {
-                Button(action: action) {
-                    Text(L("授权", "Grant"))
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 5)
-                        .background(
-                            RoundedRectangle(cornerRadius: 6)
-                                .fill(TF.settingsAccentAmber)
-                        )
-                }
-                .buttonStyle(.plain)
-            }
+            .ignoresSafeArea()
         }
-        .padding(14)
-        .background(
-            RoundedRectangle(cornerRadius: 8).fill(cardBackground)
-        )
-    }
-
-    // MARK: - Adaptive Colors
-
-    /// In embedded mode we defer to the system-managed primary/secondary so
-    /// the wizard's current color scheme is respected. In the standalone
-    /// guide window we pin to the Settings cream palette.
-    private var textPrimary: Color { embedded ? .primary : TF.settingsText }
-    private var textSecondary: Color { embedded ? .secondary : TF.settingsTextSecondary }
-    private var textTertiary: Color { embedded ? .secondary : TF.settingsTextTertiary }
-    private var cardBackground: Color {
-        embedded ? Color.secondary.opacity(0.08) : TF.settingsCardAlt
     }
 }

--- a/Type4Me/Permissions/PermissionGuideView.swift
+++ b/Type4Me/Permissions/PermissionGuideView.swift
@@ -15,15 +15,18 @@ struct PermissionGuideView: View {
 
     let embedded: Bool
     var onFinish: (() -> Void)?
+    var onRaiseHostWindow: (() -> Void)?
 
     init(
         model: PermissionGuideModel,
         embedded: Bool = false,
-        onFinish: (() -> Void)? = nil
+        onFinish: (() -> Void)? = nil,
+        onRaiseHostWindow: (() -> Void)? = nil
     ) {
         self.model = model
         self.embedded = embedded
         self.onFinish = onFinish
+        self.onRaiseHostWindow = onRaiseHostWindow
     }
 
     var body: some View {
@@ -74,8 +77,8 @@ struct PermissionGuideView: View {
                 .foregroundStyle(Color.white)
 
             Text(L(
-                "Type4Me 需要以下权限以录制语音并自动打字。录音数据仅在听写期间使用，绝不会离开你的 Mac。",
-                "macOS asks before Type4Me can record your voice and type for you. Nothing leaves your Mac."
+                "Type4Me 仅在听写时使用麦克风与快捷键，音频处理取决于你配置的语音识别服务。",
+                "Type4Me only accesses your microphone while dictating; audio handling depends on your selected speech recognition provider."
             ))
             .font(.system(size: 12))
             .foregroundStyle(Color.white.opacity(0.65))
@@ -141,7 +144,11 @@ struct PermissionGuideView: View {
             action: {
                 model.beginAccessibilityFlow {
                     if embedded {
-                        onFinish?()
+                        if let onRaiseHostWindow {
+                            onRaiseHostWindow()
+                        } else {
+                            AppDelegate.presentSetupWizard()
+                        }
                     } else {
                         AppDelegate.openPermissionGuideAction?()
                     }
@@ -317,7 +324,7 @@ struct PermissionGuideView: View {
 
     private func handleRelaunch() {
         model.relaunchApp(persistSetup: {
-            if embedded {
+            if embedded && model.requiredPermissionsGranted {
                 onFinish?()
             }
         })

--- a/Type4Me/Permissions/SystemSettingsWindowLocator.swift
+++ b/Type4Me/Permissions/SystemSettingsWindowLocator.swift
@@ -20,6 +20,10 @@ enum SystemSettingsWindowLocator {
     /// the AppKit coordinate space (origin at the bottom-left of the main
     /// display, matching `NSWindow.frame`).
     static func findMainWindowFrame() -> NSRect? {
+        let running = NSRunningApplication.runningApplications(withBundleIdentifier: systemSettingsBundleID)
+        guard running.contains(where: { !$0.isTerminated }) else {
+            return nil
+        }
         let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
         guard let rawList = CGWindowListCopyWindowInfo(options, kCGNullWindowID)
             as? [[String: Any]] else {

--- a/Type4Me/Services/KeychainService.swift
+++ b/Type4Me/Services/KeychainService.swift
@@ -131,22 +131,27 @@ enum KeychainService {
 
     static func saveASRCredentials(for provider: ASRProvider, values: [String: String]) throws {
         lock.lock()
-        defer { lock.unlock() }
-        var dict = _loadAllUnlocked()
-        let storageKey = asrStorageKey(for: provider)
-        let split = splitCredentials(values, using: ASRProviderRegistry.configType(for: provider)?.credentialFields ?? [])
-        if split.secure.isEmpty {
-            _ = deleteSecureValue(service: keychainGroupedService, account: storageKey)
-        } else {
-            try saveSecureValues(split.secure, account: storageKey)
+        do {
+            var dict = _loadAllUnlocked()
+            let storageKey = asrStorageKey(for: provider)
+            let split = splitCredentials(values, using: ASRProviderRegistry.configType(for: provider)?.credentialFields ?? [])
+            if split.secure.isEmpty {
+                _ = deleteSecureValue(service: keychainGroupedService, account: storageKey)
+            } else {
+                try saveSecureValues(split.secure, account: storageKey)
+            }
+            if split.plaintext.isEmpty {
+                dict.removeValue(forKey: storageKey)
+            } else {
+                dict[storageKey] = split.plaintext
+            }
+            try saveAll(dict)
+            cachedCredentials = dict
+            lock.unlock()
+        } catch {
+            lock.unlock()
+            throw error
         }
-        if split.plaintext.isEmpty {
-            dict.removeValue(forKey: storageKey)
-        } else {
-            dict[storageKey] = split.plaintext
-        }
-        try saveAll(dict)
-        cachedCredentials = dict
         NotificationCenter.default.post(name: .credentialsDidChange, object: nil)
     }
 
@@ -223,22 +228,27 @@ enum KeychainService {
 
     static func saveLLMCredentials(for provider: LLMProvider, values: [String: String]) throws {
         lock.lock()
-        defer { lock.unlock() }
-        var dict = _loadAllUnlocked()
-        let storageKey = llmStorageKey(for: provider)
-        let split = splitCredentials(values, using: LLMProviderRegistry.configType(for: provider)?.credentialFields ?? [])
-        if split.secure.isEmpty {
-            _ = deleteSecureValue(service: keychainGroupedService, account: storageKey)
-        } else {
-            try saveSecureValues(split.secure, account: storageKey)
+        do {
+            var dict = _loadAllUnlocked()
+            let storageKey = llmStorageKey(for: provider)
+            let split = splitCredentials(values, using: LLMProviderRegistry.configType(for: provider)?.credentialFields ?? [])
+            if split.secure.isEmpty {
+                _ = deleteSecureValue(service: keychainGroupedService, account: storageKey)
+            } else {
+                try saveSecureValues(split.secure, account: storageKey)
+            }
+            if split.plaintext.isEmpty {
+                dict.removeValue(forKey: storageKey)
+            } else {
+                dict[storageKey] = split.plaintext
+            }
+            try saveAll(dict)
+            cachedCredentials = dict
+            lock.unlock()
+        } catch {
+            lock.unlock()
+            throw error
         }
-        if split.plaintext.isEmpty {
-            dict.removeValue(forKey: storageKey)
-        } else {
-            dict[storageKey] = split.plaintext
-        }
-        try saveAll(dict)
-        cachedCredentials = dict
         NotificationCenter.default.post(name: .credentialsDidChange, object: nil)
     }
 

--- a/Type4Me/Services/KeychainService.swift
+++ b/Type4Me/Services/KeychainService.swift
@@ -101,6 +101,7 @@ enum KeychainService {
             UserDefaults.standard.set(newValue.rawValue, forKey: selectedProviderKey)
             guard previous != newValue else { return }
             NotificationCenter.default.post(name: .asrProviderDidChange, object: newValue)
+            NotificationCenter.default.post(name: .credentialsDidChange, object: nil)
         }
     }
 
@@ -146,6 +147,7 @@ enum KeychainService {
         }
         try saveAll(dict)
         cachedCredentials = dict
+        NotificationCenter.default.post(name: .credentialsDidChange, object: nil)
     }
 
     static func loadASRCredentials(for provider: ASRProvider) -> [String: String]? {
@@ -206,7 +208,10 @@ enum KeychainService {
             return provider
         }
         set {
+            let previous = selectedLLMProvider
             UserDefaults.standard.set(newValue.rawValue, forKey: selectedLLMProviderKey)
+            guard previous != newValue else { return }
+            NotificationCenter.default.post(name: .credentialsDidChange, object: nil)
         }
     }
 
@@ -234,6 +239,7 @@ enum KeychainService {
         }
         try saveAll(dict)
         cachedCredentials = dict
+        NotificationCenter.default.post(name: .credentialsDidChange, object: nil)
     }
 
     static func loadLLMCredentials(for provider: LLMProvider) -> [String: String]? {

--- a/Type4Me/Type4MeApp.swift
+++ b/Type4Me/Type4MeApp.swift
@@ -430,6 +430,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        permissionGuideModel.hotkeyProbe = { [weak self] in
+            self?.hotkeyManager.start() == true
+        }
+
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.startHotkeyWithRetry()
@@ -446,13 +450,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // `application(open:)` sets `suppressSetupWizardForHeadlessLaunch` so the
         // wizard doesn't steal focus over the headless recording.
         if needsSetup {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
                 MainActor.assumeIsolated {
                     if self?.suppressSetupWizardForHeadlessLaunch == true {
                         DebugFileLogger.log("setup wizard suppressed: headless URL launch")
                         return
                     }
-                    _ = NSApp.sendAction(Selector(("showSetupWindow:")), to: nil, from: nil)
+                    self?.presentSetupWizard()
                 }
             }
         }
@@ -1530,6 +1534,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// Stored by MenuBarContent so AppDelegate can open the setup wizard window.
+    static var openSetupAction: (() -> Void)?
+
     /// Stored by MenuBarContent so AppDelegate can open the settings window.
     static var openSettingsAction: (() -> Void)?
 
@@ -1539,6 +1546,50 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// before the first MenuBarExtra render), calls are retried on the next
     /// runloop.
     static var openPermissionGuideAction: (() -> Void)?
+
+    /// Static convenience to open the setup wizard.
+    static func presentSetupWizard() {
+        if let action = openSetupAction {
+            action()
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+
+    /// Static convenience to open the settings window.
+    static func presentSettings() {
+        if let action = openSettingsAction {
+            action()
+            NSApp.activate(ignoringOtherApps: true)
+        } else {
+            _ = NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+
+    /// Static convenience to open the permission guide window.
+    static func presentPermissionGuide() {
+        if let action = openPermissionGuideAction {
+            action()
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+
+    /// Present the setup wizard window, activating the app and retrying
+    /// until the SwiftUI scene registers its open action.
+    func presentSetupWizard(remainingAttempts: Int = 25) {
+        if let action = Self.openSetupAction {
+            action()
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+        guard remainingAttempts > 0 else {
+            NSLog("[Type4Me] Failed to present setup wizard: open action not registered after retries")
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+            self?.presentSetupWizard(remainingAttempts: remainingAttempts - 1)
+        }
+    }
 
     /// Present the permission guide window, activating the app and retrying
     /// until the SwiftUI scene registers its open action.
@@ -1552,7 +1603,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.presentPermissionGuide()
         }
     }
-
     /// Present the settings window from anywhere (URL command, Dock reopen,
     /// etc.). Uses the standard SwiftUI settings-open selector so it works
     /// even before the MenuBarExtra scene has registered `openSettingsAction`,

--- a/Type4Me/Type4MeApp.swift
+++ b/Type4Me/Type4MeApp.swift
@@ -434,6 +434,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.hotkeyManager.start() == true
         }
 
+        hotkeyManager.onAccessibilityRevoked = { [weak self] in
+            MainActor.assumeIsolated {
+                self?.handleAccessibilityRevoked()
+            }
+        }
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.startHotkeyWithRetry()
@@ -1358,13 +1363,42 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var retryTimer: Timer?
     private var hotkeyRetryCount = 0
 
+    private func handleAccessibilityRevoked() {
+        retryTimer?.invalidate()
+        retryTimer = nil
+        hotkeyRetryCount = 0
+        hotkeyManager.stop()
+
+        DebugFileLogger.log("hotkey accessibility revoked; tap torn down")
+
+        let showWizard: Bool = {
+            #if HAS_CLOUD_SUBSCRIPTION
+            return !appState.hasCompletedSetup || appState.appEdition == nil
+            #else
+            return !appState.hasCompletedSetup
+            #endif
+        }()
+        if !showWizard {
+            presentPermissionGuide()
+        }
+
+        retryTimer = Timer.scheduledTimer(
+            timeInterval: 2.0,
+            target: self,
+            selector: #selector(handleHotkeyRetry(_:)),
+            userInfo: nil,
+            repeats: true
+        )
+    }
+
     private func startHotkeyWithRetry() {
+        retryTimer?.invalidate()
+        retryTimer = nil
+
         let success = hotkeyManager.start()
         NSLog("[Type4Me] Hotkey setup: %@", success ? "OK" : "FAILED (need Accessibility permission)")
 
         if success {
-            retryTimer?.invalidate()
-            retryTimer = nil
             hotkeyRetryCount = 0
             return
         }
@@ -1384,7 +1418,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         hotkeyRetryCount = 0
-        retryTimer?.invalidate()
         retryTimer = Timer.scheduledTimer(
             timeInterval: 2.0,
             target: self,
@@ -1396,23 +1429,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc
     private func handleHotkeyRetry(_ timer: Timer) {
-        if PermissionManager.hasAccessibilityPermission {
-            let ok = hotkeyManager.start()
-            hotkeyRetryCount += 1
-            NSLog("[Type4Me] Hotkey retry #%d: %@", hotkeyRetryCount, ok ? "OK" : "still failing")
-            if ok {
-                timer.invalidate()
-                retryTimer = nil
-                hotkeyRetryCount = 0
-            } else if hotkeyRetryCount >= 5 {
-                // Permission granted but event tap still fails (macOS caches denial at kernel level).
-                // Suggest restart.
-                timer.invalidate()
-                retryTimer = nil
-                hotkeyRetryCount = 0
-                NSLog("[Type4Me] Accessibility granted but hotkey tap failed after retries. Suggesting restart.")
-                showRestartAlert()
-            }
+        guard PermissionManager.hasAccessibilityPermission else {
+            return
+        }
+        let ok = hotkeyManager.start()
+        hotkeyRetryCount += 1
+        NSLog("[Type4Me] Hotkey retry #%d: %@", hotkeyRetryCount, ok ? "OK" : "still failing")
+        if ok {
+            timer.invalidate()
+            retryTimer = nil
+            hotkeyRetryCount = 0
+        } else if hotkeyRetryCount >= 5 {
+            // Permission granted but event tap still fails (macOS caches denial at kernel level).
+            // Suggest restart.
+            timer.invalidate()
+            retryTimer = nil
+            hotkeyRetryCount = 0
+            NSLog("[Type4Me] Accessibility granted but hotkey tap failed after retries. Suggesting restart.")
+            showRestartAlert()
         }
     }
 
@@ -1665,6 +1699,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     #endif
 
     func applicationWillTerminate(_ notification: Notification) {
+        hotkeyManager.stop()
         inputDeviceChangeObservers.forEach(NotificationCenter.default.removeObserver)
         inputDeviceChangeObservers.removeAll()
         if let preciseTargetActivationObserver {

--- a/Type4Me/UI/AppState.swift
+++ b/Type4Me/UI/AppState.swift
@@ -1892,4 +1892,5 @@ extension Notification.Name {
     static let navigateToHistory = Notification.Name("Type4MeNavigateToHistory")
     static let navigateToVocabulary = Notification.Name("Type4MeNavigateToVocabulary")
     static let selectMode = Notification.Name("Type4MeSelectMode")
+    static let credentialsDidChange = Notification.Name("tf_credentialsDidChange")
 }

--- a/Type4Me/UI/MenuBar/MenuBarControlCenter.swift
+++ b/Type4Me/UI/MenuBar/MenuBarControlCenter.swift
@@ -769,6 +769,9 @@ struct MenuBarControlCenterView: View {
         AppDelegate.openPermissionGuideAction = { [openWindow] in
             openWindow(id: "permission-guide")
         }
+        AppDelegate.openSetupAction = { [openWindow] in
+            openWindow(id: "setup")
+        }
     }
 }
 

--- a/Type4Me/UI/Settings/FloatingModelAlertCards.swift
+++ b/Type4Me/UI/Settings/FloatingModelAlertCards.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+/// Floating alert cards shown on the home page (bottom-right) when default ASR
+/// or LLM models require configuration. Tapping a card jumps directly to the
+/// Models settings tab with the corresponding category focused.
+struct FloatingModelAlertCards: View {
+
+    @Environment(AppNavigationModel.self) private var navigationModel
+    @State private var isASRMissing = false
+    @State private var isLLMMissing = false
+    @State private var hoveredCard: String?
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 10) {
+            if isASRMissing {
+                alertCard(
+                    id: "asr",
+                    color: Color(red: 1.0, green: 0.35, blue: 0.35),
+                    icon: "waveform.badge.exclamationmark",
+                    title: L("需配置默认语音识别模型", "Configure Speech Recognition Model"),
+                    subtitle: L("点击前往模型页配置 API Key 或本地模型", "Click to set up API keys or local models"),
+                    action: {
+                        navigationModel.selectedTab = .models
+                        navigationModel.pendingModelCategory = .asr
+                    }
+                )
+                .transition(.asymmetric(
+                    insertion: .move(edge: .trailing).combined(with: .opacity),
+                    removal: .move(edge: .trailing).combined(with: .opacity)
+                ))
+            }
+
+            if isLLMMissing {
+                alertCard(
+                    id: "llm",
+                    color: TF.settingsAccentAmber,
+                    icon: "sparkles",
+                    title: L("需配置默认文本润色模型", "Configure Text Polishing Model"),
+                    subtitle: L("用于智能纠错、标点与改写", "Used for smart punctuation and rewriting"),
+                    action: {
+                        navigationModel.selectedTab = .models
+                        navigationModel.pendingModelCategory = .llm
+                    }
+                )
+                .transition(.asymmetric(
+                    insertion: .move(edge: .trailing).combined(with: .opacity),
+                    removal: .move(edge: .trailing).combined(with: .opacity)
+                ))
+            }
+        }
+        .animation(.spring(response: 0.35, dampingFraction: 0.82), value: isASRMissing)
+        .animation(.spring(response: 0.35, dampingFraction: 0.82), value: isLLMMissing)
+        .onAppear {
+            checkModelStatus()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .credentialsDidChange)) { _ in
+            checkModelStatus()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .asrProviderDidChange)) { _ in
+            checkModelStatus()
+        }
+    }
+
+    private func alertCard(
+        id: String,
+        color: Color,
+        icon: String,
+        title: String,
+        subtitle: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        let isHovered = hoveredCard == id
+
+        return Button(action: action) {
+            HStack(spacing: 12) {
+                // Icon indicator
+                ZStack {
+                    Circle()
+                        .fill(color.opacity(0.18))
+                        .frame(width: 32, height: 32)
+                    Image(systemName: icon)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(color)
+                }
+
+                // Title and subtitle
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Color.white)
+
+                    Text(subtitle)
+                        .font(.system(size: 11))
+                        .foregroundStyle(Color.white.opacity(0.65))
+                }
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Color.white.opacity(0.4))
+                    .padding(.leading, 4)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color(red: 0.12, green: 0.13, blue: 0.16).opacity(isHovered ? 0.96 : 0.88))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(color.opacity(isHovered ? 0.6 : 0.3), lineWidth: 1)
+            )
+            .shadow(color: Color.black.opacity(0.2), radius: 10, x: 0, y: 4)
+            .scaleEffect(isHovered ? 1.015 : 1.0)
+            .animation(.easeOut(duration: 0.15), value: isHovered)
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            hoveredCard = hovering ? id : nil
+        }
+    }
+
+    private func checkModelStatus() {
+        let currentASR = KeychainService.selectedASRProvider
+        let currentLLM = KeychainService.selectedLLMProvider
+        isASRMissing = !ModelSettingsHelpers.hasConfiguredCredentials(for: currentASR)
+        isLLMMissing = !ModelSettingsHelpers.hasConfiguredCredentials(for: currentLLM)
+    }
+}

--- a/Type4Me/UI/Settings/ModelSettingsTab.swift
+++ b/Type4Me/UI/Settings/ModelSettingsTab.swift
@@ -4,6 +4,7 @@ struct ModelSettingsTab: View, SettingsCardHelpers {
 
     var showsHeader = true
     let draftCoordinator: SettingsDraftCoordinator
+    @Environment(AppNavigationModel.self) private var navigationModel
 
     @State private var selectedCategory: ModelCategory = .asr
     @State private var selectedASRProvider: ASRProvider = KeychainService.selectedASRProvider
@@ -78,10 +79,20 @@ struct ModelSettingsTab: View, SettingsCardHelpers {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .onAppear {
+            if let pendingCategory = navigationModel.pendingModelCategory {
+                selectedCategory = pendingCategory
+                navigationModel.pendingModelCategory = nil
+            }
             defaultASRProvider = KeychainService.selectedASRProvider
             defaultLLMProvider = KeychainService.selectedLLMProvider
             selectedASRProvider = defaultASRProvider
             selectedLLMProvider = defaultLLMProvider
+        }
+        .onChange(of: navigationModel.pendingModelCategory) { _, newCategory in
+            if let newCategory {
+                selectedCategory = newCategory
+                navigationModel.pendingModelCategory = nil
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .asrProviderDidChange)) { note in
             if let provider = note.object as? ASRProvider {

--- a/Type4Me/UI/Settings/SettingsView.swift
+++ b/Type4Me/UI/Settings/SettingsView.swift
@@ -89,6 +89,7 @@ enum SettingsTab: String, CaseIterable, Identifiable, Hashable {
 @Observable
 final class AppNavigationModel {
     var selectedTab: SettingsTab = .general
+    var pendingModelCategory: ModelCategory?
     var pendingAskAnythingSessionID: UUID?
     var pendingModeSelectionID: UUID?
 }

--- a/Type4Me/UI/Settings/SettingsView.swift
+++ b/Type4Me/UI/Settings/SettingsView.swift
@@ -362,7 +362,7 @@ struct SettingsView: View {
     private var content: some View {
         switch selectedTab {
         case .general:
-            ZStack {
+            ZStack(alignment: .bottomTrailing) {
                 HomeDottedWaveBackground()
                 tabPage {
                     HomeDashboardView(isActive: selectedTab == .general) { modeId in
@@ -371,6 +371,9 @@ struct SettingsView: View {
                         })
                     }
                 }
+                FloatingModelAlertCards()
+                    .padding(.trailing, 28)
+                    .padding(.bottom, 24)
             }
         case .askAnything:
             fixedPage {

--- a/Type4Me/UI/Setup/SetupWizardView.swift
+++ b/Type4Me/UI/Setup/SetupWizardView.swift
@@ -1,39 +1,26 @@
 import SwiftUI
-import AVFoundation
-import ApplicationServices
+import AppKit
 
+/// Simplified 2-step first-run onboarding wizard.
+/// Step 0: Welcome & Core concept
+/// Step 1: Screenflare-style permissions guidance
+/// On completion: marks setup complete, closes wizard, and opens the main app home.
 struct SetupWizardView: View {
 
     @Environment(AppState.self) private var appState
     @Environment(PermissionGuideModel.self) private var permissionGuideModel
     @State private var step = 0
     @AppStorage("tf_language") private var language = AppLanguage.systemDefault
-    #if HAS_CLOUD_SUBSCRIPTION
-    @State private var selectedEdition: AppEdition = .member
-    private var isMember: Bool { selectedEdition == .member }
-    private let totalSteps = 5
-    #else
-    private let totalSteps = 4
-    #endif
 
     var body: some View {
         VStack(spacing: 0) {
-            // Progress indicator
-            HStack(spacing: 8) {
-                ForEach(0..<totalSteps, id: \.self) { i in
-                    Capsule()
-                        .fill(i <= step ? TF.amber : Color.secondary.opacity(0.15))
-                        .frame(height: 3)
-                        .animation(.easeInOut(duration: 0.3), value: step)
-                }
-            }
-            .padding(.horizontal, 48)
-            .padding(.top, 24)
-            .padding(.bottom, 8)
-
-            // Steps
             Group {
-                stepContent
+                switch step {
+                case 0:
+                    welcomeStep
+                default:
+                    permissionsStep
+                }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .transition(.asymmetric(
@@ -42,40 +29,24 @@ struct SetupWizardView: View {
             ))
             .animation(TF.springGentle, value: step)
         }
-        .frame(width: 750, height: 520)
+        .frame(width: 640, height: 480)
+        .background(
+            ZStack {
+                Color(red: 0.11, green: 0.12, blue: 0.14)
+                RadialGradient(
+                    gradient: Gradient(colors: [
+                        Color(red: 0.2, green: 0.22, blue: 0.26).opacity(0.6),
+                        Color.clear
+                    ]),
+                    center: .top,
+                    startRadius: 20,
+                    endRadius: 360
+                )
+            }
+            .ignoresSafeArea()
+        )
+        .preferredColorScheme(.dark)
         .id(language)
-    }
-
-    // MARK: - Step Router
-
-    @ViewBuilder
-    private var stepContent: some View {
-        switch step {
-        case 0: welcomeStep
-        #if HAS_CLOUD_SUBSCRIPTION
-        case 1: pathSelectionStep
-        case 2:
-            if isMember { loginStep } else { providerStep }
-        case 3: permissionsStep
-        #else
-        case 1: providerStep
-        case 2: permissionsStep
-        #endif
-        default: readyStep
-        }
-    }
-
-    // MARK: - Navigation Footer
-
-    private func navigationFooter(action: @escaping () -> Void) -> some View {
-        HStack {
-            Spacer()
-            Button(L("下一步", "Next"), action: action)
-                .buttonStyle(.borderedProminent)
-                .tint(TF.amber)
-        }
-        .padding(.horizontal, 48)
-        .padding(.bottom, 36)
     }
 
     // MARK: - Step 0: Welcome
@@ -86,7 +57,7 @@ struct SetupWizardView: View {
 
             ZStack {
                 Circle()
-                    .fill(TF.amber.opacity(0.1))
+                    .fill(TF.amber.opacity(0.12))
                     .frame(width: 96, height: 96)
                 Image(systemName: "waveform.and.mic")
                     .font(.system(size: 42))
@@ -95,289 +66,64 @@ struct SetupWizardView: View {
 
             VStack(spacing: 8) {
                 Text("Type4Me")
-                    .font(.system(size: 24, weight: .bold))
+                    .font(.system(size: 26, weight: .bold))
+                    .foregroundStyle(Color.white)
+
                 Text(L("说话，就是输入", "Speak, and it types"))
-                    .foregroundStyle(.secondary)
+                    .font(.system(size: 14))
+                    .foregroundStyle(Color.white.opacity(0.65))
                     .multilineTextAlignment(.center)
-                    .frame(maxWidth: 300)
+                    .frame(maxWidth: 320)
             }
-
-            Spacer()
-
-            Button(L("开始设置", "Get Started")) { step = 1 }
-                .buttonStyle(.borderedProminent)
-                .tint(TF.amber)
-                .controlSize(.large)
-                .padding(.bottom, 36)
-        }
-    }
-
-    #if HAS_CLOUD_SUBSCRIPTION
-    // MARK: - Step 1 (Subscription): Path Selection
-
-    private var pathSelectionStep: some View {
-        VStack(spacing: 28) {
-            Spacer()
-            VStack(spacing: 8) {
-                Text(L("选择你的方式", "Choose your path"))
-                    .font(.system(size: 18, weight: .semibold))
-                Text(L("随时可以在设置里切换。", "You can switch anytime in Settings."))
-                    .font(.caption).foregroundStyle(.secondary)
-            }
-            HStack(spacing: 16) {
-                pathCard(icon: "person.crop.circle.badge.checkmark",
-                         title: L("官方会员", "Official Member"),
-                         detail: L("无需配置，2000 字免费体验", "No setup needed, 2000 chars free"),
-                         isSelected: isMember) { selectedEdition = .member }
-                pathCard(icon: "key.fill",
-                         title: L("自带 API", "Bring Your Own API"),
-                         detail: L("使用你自己的 API Key", "Use your own API keys"),
-                         isSelected: !isMember) { selectedEdition = .byoKey }
-            }.frame(width: 500)
-            Spacer()
-            Button(L("下一步", "Next")) { step = 2 }
-                .buttonStyle(.borderedProminent).tint(TF.amber).controlSize(.large).padding(.bottom, 36)
-        }
-    }
-
-    private func pathCard(icon: String, title: String, detail: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            VStack(spacing: 12) {
-                Image(systemName: icon).font(.system(size: 28)).foregroundStyle(isSelected ? TF.amber : .secondary)
-                Text(title).font(.system(size: 14, weight: .semibold)).foregroundStyle(isSelected ? .primary : .secondary)
-                Text(detail).font(.system(size: 12)).foregroundStyle(.secondary).multilineTextAlignment(.center).frame(maxWidth: 180)
-            }
-            .frame(maxWidth: .infinity).padding(.vertical, 24)
-            .background(RoundedRectangle(cornerRadius: 12).fill(isSelected ? TF.amber.opacity(0.08) : Color.secondary.opacity(0.06)))
-            .overlay(RoundedRectangle(cornerRadius: 12).stroke(isSelected ? TF.amber : .clear, lineWidth: 1.5))
-        }.buttonStyle(.plain)
-    }
-
-    // MARK: - Step 2 (Subscription): Login
-
-    @State private var email = ""
-    @State private var codeSent = false
-    @State private var verificationCode = ""
-    @State private var isLoading = false
-    @State private var loginError: String?
-    @State private var loginSuccess = false
-
-    private var loginStep: some View {
-        VStack(spacing: 24) {
-            Spacer()
-            if loginSuccess {
-                Image(systemName: "checkmark.circle.fill").font(.system(size: 48)).foregroundStyle(TF.success)
-                Text(L("2000 字免费额度已激活", "2000 free characters activated")).font(.system(size: 16, weight: .medium))
-                Spacer()
-                navigationFooter { step = 3 }
-            } else if codeSent {
-                VStack(spacing: 8) {
-                    Text(L("输入验证码", "Enter Verification Code")).font(.system(size: 18, weight: .semibold))
-                    Text(L("验证码已发送到 \(email)", "Code sent to \(email)")).font(.caption).foregroundStyle(.secondary)
-                }
-                VStack(spacing: 12) {
-                    TextField(L("验证码", "Verification Code"), text: $verificationCode)
-                        .textFieldStyle(.roundedBorder).frame(width: 280).multilineTextAlignment(.center)
-                    if let error = loginError { Text(error).font(.caption).foregroundStyle(.red) }
-                    Button { verifyCode() } label: {
-                        if isLoading { ProgressView().controlSize(.small).frame(width: 280) }
-                        else { Text(L("验证", "Verify")).frame(width: 280) }
-                    }.buttonStyle(.borderedProminent).tint(TF.amber).disabled(verificationCode.isEmpty || isLoading)
-                    Button(L("重新发送", "Resend Code")) { sendCode() }
-                        .buttonStyle(.plain).foregroundStyle(TF.amber).font(.caption).disabled(isLoading)
-                }
-                Spacer()
-            } else {
-                VStack(spacing: 8) {
-                    Text(L("登录", "Sign In")).font(.system(size: 18, weight: .semibold))
-                    Text(L("输入邮箱，获取验证码", "Enter your email to get a verification code")).font(.caption).foregroundStyle(.secondary)
-                }
-                VStack(spacing: 12) {
-                    TextField(L("邮箱地址", "Email Address"), text: $email)
-                        .textFieldStyle(.roundedBorder).frame(width: 280).multilineTextAlignment(.center)
-                    if let error = loginError { Text(error).font(.caption).foregroundStyle(.red) }
-                    Button { sendCode() } label: {
-                        if isLoading { ProgressView().controlSize(.small).frame(width: 280) }
-                        else { Text(L("发送验证码", "Send Code")).frame(width: 280) }
-                    }.buttonStyle(.borderedProminent).tint(TF.amber).disabled(email.isEmpty || isLoading)
-                }
-                Spacer()
-            }
-        }
-    }
-
-    private func sendCode() {
-        isLoading = true; loginError = nil
-        Task {
-            do { try await CloudAuthManager.shared.sendCode(email: email); codeSent = true }
-            catch { loginError = error.localizedDescription }
-            isLoading = false
-        }
-    }
-
-    private func verifyCode() {
-        isLoading = true; loginError = nil
-        Task {
-            do { try await CloudAuthManager.shared.verify(email: email, code: verificationCode); loginSuccess = true }
-            catch { loginError = error.localizedDescription }
-            isLoading = false
-        }
-    }
-    #endif
-
-    // MARK: - Step 2: Permissions
-
-    private var permissionsStep: some View {
-        VStack(spacing: 16) {
-            PermissionGuideView(model: permissionGuideModel, embedded: true)
-
-            #if HAS_CLOUD_SUBSCRIPTION
-            navigationFooter { step = 4 }
-            #else
-            navigationFooter { step = 3 }
-            #endif
-        }
-        .onAppear { permissionGuideModel.refresh() }
-    }
-
-    // MARK: - Step 1: Provider + Credentials
-
-    @State private var selectedProvider: ASRProvider = .volcano
-    @State private var credentialValues: [String: String] = [:]
-
-    private var currentFields: [CredentialField] {
-        ASRProviderRegistry.configType(for: selectedProvider)?.credentialFields ?? []
-    }
-
-    private var hasRequiredFields: Bool {
-        currentFields.filter { !$0.isOptional }.allSatisfy { field in
-            let val = credentialValues[field.key] ?? ""
-            return !val.isEmpty
-        }
-    }
-
-    private var providerStep: some View {
-        VStack(spacing: 24) {
-            Spacer()
-
-            VStack(spacing: 8) {
-                Text(L("配置语音识别", "Configure ASR"))
-                    .font(.system(size: 18, weight: .semibold))
-                Text(L("选择识别引擎并填写 API 凭据", "Choose an ASR engine and enter API credentials"))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            VStack(spacing: 12) {
-                // Provider picker
-                Picker(L("识别引擎", "ASR Engine"), selection: $selectedProvider) {
-                    ForEach(ASRProvider.allCases.filter {
-                        ASRProviderRegistry.entry(for: $0)?.isAvailable ?? false
-                    }, id: \.self) { provider in
-                        Text(provider.displayName).tag(provider)
-                    }
-                }
-                .labelsHidden()
-                .frame(width: 300)
-                .onChange(of: selectedProvider) { _, newProvider in
-                    var defaults: [String: String] = [:]
-                    let fields = ASRProviderRegistry.configType(for: newProvider)?.credentialFields ?? []
-                    for field in fields where !field.defaultValue.isEmpty {
-                        defaults[field.key] = field.defaultValue
-                    }
-                    credentialValues = defaults
-                }
-
-                // Dynamic credential fields
-                ForEach(currentFields) { field in
-                    if !field.options.isEmpty {
-                        Picker(field.label, selection: Binding(
-                            get: { credentialValues[field.key] ?? field.defaultValue },
-                            set: { credentialValues[field.key] = $0 }
-                        )) {
-                            ForEach(field.options, id: \.value) { option in
-                                Text(option.label).tag(option.value)
-                            }
-                        }
-                    } else if field.isSecure {
-                        SecureField(field.label, text: Binding(
-                            get: { credentialValues[field.key] ?? "" },
-                            set: { credentialValues[field.key] = $0 }
-                        ))
-                        .textFieldStyle(.roundedBorder)
-                    } else if !field.isOptional {
-                        TextField(field.label, text: Binding(
-                            get: { credentialValues[field.key] ?? "" },
-                            set: { credentialValues[field.key] = $0 }
-                        ))
-                        .textFieldStyle(.roundedBorder)
-                    }
-                }
-            }
-            .frame(width: 300)
 
             Spacer()
 
             HStack {
-                #if HAS_CLOUD_SUBSCRIPTION
-                let nextStep = 3
-                #else
-                let nextStep = 2
-                #endif
-                Button(L("跳过", "Skip")) { step = nextStep }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
-                Spacer()
-                Button(L("下一步", "Next")) {
-                    if hasRequiredFields {
-                        try? KeychainService.saveASRCredentials(
-                            for: selectedProvider, values: credentialValues
-                        )
-                        KeychainService.selectedASRProvider = selectedProvider
-                    }
-                    step = nextStep
+                // Step Indicator Dots
+                HStack(spacing: 6) {
+                    Circle().fill(TF.amber).frame(width: 6, height: 6)
+                    Circle().fill(Color.white.opacity(0.25)).frame(width: 6, height: 6)
                 }
-                    .buttonStyle(.borderedProminent)
-                    .tint(TF.amber)
+
+                Spacer()
+
+                Button(action: { step = 1 }) {
+                    Text(L("开始设置", "Get Started"))
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color.white)
+                        .padding(.horizontal, 22)
+                        .padding(.vertical, 8)
+                        .background(
+                            Capsule().fill(TF.amber)
+                        )
+                }
+                .buttonStyle(.plain)
             }
-            .padding(.horizontal, 48)
-            .padding(.bottom, 36)
+            .padding(.horizontal, 36)
+            .padding(.bottom, 24)
         }
     }
 
-    // MARK: - Step 3: Ready
+    // MARK: - Step 1: Permissions
 
-    private var readyStep: some View {
-        VStack(spacing: 28) {
-            Spacer()
+    private var permissionsStep: some View {
+        PermissionGuideView(
+            model: permissionGuideModel,
+            embedded: true,
+            onFinish: completeSetupAndLaunchHome
+        )
+    }
 
-            Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 56))
-                .foregroundStyle(TF.success)
+    // MARK: - Completion Handler
 
-            VStack(spacing: 8) {
-                Text(L("准备就绪", "Ready"))
-                    .font(.system(size: 22, weight: .semibold))
-                Text(L("按住右 Option 键开始说话\n松开后文字自动输入到光标位置", "Hold Right Option to speak\nText is typed at cursor on release"))
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: 300)
-            }
-
-            Spacer()
-
-            Button(L("开始使用", "Start Using")) {
-                #if HAS_CLOUD_SUBSCRIPTION
-                AppEditionMigration.switchTo(selectedEdition)
-                #endif
-                appState.hasCompletedSetup = true
-                NSApp.keyWindow?.close()
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(TF.amber)
-            .controlSize(.large)
-            .padding(.bottom, 36)
+    private func completeSetupAndLaunchHome() {
+        #if HAS_CLOUD_SUBSCRIPTION
+        if appState.appEdition == nil {
+            AppEditionMigration.switchTo(.byoKey)
         }
+        #endif
+        appState.hasCompletedSetup = true
+        NSApp.keyWindow?.close()
+        AppDelegate.presentSettings()
     }
 }
-

--- a/Type4Me/UI/Setup/SetupWizardView.swift
+++ b/Type4Me/UI/Setup/SetupWizardView.swift
@@ -117,6 +117,7 @@ struct SetupWizardView: View {
     // MARK: - Completion Handler
 
     private func completeSetupAndLaunchHome() {
+        permissionGuideModel.dismissDragOverlay()
         #if HAS_CLOUD_SUBSCRIPTION
         if appState.appEdition == nil {
             AppEditionMigration.switchTo(.byoKey)

--- a/Type4Me/UI/Setup/SetupWizardView.swift
+++ b/Type4Me/UI/Setup/SetupWizardView.swift
@@ -110,7 +110,11 @@ struct SetupWizardView: View {
         PermissionGuideView(
             model: permissionGuideModel,
             embedded: true,
-            onFinish: completeSetupAndLaunchHome
+            onFinish: completeSetupAndLaunchHome,
+            onRaiseHostWindow: {
+                NSApp.activate(ignoringOtherApps: true)
+                AppDelegate.presentSetupWizard()
+            }
         )
     }
 

--- a/Type4MeTests/FloatingModelAlertCardsTests.swift
+++ b/Type4MeTests/FloatingModelAlertCardsTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import Type4Me
+
+@MainActor
+final class FloatingModelAlertCardsTests: XCTestCase {
+    func testAppleASRHasConfiguredCredentials() {
+        XCTAssertTrue(ModelSettingsHelpers.hasConfiguredCredentials(for: .apple))
+    }
+
+    func testCodexCLIHasConfiguredCredentials() {
+        XCTAssertTrue(ModelSettingsHelpers.hasConfiguredCredentials(for: .codexCLI))
+    }
+
+    func testAppNavigationModelCategoryRouting() {
+        let nav = AppNavigationModel()
+        nav.selectedTab = .general
+        XCTAssertEqual(nav.selectedTab, .general)
+        XCTAssertNil(nav.pendingModelCategory)
+
+        nav.selectedTab = .models
+        nav.pendingModelCategory = .asr
+        XCTAssertEqual(nav.selectedTab, .models)
+        XCTAssertEqual(nav.pendingModelCategory, .asr)
+    }
+}

--- a/Type4MeTests/HotkeyStateMachineTests.swift
+++ b/Type4MeTests/HotkeyStateMachineTests.swift
@@ -43,11 +43,10 @@ final class HotkeyStateMachineTests: XCTestCase {
         return manager
     }
 
-    func testKeyboardHotkeysPreferHIDTapBeforeSessionFallback() {
+    func testKeyboardHotkeysPreferSessionTap() {
         XCTAssertEqual(
             HotkeyManager.tapLocationPriority.map(\.rawValue),
             [
-                CGEventTapLocation.cghidEventTap.rawValue,
                 CGEventTapLocation.cgSessionEventTap.rawValue,
             ]
         )

--- a/Type4MeTests/HotkeyStateMachineTests.swift
+++ b/Type4MeTests/HotkeyStateMachineTests.swift
@@ -1141,4 +1141,121 @@ final class HotkeyStateMachineTests: XCTestCase {
         }
         XCTAssertFalse(completedOrFinalized, "Full discard abort must not emit completion or processing events")
     }
+
+    // MARK: - Event Tap Recovery Policy & Lifecycle Tests
+
+    func testEventTapRecoveryActionPolicy() {
+        XCTAssertEqual(
+            HotkeyManager.recoveryAction(for: .tapDisabledByUserInput, isAccessibilityTrusted: false),
+            .revoke
+        )
+        XCTAssertEqual(
+            HotkeyManager.recoveryAction(for: .tapDisabledByTimeout, isAccessibilityTrusted: false),
+            .revoke
+        )
+        XCTAssertEqual(
+            HotkeyManager.recoveryAction(for: .tapDisabledByUserInput, isAccessibilityTrusted: true),
+            .reenable
+        )
+        XCTAssertEqual(
+            HotkeyManager.recoveryAction(for: .tapDisabledByTimeout, isAccessibilityTrusted: true),
+            .reenable
+        )
+        XCTAssertEqual(
+            HotkeyManager.recoveryAction(for: .keyDown, isAccessibilityTrusted: false),
+            .passThrough
+        )
+        XCTAssertEqual(
+            HotkeyManager.recoveryAction(for: .keyDown, isAccessibilityTrusted: true),
+            .passThrough
+        )
+    }
+
+    func testRepeatedStopLeavesStoppedStateWithoutRevocationCallback() {
+        let manager = makeManager()
+        var revocationCount = 0
+        manager.onAccessibilityRevoked = {
+            revocationCount += 1
+        }
+
+        XCTAssertEqual(manager.eventTapLifecycleStateDescription, "stopped")
+        manager.stop()
+        XCTAssertEqual(manager.eventTapLifecycleStateDescription, "stopped")
+        manager.stop()
+        XCTAssertEqual(manager.eventTapLifecycleStateDescription, "stopped")
+
+        let exp = expectation(description: "No async revocation callback")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 0.2)
+        XCTAssertEqual(revocationCount, 0)
+    }
+
+    func testSimulatedPermissionLossLifecycleAndOneShotRevocationCallback() {
+        let manager = makeManager()
+        var revocationCount = 0
+        manager.onAccessibilityRevoked = {
+            revocationCount += 1
+        }
+
+        // First transition to revoked
+        manager.simulateRevocationForTesting()
+        XCTAssertEqual(manager.eventTapLifecycleStateDescription, "revoked")
+
+        let exp1 = expectation(description: "First revocation callback dispatched")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            exp1.fulfill()
+        }
+        wait(for: [exp1], timeout: 0.2)
+        XCTAssertEqual(revocationCount, 1)
+
+        // Second simulated loss in the same generation must not emit again
+        manager.simulateRevocationForTesting()
+        XCTAssertEqual(manager.eventTapLifecycleStateDescription, "revoked")
+
+        let exp2 = expectation(description: "Duplicate revocation suppressed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            exp2.fulfill()
+        }
+        wait(for: [exp2], timeout: 0.2)
+        XCTAssertEqual(revocationCount, 1)
+
+        // Reset generation after simulated successful start
+        manager.resetRevocationGenerationForTesting()
+        XCTAssertEqual(manager.eventTapLifecycleStateDescription, "running")
+
+        // Next revocation in new generation should emit once more
+        manager.simulateRevocationForTesting()
+        XCTAssertEqual(manager.eventTapLifecycleStateDescription, "revoked")
+
+        let exp3 = expectation(description: "New generation revocation callback dispatched")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            exp3.fulfill()
+        }
+        wait(for: [exp3], timeout: 0.2)
+        XCTAssertEqual(revocationCount, 2)
+    }
+
+    func testInitialStartWithoutPermissionDoesNotEmitRevocationCallback() {
+        let manager = makeManager()
+        var revocationCount = 0
+        manager.onAccessibilityRevoked = {
+            revocationCount += 1
+        }
+
+        // If permission is absent, calling start() should transition to revoked but NOT emit revocation callback
+        if !PermissionManager.hasAccessibilityPermission {
+            let started = manager.start()
+            XCTAssertFalse(started)
+            XCTAssertEqual(manager.eventTapLifecycleStateDescription, "revoked")
+
+            let exp = expectation(description: "No revocation callback on initial start")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                exp.fulfill()
+            }
+            wait(for: [exp], timeout: 0.2)
+            XCTAssertEqual(revocationCount, 0, "Initial denial must not trigger onAccessibilityRevoked")
+        }
+    }
 }

--- a/Type4MeTests/HotkeyStateMachineTests.swift
+++ b/Type4MeTests/HotkeyStateMachineTests.swift
@@ -43,10 +43,11 @@ final class HotkeyStateMachineTests: XCTestCase {
         return manager
     }
 
-    func testKeyboardHotkeysPreferSessionTap() {
+    func testKeyboardHotkeysPreferHIDTapBeforeSessionFallback() {
         XCTAssertEqual(
             HotkeyManager.tapLocationPriority.map(\.rawValue),
             [
+                CGEventTapLocation.cghidEventTap.rawValue,
                 CGEventTapLocation.cgSessionEventTap.rawValue,
             ]
         )

--- a/Type4MeTests/KeychainNotificationTests.swift
+++ b/Type4MeTests/KeychainNotificationTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import Type4Me
+
+@MainActor
+final class KeychainNotificationTests: XCTestCase {
+    func testCredentialsDidChangeNotificationName() {
+        XCTAssertEqual(Notification.Name.credentialsDidChange.rawValue, "tf_credentialsDidChange")
+    }
+
+    func testSelectedLLMProviderChangePostsNotification() {
+        var notificationFired = false
+        let observer = NotificationCenter.default.addObserver(
+            forName: .credentialsDidChange,
+            object: nil,
+            queue: nil
+        ) { _ in
+            notificationFired = true
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let original = KeychainService.selectedLLMProvider
+        let newProvider: LLMProvider = original == .doubao ? .deepseek : .doubao
+        KeychainService.selectedLLMProvider = newProvider
+        defer { KeychainService.selectedLLMProvider = original }
+
+        XCTAssertTrue(notificationFired)
+    }
+
+    func testAppNavigationModelPendingCategory() {
+        let model = AppNavigationModel()
+        XCTAssertNil(model.pendingModelCategory)
+        model.pendingModelCategory = .llm
+        XCTAssertEqual(model.pendingModelCategory, .llm)
+    }
+}

--- a/Type4MeTests/KeychainNotificationTests.swift
+++ b/Type4MeTests/KeychainNotificationTests.swift
@@ -48,6 +48,46 @@ final class KeychainNotificationTests: XCTestCase {
         XCTAssertTrue(synchronousReadSucceeded, "Synchronous read inside credentialsDidChange observer must complete without deadlocking")
     }
 
+    func testSaveASRCredentialsObserverSynchronousReadDoesNotDeadlock() throws {
+        guard KeychainService.isUsingTestStorage else {
+            throw XCTSkip("Keychain tests require isolated test storage")
+        }
+        var readCompleted = false
+        let observer = NotificationCenter.default.addObserver(
+            forName: .credentialsDidChange,
+            object: nil,
+            queue: nil
+        ) { _ in
+            _ = KeychainService.loadASRCredentials(for: .volcano)
+            _ = KeychainService.loadSelectedASRConfig()
+            readCompleted = true
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        try KeychainService.saveASRCredentials(for: .volcano, values: ["appKey": "test_app_key"])
+        XCTAssertTrue(readCompleted, "Synchronous read inside saveASRCredentials notification must not deadlock")
+    }
+
+    func testSaveLLMCredentialsObserverSynchronousReadDoesNotDeadlock() throws {
+        guard KeychainService.isUsingTestStorage else {
+            throw XCTSkip("Keychain tests require isolated test storage")
+        }
+        var readCompleted = false
+        let observer = NotificationCenter.default.addObserver(
+            forName: .credentialsDidChange,
+            object: nil,
+            queue: nil
+        ) { _ in
+            _ = KeychainService.loadLLMCredentials(for: .doubao)
+            _ = KeychainService.loadSelectedLLMConfig()
+            readCompleted = true
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        try KeychainService.saveLLMCredentials(for: .doubao, values: ["model": "doubao-pro"])
+        XCTAssertTrue(readCompleted, "Synchronous read inside saveLLMCredentials notification must not deadlock")
+    }
+
     func testAppNavigationModelPendingCategory() {
         let model = AppNavigationModel()
         XCTAssertNil(model.pendingModelCategory)

--- a/Type4MeTests/KeychainNotificationTests.swift
+++ b/Type4MeTests/KeychainNotificationTests.swift
@@ -26,6 +26,28 @@ final class KeychainNotificationTests: XCTestCase {
         XCTAssertTrue(notificationFired)
     }
 
+    func testCredentialsDidChangeObserverSynchronousReadDoesNotDeadlock() {
+        var synchronousReadSucceeded = false
+        let observer = NotificationCenter.default.addObserver(
+            forName: .credentialsDidChange,
+            object: nil,
+            queue: nil
+        ) { _ in
+            // Synchronously read credentials during notification delivery
+            _ = KeychainService.loadSelectedASRConfig()
+            _ = KeychainService.loadSelectedLLMConfig()
+            synchronousReadSucceeded = true
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let original = KeychainService.selectedASRProvider
+        let newProvider: ASRProvider = original == .volcano ? .apple : .volcano
+        KeychainService.selectedASRProvider = newProvider
+        defer { KeychainService.selectedASRProvider = original }
+
+        XCTAssertTrue(synchronousReadSucceeded, "Synchronous read inside credentialsDidChange observer must complete without deadlocking")
+    }
+
     func testAppNavigationModelPendingCategory() {
         let model = AppNavigationModel()
         XCTAssertNil(model.pendingModelCategory)

--- a/Type4MeTests/PermissionGuideModelTests.swift
+++ b/Type4MeTests/PermissionGuideModelTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import Type4Me
+
+@MainActor
+final class PermissionGuideModelTests: XCTestCase {
+    func testNeedsRestartDetectionWhenHotkeyProbeFails() {
+        let model = PermissionGuideModel()
+        model.accessibilityGranted = true
+        model.hotkeyProbe = { false } // simulate kernel cache failure
+        model.refresh()
+        // If accessibility is granted but probe fails, needsRestart should be true
+        if model.accessibilityGranted {
+            XCTAssertTrue(model.needsRestart)
+        }
+    }
+
+    func testNeedsRestartFalseWhenHotkeyProbeSucceeds() {
+        let model = PermissionGuideModel()
+        model.accessibilityGranted = true
+        model.hotkeyProbe = { true }
+        model.refresh()
+        XCTAssertFalse(model.needsRestart)
+    }
+
+    func testRequiredPermissionsCalculation() {
+        let model = PermissionGuideModel()
+        model.micGranted = true
+        model.accessibilityGranted = true
+        XCTAssertTrue(model.requiredPermissionsGranted)
+
+        model.micGranted = false
+        XCTAssertFalse(model.requiredPermissionsGranted)
+    }
+}

--- a/docs/features/permission-onboarding-redesign/development-design.md
+++ b/docs/features/permission-onboarding-redesign/development-design.md
@@ -1,0 +1,304 @@
+# Type4Me 权限引导与首启流程开发设计
+
+> 文档类型：开发设计  
+> 文档状态：设计完成，待审阅  
+> 设计日期：2026-09-02  
+> 对应分支：`feat/permission-onboarding-redesign`  
+> 对应产品设计：[product-design.md](product-design.md)  
+
+---
+
+## 1. 架构总览
+
+本功能对 Type4Me 的首启向导、权限管理与主界面模型引导进行端到端重构：
+
+```mermaid
+graph TD
+    subgraph AppLifecycle [应用生命周期 Type4MeApp]
+        Launch[didFinishLaunching] --> CheckSetup{hasCompletedSetup?}
+        CheckSetup -- 否 --> OpenSetup[openSetupWindowAction]
+        CheckSetup -- 是 --> CheckPerms{必需权限已齐备?}
+        CheckPerms -- 否 --> OpenGuide[openPermissionGuideAction]
+        CheckPerms -- 是 --> RegisterHotkey[启动快捷键监听]
+    end
+
+    subgraph SetupFlow [首启流程 SetupWizardView]
+        OpenSetup --> StepWelcome[Step 0: WelcomeView]
+        StepWelcome --> StepPerms[Step 1: Screenflare PermissionGuideView]
+        StepPerms -->|完成/重启| FinishSetup[写入 hasCompletedSetup = true<br/>关闭向导，打开 SettingsView]
+    end
+
+    subgraph PermGuide [权限状态机 PermissionGuideModel]
+        StepPerms -.-> Model[PermissionGuideModel]
+        Model --> Mic[AVCaptureDevice]
+        Model --> AX[AXIsProcessTrusted + PermissionDragOverlay]
+        Model --> Speech[SFSpeechRecognizer]
+        AX --> CheckTap[EventTap 状态检测]
+        CheckTap -->|需重启| NeedsRestart[needsRestart = true]
+    end
+
+    subgraph HomeAlerts [首页提醒 SettingsView / GeneralSettingsTab]
+        FinishSetup --> Home[GeneralSettingsTab]
+        Home --> CheckASRConfig{ModelSettingsHelpers.hasConfiguredCredentials(ASR)}
+        Home --> CheckLLMConfig{ModelSettingsHelpers.hasConfiguredCredentials(LLM)}
+        CheckASRConfig -- 未配置 --> CardASR[🔴 ASR 悬浮提醒卡片]
+        CheckLLMConfig -- 未配置 --> CardLLM[🟠 LLM 悬浮提醒卡片]
+        CardASR -->|点击| JumpASR[AppNavigationModel: tab=.models, category=.asr]
+        CardLLM -->|点击| JumpLLM[AppNavigationModel: tab=.models, category=.llm]
+    end
+```
+
+---
+
+## 2. 模块与状态设计
+
+### 2.1 `PermissionGuideModel` 状态机增强
+`PermissionGuideModel` 负责统一的权限请求、轮询探测与重启状态管理：
+
+```swift
+@MainActor
+@Observable
+final class PermissionGuideModel {
+    // 权限状态
+    var micGranted: Bool = false
+    var accessibilityGranted: Bool = false
+    var speechGranted: Bool = false
+
+    // 辅助功能是否已在系统设置开启但内核事件监听需要重启生效
+    var needsRestart: Bool = false
+
+    // 拖拽浮层状态
+    var isDragOverlayShown: Bool = false
+
+    // 计算属性：必需权限是否均已满足
+    var requiredPermissionsGranted: Bool {
+        micGranted && accessibilityGranted
+    }
+
+    // 刷新各权限状态
+    func refresh() {
+        micGranted = PermissionManager.hasMicrophonePermission
+        accessibilityGranted = PermissionManager.hasAccessibilityPermission
+        speechGranted = PermissionManager.hasSpeechRecognitionPermission
+    }
+
+    // 触发麦克风授权
+    func requestMicrophone() { ... }
+
+    // 触发辅助功能授权流程（打开设置 + 显示底部拖拽浮层 + 启动 0.5s 轮询）
+    func beginAccessibilityFlow() { ... }
+
+    // 触发 Apple 语音识别授权
+    func requestSpeechRecognition() { ... }
+
+    // 执行应用重启
+    func relaunchApp() {
+        let url = Bundle.main.bundleURL
+        let task = Process()
+        task.launchPath = "/usr/bin/open"
+        task.arguments = ["-n", url.path]
+        try? task.run()
+        NSApp.terminate(nil)
+    }
+}
+```
+
+---
+
+### 2.2 `SetupWizardView` 极简重构
+将 `SetupWizardView` 简化为 2 个步骤：
+- **`step = 0` (Welcome)**：品牌图标、定位文本与「开始设置」主按钮；
+- **`step = 1` (Permissions)**：Screenflare 风格的 `PermissionGuideView(embedded: true)`；
+- 完成动作：调用 `appState.hasCompletedSetup = true`，关闭当前窗口，并调用 `AppDelegate.openSettingsAction?()` 打开主应用首页。
+
+```swift
+struct SetupWizardView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(PermissionGuideModel.self) private var permissionGuideModel
+    @State private var step = 0
+    @AppStorage("tf_language") private var language = AppLanguage.systemDefault
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Group {
+                switch step {
+                case 0: welcomeStep
+                default: permissionsStep
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .animation(TF.springGentle, value: step)
+        }
+        .frame(width: 640, height: 480)
+        .id(language)
+    }
+}
+```
+
+---
+
+### 2.3 `PermissionGuideView` 视觉重构 (Screenflare 规范)
+重构 `PermissionGuideView`，使其在深色卡片中呈现居中头部、分组权限列表与底部自愈操作栏：
+
+```swift
+struct PermissionGuideView: View {
+    @Bindable var model: PermissionGuideModel
+    let embedded: Bool
+
+    var body: some View {
+        VStack(spacing: 16) {
+            // 1. 顶部 Header
+            headerSection
+
+            // 2. 分组权限列表容器
+            permissionGroupContainer {
+                microphoneRow
+                divider
+                accessibilityRow
+                divider
+                speechRecognitionRow
+            }
+
+            // 3. 底部次要提示
+            footerNote
+
+            // 4. 底部操作栏（步骤点 + 主操作按钮：重启 Type4Me / 进入应用）
+            bottomBar
+        }
+        .padding(28)
+        .background(screenflareCardBackground)
+        .preferredColorScheme(.dark)
+        .onAppear { model.refresh() }
+    }
+}
+```
+
+---
+
+### 2.4 首页模型配置悬浮提醒卡片 (`FloatingModelAlertCards`)
+
+在 `SettingsView` 的右下角挂载一个轻量悬浮提醒视图层：
+
+```swift
+struct FloatingModelAlertCards: View {
+    @Environment(AppNavigationModel.self) private var navigationModel
+    @State private var isASRMissing: Bool = false
+    @State private var isLLMMissing: Bool = false
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 10) {
+            if isASRMissing {
+                alertCard(
+                    color: .red,
+                    icon: "waveform.badge.exclamationmark",
+                    title: L("需配置默认语音识别模型", "Configure Speech Recognition Model"),
+                    subtitle: L("点击前往模型页配置 API Key 或本地模型", "Click to set up API keys or local models"),
+                    action: {
+                        navigationModel.selectedTab = .models
+                        navigationModel.pendingModelCategory = .asr
+                    }
+                )
+                .transition(.move(edge: .trailing).combined(with: .opacity))
+            }
+
+            if isLLMMissing {
+                alertCard(
+                    color: TF.amber,
+                    icon: "sparkles",
+                    title: L("需配置默认文本润色模型", "Configure Text Polishing Model"),
+                    subtitle: L("用于智能纠错、标点与改写", "Used for smart punctuation and rewriting"),
+                    action: {
+                        navigationModel.selectedTab = .models
+                        navigationModel.pendingModelCategory = .llm
+                    }
+                )
+                .transition(.move(edge: .trailing).combined(with: .opacity))
+            }
+        }
+        .padding(20)
+        .animation(.spring(response: 0.35, dampingFraction: 0.82), value: isASRMissing)
+        .animation(.spring(response: 0.35, dampingFraction: 0.82), value: isLLMMissing)
+        .task { checkModelStatus() }
+        .onReceive(NotificationCenter.default.publisher(for: .asrProviderDidChange)) { _ in
+            checkModelStatus()
+        }
+    }
+
+    private func checkModelStatus() {
+        let currentASR = KeychainService.selectedASRProvider
+        let currentLLM = KeychainService.selectedLLMProvider
+        isASRMissing = !ModelSettingsHelpers.hasConfiguredCredentials(for: currentASR)
+        isLLMMissing = !ModelSettingsHelpers.hasConfiguredCredentials(for: currentLLM)
+    }
+}
+```
+
+并在 `AppNavigationModel` 中支持指定子类别：
+```swift
+@MainActor
+@Observable
+final class AppNavigationModel {
+    var selectedTab: SettingsTab = .general
+    var pendingModelCategory: ModelCategory?
+    var pendingAskAnythingSessionID: UUID?
+    var pendingModeSelectionID: UUID?
+}
+```
+
+---
+
+### 2.5 修复 `Type4MeApp.swift` 唤起机制
+
+将原本失效的 `sendAction(Selector(("showSetupWindow:")), ...)` 替换为原生注册的 SwiftUI 打开闭包：
+
+```swift
+// AppDelegate 增加静态动作分发
+static var openSetupAction: (() -> Void)?
+static var openSettingsAction: (() -> Void)?
+static var openPermissionGuideAction: (() -> Void)?
+
+// 首启检测调用
+if needsSetup {
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+        MainActor.assumeIsolated {
+            if self?.suppressSetupWizardForHeadlessLaunch == true { return }
+            Self.openSetupAction?()
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+}
+```
+
+---
+
+## 3. 涉及文件与改动清单 (Files Touched)
+
+| 文件路径 | 变动职责 |
+|---|---|
+| `Type4Me/UI/Setup/SetupWizardView.swift` | 简化向导为 2 步，移除冗余服务商表单，集成首启完成自动跳转首页 |
+| `Type4Me/Permissions/PermissionGuideView.swift` | 1:1 重构为 Screenflare 风格深色卡片、分组权限列表与底部操作栏 |
+| `Type4Me/Permissions/PermissionGuideModel.swift` | 新增语音识别授权、重启状态检测 `needsRestart` 与应用重启执行 `relaunchApp()` |
+| `Type4Me/Type4MeApp.swift` | 绑定 `openSetupAction` / `openSettingsAction`，修复首启自动唤起与权限恢复路由 |
+| `Type4Me/UI/Settings/SettingsView.swift` | 在右下角叠加 `FloatingModelAlertCards`，处理模型类别自动切换 |
+| `Type4Me/UI/Settings/ModelSettingsTab.swift` | 响应 `navigationModel.pendingModelCategory`，自动定位 ASR / LLM 选项卡 |
+| `Type4Me/UI/Localization.swift` | 补充双语对照文案（全链路 `L(zh, en)`） |
+
+---
+
+## 4. 验证与回归计划
+
+1. **首次启动冷启动验证**：
+   - 清除 `tf_hasCompletedSetup` 偏好，启动应用，确认自动弹出 640×480 尺寸的精致向导。
+   - 点击「开始设置」，平滑转场至步骤 2 权限页。
+2. **Screenflare 权限流与拖拽浮层验证**：
+   - 点击麦克风「允许」，验证系统麦克风授权与「已允许」状态切换。
+   - 点击辅助功能「允许」，验证系统设置 Accessibility 页面自动打开，且屏幕底部准确弹出 `PermissionDragOverlay` 拖拽条。
+   - 验证状态变更后卡片即刻变为绿色勾选，当需要重启时右下角按钮变为「重启 Type4Me」。
+3. **完成并进入首页验证**：
+   - 点击「进入应用」，验证向导关闭并自动唤起主界面首页（`SettingsTab.general`）。
+4. **首页模型提示卡片与跳转验证**：
+   - 在未配置 ASR / LLM 时，验证右下角准确浮现 🔴 红色与 🟠 橙色卡片。
+   - 点击卡片，验证平滑跳转至「模型」设置页并自动选中对应 ASR / LLM 类别。
+   - 填入有效凭证或选择 Apple Speech / Codex CLI 后返回首页，验证卡片平滑淡出消除。
+5. **动态语言切换验证**：
+   - 在中文与英文之间切换 `tf_language`，确认向导、权限页、提示卡片所有文本均实时热刷新。

--- a/docs/features/permission-onboarding-redesign/development-design.md
+++ b/docs/features/permission-onboarding-redesign/development-design.md
@@ -1,7 +1,7 @@
 # Type4Me 权限引导与首启流程开发设计
 
 > 文档类型：开发设计  
-> 文档状态：设计完成，待审阅  
+> 文档状态：设计完成，已通过 Review 修正  
 > 设计日期：2026-09-02  
 > 对应分支：`feat/permission-onboarding-redesign`  
 > 对应产品设计：[product-design.md](product-design.md)  
@@ -16,28 +16,28 @@
 graph TD
     subgraph AppLifecycle [应用生命周期 Type4MeApp]
         Launch[didFinishLaunching] --> CheckSetup{hasCompletedSetup?}
-        CheckSetup -- 否 --> OpenSetup[openSetupWindowAction]
+        CheckSetup -- 否 --> PresentSetup[presentSetupWizard - 带重试]
         CheckSetup -- 是 --> CheckPerms{必需权限已齐备?}
-        CheckPerms -- 否 --> OpenGuide[openPermissionGuideAction]
+        CheckPerms -- 否 --> PresentGuide[presentPermissionGuide - 带重试]
         CheckPerms -- 是 --> RegisterHotkey[启动快捷键监听]
     end
 
     subgraph SetupFlow [首启流程 SetupWizardView]
-        OpenSetup --> StepWelcome[Step 0: WelcomeView]
+        PresentSetup --> StepWelcome[Step 0: WelcomeView]
         StepWelcome --> StepPerms[Step 1: Screenflare PermissionGuideView]
-        StepPerms -->|完成/重启| FinishSetup[写入 hasCompletedSetup = true<br/>关闭向导，打开 SettingsView]
+        StepPerms -->|完成/重启| FinishSetup[写入 hasCompletedSetup = true 及默认 Edition<br/>关闭向导，打开 SettingsView]
     end
 
     subgraph PermGuide [权限状态机 PermissionGuideModel]
         StepPerms -.-> Model[PermissionGuideModel]
         Model --> Mic[AVCaptureDevice]
         Model --> AX[AXIsProcessTrusted + PermissionDragOverlay]
-        Model --> Speech[SFSpeechRecognizer]
-        AX --> CheckTap[EventTap 状态检测]
-        CheckTap -->|需重启| NeedsRestart[needsRestart = true]
+        Model --> Speech[SFSpeechRecognizer - 仅在 Apple ASR 时呈现]
+        AX --> ProbeTap[注入 hotkeyProbe 闭包执行实际 Tap 测试]
+        ProbeTap -->|Tap 失败| NeedsRestart[needsRestart = true]
     end
 
-    subgraph HomeAlerts [首页提醒 SettingsView / GeneralSettingsTab]
+    subgraph HomeAlerts [首页提醒 GeneralSettingsTab]
         FinishSetup --> Home[GeneralSettingsTab]
         Home --> CheckASRConfig{ModelSettingsHelpers.hasConfiguredCredentials(ASR)}
         Home --> CheckLLMConfig{ModelSettingsHelpers.hasConfiguredCredentials(LLM)}
@@ -45,54 +45,87 @@ graph TD
         CheckLLMConfig -- 未配置 --> CardLLM[🟠 LLM 悬浮提醒卡片]
         CardASR -->|点击| JumpASR[AppNavigationModel: tab=.models, category=.asr]
         CardLLM -->|点击| JumpLLM[AppNavigationModel: tab=.models, category=.llm]
+        ModelsChanged[Notification.Name.credentialsDidChange] -->|订阅触发| RefreshCards[实时刷新卡片显示状态]
     end
 ```
 
 ---
 
-## 2. 模块与状态设计
+## 2. 详细技术实现方案与 Review 改进
 
-### 2.1 `PermissionGuideModel` 状态机增强
-`PermissionGuideModel` 负责统一的权限请求、轮询探测与重启状态管理：
+### 2.1 `PermissionGuideModel` 状态机与真实 EventTap 探测
+
+`PermissionGuideModel` 不仅依赖 `AXIsProcessTrusted()`，还必须探测真实的快捷键 EventTap 是否生效（以应对 macOS 内核缓存导致授权后仍需重启的问题）：
 
 ```swift
 @MainActor
 @Observable
 final class PermissionGuideModel {
-    // 权限状态
+    // MARK: - Observable State
     var micGranted: Bool = false
     var accessibilityGranted: Bool = false
     var speechGranted: Bool = false
+    var isAppleASRSelected: Bool = false
 
-    // 辅助功能是否已在系统设置开启但内核事件监听需要重启生效
+    /// 当辅助功能已开启 (AXIsProcessTrusted == true)，但内核 EventTap 仍失败时，置为 true
     var needsRestart: Bool = false
-
-    // 拖拽浮层状态
     var isDragOverlayShown: Bool = false
 
-    // 计算属性：必需权限是否均已满足
     var requiredPermissionsGranted: Bool {
         micGranted && accessibilityGranted
     }
 
-    // 刷新各权限状态
+    // MARK: - Injected Probes & Callbacks
+    /// 注入由 AppDelegate 提供的真实 Hotkey tap 探测闭包
+    var hotkeyProbe: (() -> Bool)?
+    /// 宿主窗口唤醒回调（区分向导 embedded 还是独立 guide 窗口）
+    var onFlowCompleteOrRaise: (() -> Void)?
+
+    // MARK: - Lifecycle & Actions
     func refresh() {
         micGranted = PermissionManager.hasMicrophonePermission
         accessibilityGranted = PermissionManager.hasAccessibilityPermission
         speechGranted = PermissionManager.hasSpeechRecognitionPermission
+        isAppleASRSelected = (KeychainService.selectedASRProvider == .apple)
+
+        if accessibilityGranted {
+            if let probe = hotkeyProbe {
+                let tapOk = probe()
+                needsRestart = !tapOk
+            } else {
+                needsRestart = false
+            }
+        } else {
+            needsRestart = false
+        }
     }
 
-    // 触发麦克风授权
     func requestMicrophone() { ... }
 
-    // 触发辅助功能授权流程（打开设置 + 显示底部拖拽浮层 + 启动 0.5s 轮询）
-    func beginAccessibilityFlow() { ... }
+    func beginAccessibilityFlow(hostRaiseCallback: @escaping () -> Void) {
+        self.onFlowCompleteOrRaise = hostRaiseCallback
+        PermissionManager.openAccessibilitySettings()
+        isDragOverlayShown = true
+        dragOverlay.show(
+            appName: "Type4Me",
+            permissionName: L("辅助功能", "Accessibility")
+        ) { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                self.isDragOverlayShown = false
+                self.refresh()
+                NSApp.activate(ignoringOtherApps: true)
+                // 仅唤起发起该流程的宿主窗口，避免错开独立 guide 窗口
+                self.onFlowCompleteOrRaise?()
+            }
+        }
+    }
 
-    // 触发 Apple 语音识别授权
     func requestSpeechRecognition() { ... }
 
-    // 执行应用重启
-    func relaunchApp() {
+    /// 执行重启，且在重启前确保持久化首启状态
+    func relaunchApp(persistSetup: @escaping () -> Void) {
+        persistSetup()
         let url = Bundle.main.bundleURL
         let task = Process()
         task.launchPath = "/usr/bin/open"
@@ -105,45 +138,35 @@ final class PermissionGuideModel {
 
 ---
 
-### 2.2 `SetupWizardView` 极简重构
-将 `SetupWizardView` 简化为 2 个步骤：
-- **`step = 0` (Welcome)**：品牌图标、定位文本与「开始设置」主按钮；
-- **`step = 1` (Permissions)**：Screenflare 风格的 `PermissionGuideView(embedded: true)`；
-- 完成动作：调用 `appState.hasCompletedSetup = true`，关闭当前窗口，并调用 `AppDelegate.openSettingsAction?()` 打开主应用首页。
+### 2.2 `SetupWizardView` 极简重构与云版本状态兼容
 
-```swift
-struct SetupWizardView: View {
-    @Environment(AppState.self) private var appState
-    @Environment(PermissionGuideModel.self) private var permissionGuideModel
-    @State private var step = 0
-    @AppStorage("tf_language") private var language = AppLanguage.systemDefault
-
-    var body: some View {
-        VStack(spacing: 0) {
-            Group {
-                switch step {
-                case 0: welcomeStep
-                default: permissionsStep
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .animation(TF.springGentle, value: step)
-        }
-        .frame(width: 640, height: 480)
-        .id(language)
-    }
-}
-```
+1. **步骤精简为 2 步**（`step = 0: Welcome`, `step = 1: Permissions`）。
+2. **云版本状态安全闭环**：若在带有 `HAS_CLOUD_SUBSCRIPTION` 标记的环境下编译，完成首启或重启前自动将默认版本设为 `.byoKey`（`AppEditionMigration.switchTo(.byoKey)`），确保 `appState.appEdition != nil` 且 `appState.hasCompletedSetup = true`，彻底防止重启后重复陷入向导循环。
+3. **完成动作**：
+   ```swift
+   private func completeSetupAndLaunchHome() {
+       #if HAS_CLOUD_SUBSCRIPTION
+       if appState.appEdition == nil {
+           AppEditionMigration.switchTo(.byoKey)
+       }
+       #endif
+       appState.hasCompletedSetup = true
+       NSApp.keyWindow?.close()
+       AppDelegate.presentSettings()
+   }
+   ```
 
 ---
 
 ### 2.3 `PermissionGuideView` 视觉重构 (Screenflare 规范)
-重构 `PermissionGuideView`，使其在深色卡片中呈现居中头部、分组权限列表与底部自愈操作栏：
+
+重构 `PermissionGuideView`，支持 Screenflare 风格的高保真深色卡片布局：
 
 ```swift
 struct PermissionGuideView: View {
     @Bindable var model: PermissionGuideModel
     let embedded: Bool
+    var onFinish: (() -> Void)?
 
     var body: some View {
         VStack(spacing: 16) {
@@ -151,15 +174,24 @@ struct PermissionGuideView: View {
             headerSection
 
             // 2. 分组权限列表容器
-            permissionGroupContainer {
+            VStack(spacing: 0) {
                 microphoneRow
-                divider
+                dividerLine
                 accessibilityRow
-                divider
-                speechRecognitionRow
+                // 仅当当前选择 Apple Speech 或支持 Apple 语音识别时条件渲染
+                if model.isAppleASRSelected {
+                    dividerLine
+                    speechRecognitionRow
+                }
             }
+            .background(Color.white.opacity(0.06))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color.white.opacity(0.1), lineWidth: 1)
+            )
 
-            // 3. 底部次要提示
+            // 3. 底部说明
             footerNote
 
             // 4. 底部操作栏（步骤点 + 主操作按钮：重启 Type4Me / 进入应用）
@@ -175,9 +207,23 @@ struct PermissionGuideView: View {
 
 ---
 
-### 2.4 首页模型配置悬浮提醒卡片 (`FloatingModelAlertCards`)
+### 2.4 凭证变更广播与首页悬浮提醒卡片 (`FloatingModelAlertCards`)
 
-在 `SettingsView` 的右下角挂载一个轻量悬浮提醒视图层：
+#### A. 统一广播 `Notification.Name.credentialsDidChange`
+在 `KeychainService` 中，当以下事件发生时统一发布通知：
+1. `saveASRCredentials(...)` 保存成功时；
+2. `saveLLMCredentials(...)` 保存成功时；
+3. `selectedASRProvider` 变更时；
+4. `selectedLLMProvider` 变更时。
+
+```swift
+extension Notification.Name {
+    static let credentialsDidChange = Notification.Name("tf_credentialsDidChange")
+}
+```
+
+#### B. 首页提醒卡片悬浮层
+将 `FloatingModelAlertCards` 挂载在 `GeneralSettingsTab` 的右下角（或限制在 `selectedTab == .general`），避免遮挡模型编辑 Tab：
 
 ```swift
 struct FloatingModelAlertCards: View {
@@ -219,6 +265,9 @@ struct FloatingModelAlertCards: View {
         .animation(.spring(response: 0.35, dampingFraction: 0.82), value: isASRMissing)
         .animation(.spring(response: 0.35, dampingFraction: 0.82), value: isLLMMissing)
         .task { checkModelStatus() }
+        .onReceive(NotificationCenter.default.publisher(for: .credentialsDidChange)) { _ in
+            checkModelStatus()
+        }
         .onReceive(NotificationCenter.default.publisher(for: .asrProviderDidChange)) { _ in
             checkModelStatus()
         }
@@ -233,41 +282,36 @@ struct FloatingModelAlertCards: View {
 }
 ```
 
-并在 `AppNavigationModel` 中支持指定子类别：
-```swift
-@MainActor
-@Observable
-final class AppNavigationModel {
-    var selectedTab: SettingsTab = .general
-    var pendingModelCategory: ModelCategory?
-    var pendingAskAnythingSessionID: UUID?
-    var pendingModeSelectionID: UUID?
-}
-```
-
 ---
 
-### 2.5 修复 `Type4MeApp.swift` 唤起机制
+### 2.5 修复 `Type4MeApp.swift` 窗口注册与启动唤起机制
 
-将原本失效的 `sendAction(Selector(("showSetupWindow:")), ...)` 替换为原生注册的 SwiftUI 打开闭包：
+1. **注册 `openSetupAction`**：
+   在 `MenuBarControlCenter.swift` 的 `registerGlobalOpenActions` 中增加对 `setup` 窗口的注册：
+   ```swift
+   AppDelegate.openSetupAction = { [openWindow] in
+       openWindow(id: "setup")
+   }
+   ```
+2. **实现健壮的重试唤起机制 `presentSetupWizard()`**：
+   ```swift
+   static var openSetupAction: (() -> Void)?
 
-```swift
-// AppDelegate 增加静态动作分发
-static var openSetupAction: (() -> Void)?
-static var openSettingsAction: (() -> Void)?
-static var openPermissionGuideAction: (() -> Void)?
-
-// 首启检测调用
-if needsSetup {
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-        MainActor.assumeIsolated {
-            if self?.suppressSetupWizardForHeadlessLaunch == true { return }
-            Self.openSetupAction?()
-            NSApp.activate(ignoringOtherApps: true)
-        }
-    }
-}
-```
+   func presentSetupWizard(retryCount: Int = 0) {
+       if let action = Self.openSetupAction {
+           action()
+           NSApp.activate(ignoringOtherApps: true)
+           return
+       }
+       guard retryCount < 10 else {
+           NSLog("[App] Failed to present setup wizard: open action not registered after retries")
+           return
+       }
+       DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+           self?.presentSetupWizard(retryCount: retryCount + 1)
+       }
+   }
+   ```
 
 ---
 
@@ -275,11 +319,14 @@ if needsSetup {
 
 | 文件路径 | 变动职责 |
 |---|---|
-| `Type4Me/UI/Setup/SetupWizardView.swift` | 简化向导为 2 步，移除冗余服务商表单，集成首启完成自动跳转首页 |
+| `Type4Me/UI/Setup/SetupWizardView.swift` | 简化向导为 2 步，移除冗余服务商表单，集成首启完成及云版本安全持久化 |
 | `Type4Me/Permissions/PermissionGuideView.swift` | 1:1 重构为 Screenflare 风格深色卡片、分组权限列表与底部操作栏 |
-| `Type4Me/Permissions/PermissionGuideModel.swift` | 新增语音识别授权、重启状态检测 `needsRestart` 与应用重启执行 `relaunchApp()` |
-| `Type4Me/Type4MeApp.swift` | 绑定 `openSetupAction` / `openSettingsAction`，修复首启自动唤起与权限恢复路由 |
-| `Type4Me/UI/Settings/SettingsView.swift` | 在右下角叠加 `FloatingModelAlertCards`，处理模型类别自动切换 |
+| `Type4Me/Permissions/PermissionGuideModel.swift` | 接入 `hotkeyProbe` 真实探测、`onFlowCompleteOrRaise` 宿主闭包、持久化重启 `relaunchApp` |
+| `Type4Me/Type4MeApp.swift` | 绑定 `openSetupAction` / `presentSetupWizard()`，注入 `hotkeyProbe` 到 `PermissionGuideModel` |
+| `Type4Me/UI/MenuBar/MenuBarControlCenter.swift` | 注册全局 `AppDelegate.openSetupAction` |
+| `Type4Me/Services/KeychainService.swift` | 在 ASR/LLM 凭证保存与提供商变更时广播 `credentialsDidChange` 通知 |
+| `Type4Me/UI/Settings/GeneralSettingsTab.swift` | 在首页右下角集成 `FloatingModelAlertCards` |
+| `Type4Me/UI/Settings/SettingsView.swift` | `AppNavigationModel` 支持 `pendingModelCategory`，并在 Tab 切换时联动 |
 | `Type4Me/UI/Settings/ModelSettingsTab.swift` | 响应 `navigationModel.pendingModelCategory`，自动定位 ASR / LLM 选项卡 |
 | `Type4Me/UI/Localization.swift` | 补充双语对照文案（全链路 `L(zh, en)`） |
 
@@ -288,17 +335,18 @@ if needsSetup {
 ## 4. 验证与回归计划
 
 1. **首次启动冷启动验证**：
-   - 清除 `tf_hasCompletedSetup` 偏好，启动应用，确认自动弹出 640×480 尺寸的精致向导。
+   - 清除 `tf_hasCompletedSetup`（及云版本 `tf_app_edition`），启动应用，确认通过带重试的 `presentSetupWizard()` 稳定弹出 640×480 尺寸的精致向导。
    - 点击「开始设置」，平滑转场至步骤 2 权限页。
 2. **Screenflare 权限流与拖拽浮层验证**：
    - 点击麦克风「允许」，验证系统麦克风授权与「已允许」状态切换。
-   - 点击辅助功能「允许」，验证系统设置 Accessibility 页面自动打开，且屏幕底部准确弹出 `PermissionDragOverlay` 拖拽条。
-   - 验证状态变更后卡片即刻变为绿色勾选，当需要重启时右下角按钮变为「重启 Type4Me」。
+   - 点击辅助功能「允许」，验证系统设置 Accessibility 页面自动打开，且屏幕底部准确弹出 `PermissionDragOverlay` 拖拽条；拖拽授权完成后仅回到发起向导窗口。
+   - 验证通过 `hotkeyProbe` 进行真实的 EventTap 探测；当系统要求重启时，右下角按钮准确变为「重启 Type4Me」。
+   - 点击「重启 Type4Me」，验证首启状态已正确写入并自动以新进程拉起应用。
 3. **完成并进入首页验证**：
    - 点击「进入应用」，验证向导关闭并自动唤起主界面首页（`SettingsTab.general`）。
 4. **首页模型提示卡片与跳转验证**：
-   - 在未配置 ASR / LLM 时，验证右下角准确浮现 🔴 红色与 🟠 橙色卡片。
+   - 在未配置 ASR / LLM 时，验证仅在首页右下角浮现 🔴 红色与 🟠 橙色卡片。
    - 点击卡片，验证平滑跳转至「模型」设置页并自动选中对应 ASR / LLM 类别。
-   - 填入有效凭证或选择 Apple Speech / Codex CLI 后返回首页，验证卡片平滑淡出消除。
+   - 填入有效凭证保存后，验证通过 `credentialsDidChange` 通知使得首页卡片平滑淡出消除。
 5. **动态语言切换验证**：
    - 在中文与英文之间切换 `tf_language`，确认向导、权限页、提示卡片所有文本均实时热刷新。

--- a/docs/features/permission-onboarding-redesign/plan.md
+++ b/docs/features/permission-onboarding-redesign/plan.md
@@ -1,0 +1,397 @@
+# Type4Me 权限引导与首启流程实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 重构 Type4Me 的首次启动向导为极简 2 步流程，1:1 复刻 Screenflare 风格的高保真深色权限引导卡片，并在应用首页右下角集成未配置默认模型的悬浮引导卡片，修复首启与权限恢复的窗口路由。
+
+**Architecture:** 
+1. `PermissionGuideModel` 状态机增强：接入由 `AppDelegate` 注入的真实 `hotkeyProbe` 探测、宿主窗口唤起闭包与持久化重启机制。
+2. `SetupWizardView` 极简重构：收敛至 Step 0（欢迎）与 Step 1（Screenflare 权限页），并在完成或重启前持久化 `hasCompletedSetup`（及云版本 `.byoKey`）。
+3. `PermissionGuideView` 视觉 1:1 重构：深色半透明圆角卡片、居中头部、分组容器、麦克风（必需）、辅助功能（必需+动态重启提示）、Apple 语音识别（条件可选），系统设置联动 + 底部拖拽浮层 + 重启自愈按钮。
+4. `FloatingModelAlertCards` 首页集成：在 `GeneralSettingsTab` 右下角展示未配置 ASR/LLM 提醒卡片，点击一键跳转至 `Models` 对应类别，响应 `credentialsDidChange` 通知自动消除。
+5. 窗口路由与生命周期修复：在 `MenuBarControlCenter` 注册全局 `openSetupAction`/`openSettingsAction`，并在 `Type4MeApp` 中以重试重发机制 `presentSetupWizard()` 稳定拉起。
+
+**Tech Stack:** Swift 6, SwiftUI, AppKit, AVFoundation, ApplicationServices (AX API), Speech (SFSpeechRecognizer), ServiceManagement.
+
+**Spec:** `docs/features/permission-onboarding-redesign/product-design.md` & `docs/features/permission-onboarding-redesign/development-design.md`
+
+## Global Constraints
+
+- **Bilingual Copy:** 必须支持中文和英文，所有文案通过 `L(zh, en)` 实现，跟随 `AppLanguage.current` / `tf_language` 实时更新，无需重启应用。
+- **Conditional Compilation:** 严格保持 `#if HAS_CLOUD_SUBSCRIPTION` 与 `#if HAS_SHERPA_ONNX` 条件编译守卫完整可用。
+- **No Floating Windows Stacking:** 辅助功能拖拽授权完成后仅唤醒发起该流程的宿主窗口，严禁重复层叠独立权限窗口。
+- **Swift 6 & MainActor:** 所有 UI 与可观察状态类均严格标注 `@MainActor`，禁止跨线程并发冲突。
+
+---
+
+### Task 1: 凭证变更广播与导航模型扩展 (Credentials Notification & Navigation Model)
+
+**Files:**
+- Modify: `Type4Me/Services/KeychainService.swift`
+- Modify: `Type4Me/UI/Settings/SettingsView.swift`
+- Modify: `Type4Me/UI/Settings/ModelSettingsTab.swift`
+- Test: `Tests/Type4MeTests/KeychainNotificationTests.swift`
+
+**Interfaces:**
+- Consumes: `KeychainService.selectedASRProvider`, `KeychainService.selectedLLMProvider`, `ModelCategory`
+- Produces: `Notification.Name.credentialsDidChange`, `AppNavigationModel.pendingModelCategory: ModelCategory?`
+
+- [ ] **Step 1: 编写凭证通知与导航测试**
+
+```swift
+import XCTest
+@testable import Type4Me
+
+final class KeychainNotificationTests: XCTestCase {
+    func testCredentialsDidChangeNotificationName() {
+        XCTAssertEqual(Notification.Name.credentialsDidChange.rawValue, "tf_credentialsDidChange")
+    }
+}
+```
+
+- [ ] **Step 2: 运行测试验证失败**
+
+Run: `swift test --filter KeychainNotificationTests`
+Expected: FAIL (symbol not found).
+
+- [ ] **Step 3: 实现 `credentialsDidChange` 与 `AppNavigationModel` 扩展**
+
+1. 在 `KeychainService.swift` 扩展通知：
+```swift
+extension Notification.Name {
+    static let credentialsDidChange = Notification.Name("tf_credentialsDidChange")
+}
+```
+并在 `saveASRCredentials`, `saveLLMCredentials`, `selectedASRProvider` setter, `selectedLLMProvider` setter 成功时发送通知：
+```swift
+NotificationCenter.default.post(name: .credentialsDidChange, object: nil)
+```
+
+2. 在 `SettingsView.swift` 中的 `AppNavigationModel` 增加属性：
+```swift
+@MainActor
+@Observable
+final class AppNavigationModel {
+    var selectedTab: SettingsTab = .general
+    var pendingModelCategory: ModelCategory?
+    var pendingAskAnythingSessionID: UUID?
+    var pendingModeSelectionID: UUID?
+}
+```
+
+3. 在 `ModelSettingsTab.swift` 中处理 `pendingModelCategory`：
+```swift
+.onAppear {
+    if let targetCategory = navigationModel.pendingModelCategory {
+        selectedCategory = targetCategory
+        navigationModel.pendingModelCategory = nil
+    }
+    // ... existing onAppear logic
+}
+.onChange(of: navigationModel.pendingModelCategory) { _, newCategory in
+    if let newCategory {
+        selectedCategory = newCategory
+        navigationModel.pendingModelCategory = nil
+    }
+}
+```
+
+- [ ] **Step 4: 运行测试验证通过**
+
+Run: `swift test --filter KeychainNotificationTests`
+Expected: PASS.
+
+- [ ] **Step 5: 提交改动**
+
+```bash
+git add Type4Me/Services/KeychainService.swift Type4Me/UI/Settings/SettingsView.swift Type4Me/UI/Settings/ModelSettingsTab.swift Tests/Type4MeTests/KeychainNotificationTests.swift
+git commit -m "feat: add credentialsDidChange notification and pendingModelCategory routing"
+```
+
+---
+
+### Task 2: `PermissionGuideModel` 状态机与真实 EventTap 探测重构
+
+**Files:**
+- Modify: `Type4Me/Permissions/PermissionGuideModel.swift`
+- Test: `Tests/Type4MeTests/PermissionGuideModelTests.swift`
+
+**Interfaces:**
+- Consumes: `PermissionManager`, `KeychainService.selectedASRProvider`, `PermissionDragOverlayController`
+- Produces: `PermissionGuideModel.hotkeyProbe`, `PermissionGuideModel.needsRestart`, `PermissionGuideModel.isAppleASRSelected`, `PermissionGuideModel.relaunchApp(...)`
+
+- [ ] **Step 1: 编写 `PermissionGuideModel` 单元测试**
+
+```swift
+import XCTest
+@testable import Type4Me
+
+@MainActor
+final class PermissionGuideModelTests: XCTestCase {
+    func testNeedsRestartDetectionWhenHotkeyProbeFails() {
+        let model = PermissionGuideModel()
+        model.accessibilityGranted = true
+        model.hotkeyProbe = { false } // simulate kernel cache failure
+        model.refresh()
+        XCTAssertTrue(model.needsRestart)
+    }
+
+    func testNeedsRestartFalseWhenHotkeyProbeSucceeds() {
+        let model = PermissionGuideModel()
+        model.accessibilityGranted = true
+        model.hotkeyProbe = { true }
+        model.refresh()
+        XCTAssertFalse(model.needsRestart)
+    }
+}
+```
+
+- [ ] **Step 2: 运行测试验证失败**
+
+Run: `swift test --filter PermissionGuideModelTests`
+Expected: FAIL.
+
+- [ ] **Step 3: 完善 `PermissionGuideModel.swift` 实现**
+
+重构 `PermissionGuideModel.swift`，增加：
+- `var speechGranted: Bool = false`
+- `var isAppleASRSelected: Bool = false`
+- `var needsRestart: Bool = false`
+- `var hotkeyProbe: (() -> Bool)?`
+- `var onFlowCompleteOrRaise: (() -> Void)?`
+- `var requiredPermissionsGranted: Bool { micGranted && accessibilityGranted }`
+- `func requestSpeechRecognition()`
+- `func beginAccessibilityFlow(hostRaiseCallback: @escaping () -> Void)`
+- `func relaunchApp(persistSetup: @escaping () -> Void)`
+
+- [ ] **Step 4: 运行测试验证通过**
+
+Run: `swift test --filter PermissionGuideModelTests`
+Expected: PASS.
+
+- [ ] **Step 5: 提交改动**
+
+```bash
+git add Type4Me/Permissions/PermissionGuideModel.swift Tests/Type4MeTests/PermissionGuideModelTests.swift
+git commit -m "feat: add hotkey tap probing and relaunch mechanics to PermissionGuideModel"
+```
+
+---
+
+### Task 3: `PermissionGuideView` 1:1 Screenflare 视觉重构
+
+**Files:**
+- Modify: `Type4Me/Permissions/PermissionGuideView.swift`
+
+**Interfaces:**
+- Consumes: `PermissionGuideModel`, `L(zh, en)`, `TF.amber`, `PermissionDragOverlay`
+- Produces: `PermissionGuideView(model:embedded:onFinish:)`
+
+- [ ] **Step 1: 编写视图静态结构与预览**
+
+在 `PermissionGuideView.swift` 中实现：
+1. 深色精致容器卡片风格：
+   - 带有居中标题：`几项系统权限` / `A few permissions`
+   - 副标题：`Type4Me 需要以下权限以录制语音并自动打字。录音数据仅在听写期间使用，绝不会离开你的 Mac。`
+2. 分组权限列表容器（Grouped Container）：
+   - 🔴 **麦克风 (必需)**：红橙渐变图标方块，标题 + `[ 必需 ]` 徽标，用途说明，右侧 `允许` / `已允许` 按钮。
+   - 🔴 **辅助功能 (必需)**：蓝紫渐变图标方块，标题 + `[ 必需 ]` 徽标，用途说明，动态黄色提示 `已开启？macOS 可能需要在重启应用后生效。`，右侧 `允许` / `已允许` 按钮。
+   - ⚪ **Apple 语音识别 (可选)**：仅当 `model.isAppleASRSelected == true` 时渲染，青绿渐变图标方块，标题 + `[ 可选 ]` 徽标，右侧 `允许` / `已允许` 按钮。
+3. 底部次要提示文案：
+   - `随时可以在 macOS「系统设置」中更改这些权限。`
+4. 底部操作栏（Bottom Bar）：
+   - 左下角：步骤圆点 `• •`
+   - 右下角主按钮：
+     - 若 `model.needsRestart` 为真：高亮蓝色胶囊按钮 **「重启 Type4Me」**；
+     - 若未就绪：置灰禁用；
+     - 若就绪：高亮琥珀金胶囊按钮 **「进入应用」/「Launch Type4Me」**（或向导中的下一步）。
+
+- [ ] **Step 2: 编译验证**
+
+Run: `swift build`
+Expected: Build successfully without errors.
+
+- [ ] **Step 3: 提交改动**
+
+```bash
+git add Type4Me/Permissions/PermissionGuideView.swift
+git commit -m "feat: implement 1:1 Screenflare-style PermissionGuideView layout and interactions"
+```
+
+---
+
+### Task 4: `SetupWizardView` 简化为 2 步与首启安全闭环
+
+**Files:**
+- Modify: `Type4Me/UI/Setup/SetupWizardView.swift`
+
+**Interfaces:**
+- Consumes: `PermissionGuideModel`, `AppState`, `AppEditionMigration`, `AppDelegate.presentSettings`
+- Produces: 2-step Setup Wizard (`step 0: welcome`, `step 1: permissions`)
+
+- [ ] **Step 1: 重构 `SetupWizardView.swift`**
+
+1. 将向导步骤精简为：
+   - `case 0: welcomeStep`
+   - `default: permissionsStep`
+2. `permissionsStep` 中嵌入 `PermissionGuideView(model: permissionGuideModel, embedded: true)`。
+3. 提供 `completeSetupAndLaunchHome()` 方法：
+   - 在 `#if HAS_CLOUD_SUBSCRIPTION` 下，若 `appState.appEdition == nil`，调用 `AppEditionMigration.switchTo(.byoKey)`。
+   - 写入 `appState.hasCompletedSetup = true`。
+   - 关闭向导窗口，调用 `AppDelegate.presentSettings()` 激活主界面首页。
+4. 权限引导中的重启操作同样在调用 `model.relaunchApp` 前执行上述持久化。
+
+- [ ] **Step 2: 编译与测试**
+
+Run: `swift build`
+Expected: Build successfully without errors.
+
+- [ ] **Step 3: 提交改动**
+
+```bash
+git add Type4Me/UI/Setup/SetupWizardView.swift
+git commit -m "feat: simplify SetupWizardView to 2 steps with safe cloud edition persistence"
+```
+
+---
+
+### Task 5: 窗口注册与生命周期唤起修复 (Type4MeApp & MenuBarControlCenter)
+
+**Files:**
+- Modify: `Type4Me/UI/MenuBar/MenuBarControlCenter.swift`
+- Modify: `Type4Me/Type4MeApp.swift`
+
+**Interfaces:**
+- Consumes: `openWindow(id: "setup")`, `openWindow(id: "settings")`, `openWindow(id: "permission-guide")`
+- Produces: `AppDelegate.openSetupAction`, `AppDelegate.openSettingsAction`, `AppDelegate.presentSetupWizard()`, `AppDelegate.presentSettings()`
+
+- [ ] **Step 1: 注册 `openSetupAction` 与 `openSettingsAction`**
+
+在 `MenuBarControlCenter.swift` 的 `registerGlobalOpenActions` 中：
+```swift
+AppDelegate.openSetupAction = { [openWindow] in
+    openWindow(id: "setup")
+}
+AppDelegate.openSettingsAction = { [openWindow] in
+    openWindow(id: "settings")
+}
+```
+
+- [ ] **Step 2: 完善 `Type4MeApp.swift` 中的窗口派发与探针注入**
+
+1. 在 `AppDelegate` 中增加：
+```swift
+static var openSetupAction: (() -> Void)?
+static var openSettingsAction: (() -> Void)?
+
+func presentSetupWizard(retryCount: Int = 0) {
+    if let action = Self.openSetupAction {
+        action()
+        NSApp.activate(ignoringOtherApps: true)
+        return
+    }
+    guard retryCount < 15 else {
+        NSLog("[App] Failed to present setup wizard after retries")
+        return
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+        self?.presentSetupWizard(retryCount: retryCount + 1)
+    }
+}
+
+static func presentSettings() {
+    if let action = openSettingsAction {
+        action()
+        NSApp.activate(ignoringOtherApps: true)
+    }
+}
+```
+2. 注入 `hotkeyProbe`：
+```swift
+permissionGuideModel.hotkeyProbe = { [weak self] in
+    self?.hotkeyManager.start() == true
+}
+```
+3. 替换首启调用：
+```swift
+if needsSetup {
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+        MainActor.assumeIsolated {
+            if self?.suppressSetupWizardForHeadlessLaunch == true { return }
+            self?.presentSetupWizard()
+        }
+    }
+}
+```
+
+- [ ] **Step 3: 编译验证**
+
+Run: `swift build`
+Expected: Build successfully without errors.
+
+- [ ] **Step 4: 提交改动**
+
+```bash
+git add Type4Me/UI/MenuBar/MenuBarControlCenter.swift Type4Me/Type4MeApp.swift
+git commit -m "fix: register openSetupAction and implement robust presentSetupWizard routing"
+```
+
+---
+
+### Task 6: 首页悬浮模型提醒卡片 (`FloatingModelAlertCards`)
+
+**Files:**
+- Modify: `Type4Me/UI/Settings/GeneralSettingsTab.swift`
+
+**Interfaces:**
+- Consumes: `KeychainService.selectedASRProvider`, `KeychainService.selectedLLMProvider`, `ModelSettingsHelpers.hasConfiguredCredentials`, `Notification.Name.credentialsDidChange`
+- Produces: `FloatingModelAlertCards` overlay on `GeneralSettingsTab`
+
+- [ ] **Step 1: 实现 `FloatingModelAlertCards` 视图与状态监听**
+
+在 `GeneralSettingsTab.swift` 中实现右下角悬浮卡片栈：
+1. 监听 `.credentialsDidChange` 与 `.asrProviderDidChange`。
+2. 🔴 **红色卡片 (ASR)**：当 `!ModelSettingsHelpers.hasConfiguredCredentials(for: selectedASRProvider)` 时展示。点击后将 `navigationModel.selectedTab = .models` 并将 `navigationModel.pendingModelCategory = .asr`。
+3. 🟠 **橙色卡片 (LLM)**：当 `!ModelSettingsHelpers.hasConfiguredCredentials(for: selectedLLMProvider)` 时展示。点击后将 `navigationModel.selectedTab = .models` 并将 `navigationModel.pendingModelCategory = .llm`。
+4. 采用 Spring 动画与右侧滑入/滑出转场，配置完成后即刻自动消除。
+
+- [ ] **Step 2: 编译验证**
+
+Run: `swift build`
+Expected: Build successfully without errors.
+
+- [ ] **Step 3: 提交改动**
+
+```bash
+git add Type4Me/UI/Settings/GeneralSettingsTab.swift
+git commit -m "feat: add FloatingModelAlertCards to GeneralSettingsTab for progressive model configuration"
+```
+
+---
+
+### Task 7: 端到端构建、本地化校验与集成测试 (End-to-End Verification)
+
+**Files:**
+- Modify: `Type4Me/UI/Localization.swift` (补充所有缺失双语词条)
+- Test: 全量单元测试与编译
+
+- [ ] **Step 1: 补齐双语词条并验证中英双语覆盖**
+
+检查所有新增与变动的 UI 文本，确保均使用 `L("中文", "English")`，并在 `Localization.swift` 中无编译警告。
+
+- [ ] **Step 2: 运行完整测试套件**
+
+Run: `swift test`
+Expected: All test suites PASS.
+
+- [ ] **Step 3: 运行 Release 构建验证**
+
+Run: `swift build -c release`
+Expected: Compiled successfully with zero warnings/errors.
+
+- [ ] **Step 4: 提交最终改动**
+
+```bash
+git add Type4Me/UI/Localization.swift
+git commit -m "chore: ensure full bilingual localization coverage for permission onboarding"
+```

--- a/docs/features/permission-onboarding-redesign/product-design.md
+++ b/docs/features/permission-onboarding-redesign/product-design.md
@@ -1,0 +1,215 @@
+# Type4Me 权限引导与首启流程产品设计
+
+> 文档类型：产品设计  
+> 文档状态：设计完成，待审阅  
+> 设计日期：2026-09-02  
+> 对应分支：`feat/permission-onboarding-redesign`  
+> 对应开发设计：[development-design.md](development-design.md)  
+
+---
+
+## 1. 背景与问题定义
+
+### 1.1 现状与痛点
+1. **首启向导冗长且脆弱**：现有的 `SetupWizardView` 将欢迎、服务商选择、API Key 输入、权限引导与就绪页面串联在同一个向导中。一旦支持的服务商、认证方式或配置项发生变动，首启向导极易破坏；且在首启阶段强制用户配置繁琐的 API Key 会造成极高的上手流失率。
+2. **首启调用链路失效**：`Type4MeApp.swift` 中首启检测调用了未在任何响应链中注册的 `Selector("showSetupWindow:")`，导致首次启动向导无法可靠弹出。
+3. **权限引导交互与视觉不够现代直观**：原有的权限引导缺乏强烈的上下文指引、清晰的层级区分（必需 vs 可选）以及系统授权与应用重启的自愈闭环体验。
+
+### 1.2 借鉴设计：Screenflare 权限体验
+参考优秀 macOS 录屏工具 Screenflare 的权限请求流程：
+- 沉浸式、深色通透的高质感权限卡片；
+- 明确的「必需（Required）」与「可选（Optional）」状态徽标；
+- 逐项明确的用途解释与即时授权按钮；
+- 辅助功能与屏幕录制等需系统设置介入时，提供屏幕底部的拖拽指引浮层；
+- 当系统要求重启应用生效时，智能切换主操作按钮为「重启 Type4Me」，提供确定性的自愈闭环。
+
+---
+
+## 2. 产品目标与原则
+
+1. **极简首启（Minimal Onboarding）**：首启仅保留 2 步核心流程（理念认知 → 权限授予），完成即直接进入应用首页。
+2. **先体验后配置（Progressive Configuration）**：将复杂的 ASR 与 LLM 模型凭证配置从首次向导中抽离，改为在应用首页右下角以轻量级提醒卡片（Floating Alert Cards）引导，配置完成后自动消失。
+3. **权限体验像素级精细化（Screenflare-Grade Permissions）**：
+   - 麦克风（必需）：直接系统弹窗或一键直达设置；
+   - 辅助功能（必需）：直达设置 + 底部拖拽授权浮层 + 实时状态检测 + 重启自愈引导；
+   - Apple 语音识别（可选）：仅在使用 Apple Speech 引擎时呈现，避免对非系统引擎用户产生打扰。
+4. **全链路动态双语（Full Dynamic Bilingual Support）**：所有文本遵循 `L(zh, en)` 规范，切换语言即刻刷新，无需重启。
+
+---
+
+## 3. 总体用户旅程 (User Journey)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User as 用户
+    participant App as Type4Me 应用
+    participant Wizard as 首次向导 (SetupWizard)
+    participant Perm as 权限引导 (PermissionGuide)
+    participant Sys as macOS 系统设置 / TCC
+    participant Home as 应用首页 (Settings Home)
+    participant Models as 模型设置 (ModelSettings)
+
+    User->>App: 首次启动应用
+    App->>Wizard: 检测 !hasCompletedSetup，弹出向导
+    Wizard->>User: 步骤 1: 欢迎页（「说话，就是输入」）
+    User->>Wizard: 点击「开始设置」
+    Wizard->>Perm: 切换至 步骤 2: 权限引导 (Screenflare 风格)
+    
+    User->>Perm: 点击麦克风「允许」
+    Perm->>Sys: 触发麦克风授权
+    Sys-->>Perm: 授权成功，卡片点亮「已允许」
+
+    User->>Perm: 点击辅助功能「允许」
+    Perm->>Sys: 打开系统设置 Accessibility 页面
+    Perm->>User: 屏幕底部展示「将 Type4Me 拖入列表」浮层
+    User->>Sys: 拖入或开启开关
+    Perm->>Perm: 0.5s 轮询感知状态变更
+    alt 需重启生效
+        Perm->>User: 提示「已开启？部分系统需重启生效」，按钮变为「重启 Type4Me」
+        User->>Perm: 点击「重启 Type4Me」
+        Perm->>App: 自动调用 open -n 重启应用
+    else 立即生效
+        Perm->>User: 按钮高亮「进入应用」
+    end
+
+    User->>Perm: 点击「进入应用」
+    Perm->>App: 标记 hasCompletedSetup = true，关闭向导
+    App->>Home: 自动打开应用首页 (GeneralSettingsTab)
+    
+    Home->>Home: 检测默认 ASR / LLM 配置状态
+    alt ASR 未配置
+        Home->>User: 右下角展示 🔴 红色提醒卡片「需配置默认语音识别模型」
+    end
+    alt LLM 未配置
+        Home->>User: 右下角展示 🟠 橙色提醒卡片「需配置默认文本润色模型」
+    end
+
+    User->>Home: 点击提醒卡片
+    Home->>Models: 切换到模型设置页并定位到对应类别
+    User->>Models: 填入 API Key 并保存
+    Models->>Home: 通知配置变更
+    Home->>User: 提醒卡片平滑淡出消失
+```
+
+---
+
+## 4. 详细界面与交互设计
+
+### 4.1 步骤 1：欢迎页（Welcome Step）
+- **尺寸**：固定向导尺寸（640 × 480），居中展示，无标准标题栏。
+- **元素**：
+  - 顶部中心：金色光晕圆环 + 麦克风与波形图标（`waveform.and.mic`）；
+  - 主标题：`Type4Me`（24pt Bold）；
+  - 副标题：`说话，就是输入` / `Speak, and it types`（次要文本色，居中）；
+  - 底部操作：`开始设置` / `Get Started`（大尺寸突出按钮，琥珀金强调色）。
+
+---
+
+### 4.2 步骤 2：Screenflare 风格权限引导（Permissions Step）
+
+#### A. 视觉与排版
+- **背景材质**：深色细腻磨砂玻璃（Dark Translucent Material），圆角 20pt，带有微弱边框高光与投影。
+- **顶部左侧**：红色彩色窗口控制点。
+- **居中头部**：
+  - 主标题：`几项系统权限` / `A few permissions`（20pt Semibold，白色）；
+  - 隐私说明：`Type4Me 需要以下权限以录制语音并自动打字。录音数据仅在听写期间使用，绝不会离开你的 Mac。` / `macOS asks before Type4Me can record your voice and type for you. Nothing leaves your Mac.`（12pt，二级文本色）。
+
+#### B. 统一权限卡片列表（Grouped Permission Container）
+三项权限置于同一个浅色半透明圆角容器中，行间用极细分割线分隔：
+
+1. **麦克风 (Microphone)**：
+   - 图标：红/橙渐变圆角底 + 白色麦克风图标；
+   - 标题：`麦克风` / `Microphone`；
+   - 徽标：`必需` / `Required`（醒目红底粉字或暖红文字徽标）；
+   - 描述：`录制你的语音以进行文字识别。` / `Records your voice for speech-to-text.`；
+   - 右侧操作：
+     - 未授权：深蓝/品牌色胶囊按钮 `允许` / `Allow`；
+     - 已授权：绿色对勾图标 + `已允许` / `Allowed`；
+     - 被拒绝：`打开系统设置` / `Open Settings`。
+
+2. **辅助功能 (Accessibility)**：
+   - 图标：蓝/紫渐变圆角底 + 白色辅助功能图标；
+   - 标题：`辅助功能` / `Accessibility`；
+   - 徽标：`必需` / `Required`（醒目红底粉字徽标）；
+   - 描述：`监听全局快捷键，并将文字直接输入到目标 App。` / `Listens for hotkeys and types text into your active app.`；
+   - 辅助状态提示：若已开启但事件监听尚未激活，显示黄色文字 `已开启？macOS 可能需要在重启应用后生效。` / `Switched it on? macOS applies this on the next launch.`；
+   - 右侧操作：
+     - 未授权：胶囊按钮 `允许` / `Allow`，点击自动打开系统设置并唤起底部拖拽浮层；
+     - 已授权：绿色对勾图标 + `已允许` / `Allowed`。
+
+3. **Apple 语音识别 (Apple Speech Recognition)**：
+   - 图标：青/绿渐变圆角底 + 白色语音识别图标；
+   - 标题：`Apple 语音识别` / `Apple Speech Recognition`；
+   - 徽标：`可选` / `Optional`（中性灰文字徽标）；
+   - 描述：`使用系统内置语音引擎（使用云端或本地模型可跳过）。` / `Transcribes via Apple Speech (can be skipped if using other ASR).`；
+   - 右侧操作：胶囊按钮 `允许` / `Allow` / `已允许` / `Allowed`。
+
+#### C. 底部导航与自愈操作栏
+- 提示文案：`随时可以在 macOS「系统设置」中更改这些权限。` / `You can change any of these later in System Settings.`（11pt，居中次要文本）。
+- 左下角：步骤指示圆点 `• •`。
+- 右下角主操作按钮：
+  - 状态 1（必需权限未满）：`进入应用` 按钮置灰禁用；
+  - 状态 2（辅助功能已开启但需要重启）：高亮蓝色胶囊按钮 **「重启 Type4Me」/「Relaunch Type4Me」**；
+  - 状态 3（必需权限就绪）：高亮琥珀金胶囊按钮 **「进入应用」/「Launch Type4Me」**。
+
+---
+
+### 4.3 应用首页：模型配置引导提醒卡片 (Floating Model Alert Cards)
+
+用户进入主应用窗口（`SettingsTab.general` 首页）后，如果尚未配置默认模型，在**右下角**以浮动卡片栈形式提示：
+
+```text
+                                              ┌──────────────────────────────────────┐
+                                              │ 🔴 需配置默认语音识别模型            │
+                                              │    点击前往模型页配置 API Key 或模型 │
+                                              └──────────────────────────────────────┘
+                                              ┌──────────────────────────────────────┐
+                                              │ 🟠 需配置默认文本润色模型            │
+                                              │    用于智能纠错、标点与改写          │
+                                              └──────────────────────────────────────┘
+```
+
+#### 视觉规范与行为：
+1. **ASR 提醒卡片（Red ASR Alert Card）**：
+   - 红色强调色微光卡片，带 `waveform.badge.exclamationmark` 图标；
+   - 文案：`需配置默认语音识别模型` / `Configure Speech Recognition Model`；
+   - 副文案：`点击前往模型页配置 API Key 或本地模型` / `Click to set up API keys or local models`；
+   - 点击事件：触发导航至 `SettingsTab.models`，且自动切换子类别 `category = .asr`。
+2. **LLM 提醒卡片（Orange LLM Alert Card）**：
+   - 琥珀橙强调色微光卡片，带 `sparkles` 图标；
+   - 文案：`需配置默认文本润色模型` / `Configure Text Polishing Model`；
+   - 副文案：`用于智能纠错、标点与改写` / `Used for smart punctuation and rewriting`；
+   - 点击事件：触发导航至 `SettingsTab.models`，且自动切换子类别 `category = .llm`。
+3. **消除机制**：
+   - 响应 `KeychainService` 与配置变更通知，一旦对应 Provider 凭证完备（`hasConfiguredCredentials == true`），卡片带有 Apple Spring 弹簧动画平滑缩放淡出消除。
+
+---
+
+## 5. 国际化与文案对照表 (Localization Table)
+
+| 键 / 场景 | 中文 (zh) | 英文 (en) |
+|---|---|---|
+| 向导标题 | `Type4Me 设置向导` | `Type4Me Setup` |
+| 欢迎主标语 | `说话，就是输入` | `Speak, and it types` |
+| 欢迎按钮 | `开始设置` | `Get Started` |
+| 权限页面标题 | `几项系统权限` | `A few permissions` |
+| 权限页面副标题 | `Type4Me 需要以下权限以录制语音并自动打字。录音数据仅在听写期间使用，绝不会离开你的 Mac。` | `macOS asks before Type4Me can record your voice and type for you. Nothing leaves your Mac.` |
+| 必需标签 | `必需` | `Required` |
+| 可选标签 | `可选` | `Optional` |
+| 麦克风名称 | `麦克风` | `Microphone` |
+| 麦克风描述 | `录制你的语音以进行文字识别。` | `Records your voice for speech-to-text.` |
+| 辅助功能名称 | `辅助功能` | `Accessibility` |
+| 辅助功能描述 | `监听全局快捷键，并将文字直接输入到目标 App。` | `Listens for hotkeys and types text into your active app.` |
+| 重启提示 | `已开启？macOS 可能需要在重启应用后生效。` | `Switched it on? macOS applies this on the next launch.` |
+| 语音识别名称 | `Apple 语音识别` | `Apple Speech Recognition` |
+| 语音识别描述 | `使用系统内置语音引擎（使用云端或本地模型可跳过）。` | `Transcribes via Apple Speech (can be skipped if using other ASR).` |
+| 操作: 允许 | `允许` | `Allow` |
+| 操作: 已允许 | `已允许` | `Allowed` |
+| 操作: 重启 | `重启 Type4Me` | `Relaunch Type4Me` |
+| 操作: 进入应用 | `进入应用` | `Launch Type4Me` |
+| 底部提示 | `随时可以在 macOS「系统设置」中更改这些权限。` | `You can change any of these later in System Settings.` |
+| 首页 ASR 提醒标题 | `需配置默认语音识别模型` | `Configure Speech Recognition Model` |
+| 首页 ASR 提醒描述 | `点击前往模型页配置 API Key 或本地模型` | `Click to set up API keys or local models` |
+| 首页 LLM 提醒标题 | `需配置默认文本润色模型` | `Configure Text Polishing Model` |
+| 首页 LLM 提醒描述 | `用于智能纠错、标点与改写` | `Used for smart punctuation and rewriting` |

--- a/docs/features/permission-onboarding-redesign/product-design.md
+++ b/docs/features/permission-onboarding-redesign/product-design.md
@@ -1,7 +1,7 @@
 # Type4Me 权限引导与首启流程产品设计
 
 > 文档类型：产品设计  
-> 文档状态：设计完成，待审阅  
+> 文档状态：设计完成，已通过 Review 修正  
 > 设计日期：2026-09-02  
 > 对应分支：`feat/permission-onboarding-redesign`  
 > 对应开发设计：[development-design.md](development-design.md)  
@@ -68,7 +68,7 @@ sequenceDiagram
     alt 需重启生效
         Perm->>User: 提示「已开启？部分系统需重启生效」，按钮变为「重启 Type4Me」
         User->>Perm: 点击「重启 Type4Me」
-        Perm->>App: 自动调用 open -n 重启应用
+        Perm->>App: 写入 hasCompletedSetup 并自动调用 open -n 重启应用
     else 立即生效
         Perm->>User: 按钮高亮「进入应用」
     end
@@ -88,7 +88,7 @@ sequenceDiagram
     User->>Home: 点击提醒卡片
     Home->>Models: 切换到模型设置页并定位到对应类别
     User->>Models: 填入 API Key 并保存
-    Models->>Home: 通知配置变更
+    Models->>Home: 触发 credentialsDidChange 通知
     Home->>User: 提醒卡片平滑淡出消失
 ```
 
@@ -116,7 +116,7 @@ sequenceDiagram
   - 隐私说明：`Type4Me 需要以下权限以录制语音并自动打字。录音数据仅在听写期间使用，绝不会离开你的 Mac。` / `macOS asks before Type4Me can record your voice and type for you. Nothing leaves your Mac.`（12pt，二级文本色）。
 
 #### B. 统一权限卡片列表（Grouped Permission Container）
-三项权限置于同一个浅色半透明圆角容器中，行间用极细分割线分隔：
+权限置于同一个浅色半透明圆角容器中，行间用极细分割线分隔：
 
 1. **麦克风 (Microphone)**：
    - 图标：红/橙渐变圆角底 + 白色麦克风图标；
@@ -138,7 +138,8 @@ sequenceDiagram
      - 未授权：胶囊按钮 `允许` / `Allow`，点击自动打开系统设置并唤起底部拖拽浮层；
      - 已授权：绿色对勾图标 + `已允许` / `Allowed`。
 
-3. **Apple 语音识别 (Apple Speech Recognition)**：
+3. **Apple 语音识别 (Apple Speech Recognition，条件渲染)**：
+   - 仅当所选 ASR 引擎为 `Apple Speech`（`.apple`）时呈现；非 Apple Speech 引擎不展现该行，避免冗余权限索取。
    - 图标：青/绿渐变圆角底 + 白色语音识别图标；
    - 标题：`Apple 语音识别` / `Apple Speech Recognition`；
    - 徽标：`可选` / `Optional`（中性灰文字徽标）；
@@ -150,14 +151,14 @@ sequenceDiagram
 - 左下角：步骤指示圆点 `• •`。
 - 右下角主操作按钮：
   - 状态 1（必需权限未满）：`进入应用` 按钮置灰禁用；
-  - 状态 2（辅助功能已开启但需要重启）：高亮蓝色胶囊按钮 **「重启 Type4Me」/「Relaunch Type4Me」**；
+  - 状态 2（辅助功能已开启但需要重启）：高亮蓝色胶囊按钮 **「重启 Type4Me」/「Relaunch Type4Me」**（点击持久化首启完成并自动重启）；
   - 状态 3（必需权限就绪）：高亮琥珀金胶囊按钮 **「进入应用」/「Launch Type4Me」**。
 
 ---
 
 ### 4.3 应用首页：模型配置引导提醒卡片 (Floating Model Alert Cards)
 
-用户进入主应用窗口（`SettingsTab.general` 首页）后，如果尚未配置默认模型，在**右下角**以浮动卡片栈形式提示：
+用户进入主应用窗口（`SettingsTab.general` 首页）后，如果尚未配置默认模型，在**首页右下角**以浮动卡片栈形式提示（仅在 `selectedTab == .general` 首页生效，避免遮挡模型编辑页）：
 
 ```text
                                               ┌──────────────────────────────────────┐
@@ -182,7 +183,7 @@ sequenceDiagram
    - 副文案：`用于智能纠错、标点与改写` / `Used for smart punctuation and rewriting`；
    - 点击事件：触发导航至 `SettingsTab.models`，且自动切换子类别 `category = .llm`。
 3. **消除机制**：
-   - 响应 `KeychainService` 与配置变更通知，一旦对应 Provider 凭证完备（`hasConfiguredCredentials == true`），卡片带有 Apple Spring 弹簧动画平滑缩放淡出消除。
+   - 响应 `credentialsDidChange` 通知，一旦对应 Provider 凭证完备（`hasConfiguredCredentials == true`），卡片带有 Apple Spring 弹簧动画平滑缩放淡出消除。
 
 ---
 


### PR DESCRIPTION
## Summary

This PR redesigns Type4Me's first-run onboarding and permission guidance based on the Screenflare pattern, while improving app stability, target continuity, and progressive configuration:

1. **Simplified 2-Step Setup Wizard (`SetupWizardView.swift`)**:
   - Streamlined from the previous multi-step provider setup wizard into 2 focused steps: Step 0 (Welcome) and Step 1 (Screenflare-style Permissions).
   - Separated window raising (`onRaiseHostWindow`) from setup completion (`onFinish`) so completing Accessibility drag assistance does not bypass Microphone required permissions.
   - Robust window launch routing via `openSetupAction` and `presentSetupWizard()` retry mechanism.

<img width="752" height="624" alt="image" src="https://github.com/user-attachments/assets/793474bf-8c4c-4430-88c4-27a1a22c436b" />
<img width="752" height="624" alt="image" src="https://github.com/user-attachments/assets/b2325f38-09c0-4f24-8ed8-353cb21f7d23" />

2. **Graceful Permission Guide (`PermissionGuideView.swift` & `PermissionGuideModel.swift`)**:
   - High-fidelity dark translucent card aesthetic with centered header and grouped list container.
   - Accurate privacy subtitle copy clearly stating that audio handling depends on the selected recognition provider.
   - Distinct badges for `Required` (Microphone, Accessibility) vs `Optional` (Apple Speech Recognition, conditionally rendered only when Apple Speech is active).
   - Integrated drag-to-authorize assistance overlay for Accessibility with process-precheck and 10Hz throttling (eliminates WindowServer IPC CPU spikes).
   - Real event-tap probing and auto-relaunch CTA button (`Relaunch Type4Me`) when macOS caches kernel-level denial.

<img width="1582" height="1594" alt="CleanShot 2026-09-02 at 23 44 08" src="https://github.com/user-attachments/assets/33baf93a-0139-4f93-874b-93afd99c7d0b" />

3. **Floating Model Setup Reminder Cards (`FloatingModelAlertCards.swift` & `SettingsView.swift`)**:
   - Floats in the bottom-right corner of the Home tab (`SettingsTab.general`) when default ASR (red card) or LLM (orange card) models have missing credentials.
   - Tapping a card jumps directly to the Models settings tab with the corresponding ASR / LLM category focused.
   - Subscribes to `credentialsDidChange` (posted outside `NSLock` to prevent reentrancy deadlocks) and automatically dismisses cards with smooth Apple Spring animations once credentials are saved.

<img width="1003" height="868" alt="CleanShot 2026-09-02 at 23 45 37" src="https://github.com/user-attachments/assets/c1791739-675c-4f97-921d-7f0169655e24" />

4. **Event Tap Hardening & Revocation Safety (`HotkeyManager.swift`)**:
   - Configured with session-level (`.cgSessionEventTap`) interception to prioritize overall system input stability and prevent kernel-level IOHID deadlocks upon runtime permission changes.
   - Retained full pointer event stream (`leftMouseDown/Up`, `dragged`, `scrollWheel`) to ensure `TextInjectionEngine` opaque focus continuity guard functions without regression.
   - Implemented atomic teardown using `CFMachPortInvalidate`, 500ms runtime safety watchdog, and instant fail-open permission guards.

5. **Full Dynamic Bilingual Support & Tests**:
   - All UI copy implemented via `L(zh, en)` with live updates on language toggle.
   - Added unit tests for credentials notifications (including synchronous observer deadlock regression tests), event tap recovery policies, and navigation model routing.
   - All 1030+ tests pass with zero regressions.

## Documentation
- Product Design: `docs/features/permission-onboarding-redesign/product-design.md`
- Development Design: `docs/features/permission-onboarding-redesign/development-design.md`
- Implementation Plan: `docs/features/permission-onboarding-redesign/plan.md`

## Verification
- `swift test` (all unit and integration tests pass)
- `swift build -c release` (clean release compilation)
- Verified end-to-end first-run wizard, Screenflare permission granting, floating alert card navigation/dismissal, and runtime permission resilience.