### PR TITLE
fix: preserve playback during voice input

### DIFF
--- a/Type4Me/Audio/AudioCaptureEngine.swift
+++ b/Type4Me/Audio/AudioCaptureEngine.swift
@@ -16,8 +16,8 @@ enum AudioCaptureError: Error, LocalizedError {
             return L("找不到麦克风", "No microphone found")
         case .preferredInputDeviceUnavailable:
             return L(
-                "首选麦克风不可用。为避免中断蓝牙播放，本次录音已取消",
-                "Preferred microphone unavailable. Recording was cancelled to preserve Bluetooth playback"
+                "首选麦克风不可用，未自动切换至蓝牙麦克风。请重新连接或在设置中指定麦克风",
+                "Preferred microphone unavailable and will not fall back to Bluetooth. Reconnect it or choose another microphone in Settings"
             )
         }
     }

--- a/Type4Me/Audio/AudioCaptureEngine.swift
+++ b/Type4Me/Audio/AudioCaptureEngine.swift
@@ -4,6 +4,7 @@ enum AudioCaptureError: Error, LocalizedError {
     case converterCreationFailed
     case microphonePermissionDenied
     case noInputDevice
+    case preferredInputDeviceUnavailable
 
     var errorDescription: String? {
         switch self {
@@ -13,6 +14,11 @@ enum AudioCaptureError: Error, LocalizedError {
             return L("未授予麦克风权限", "Microphone permission not granted")
         case .noInputDevice:
             return L("找不到麦克风", "No microphone found")
+        case .preferredInputDeviceUnavailable:
+            return L(
+                "首选麦克风不可用。为避免中断蓝牙播放，本次录音已取消",
+                "Preferred microphone unavailable. Recording was cancelled to preserve Bluetooth playback"
+            )
         }
     }
 }
@@ -66,11 +72,11 @@ final class AudioCaptureEngine: NSObject, @unchecked Sendable, AVCaptureAudioDat
         availableAudioInputDevices().map { (uid: $0.uid, name: $0.name) }
     }
 
-    /// Resolve the capture device: use selectedDeviceUID if set and valid, otherwise system default.
+    /// Resolve the capture device. An explicit device that disappears must fail
+    /// instead of silently switching to the system-default Bluetooth microphone.
     private func resolveDevice() -> AVCaptureDevice? {
-        if let uid = selectedDeviceUID, !uid.isEmpty,
-           let device = AVCaptureDevice(uniqueID: uid) {
-            return device
+        if let uid = selectedDeviceUID, !uid.isEmpty {
+            return AVCaptureDevice(uniqueID: uid)
         }
         return AVCaptureDevice.default(for: .audio)
     }

--- a/Type4Me/Audio/AudioInputDevicePreference.swift
+++ b/Type4Me/Audio/AudioInputDevicePreference.swift
@@ -38,6 +38,12 @@ enum AudioInputDevicePreferenceMode: String {
     case priority
 }
 
+enum AudioInputCaptureResolution: Equatable {
+    case explicitDevice(uid: String)
+    case systemDefault
+    case unavailable
+}
+
 struct AudioInputDevicePreferenceEntry: Codable, Equatable, Identifiable {
     var id: String { uid }
     let uid: String
@@ -85,6 +91,34 @@ enum AudioInputDevicePreferenceStore {
     static func resolvedCachedDeviceUID() -> String? {
         let devices = cachedDevicesOrRefresh()
         return resolvedDevice(devices: devices)?.uid
+    }
+
+    /// Resolves the input policy used for capture. In priority mode, silently
+    /// falling back to a Bluetooth system default can switch the headset to its
+    /// low-bandwidth call profile and interrupt media playback, so that fallback
+    /// is deliberately rejected unless the user explicitly follows the system.
+    static func captureResolution(
+        devices: [AudioInputDevice],
+        systemDefault: AudioInputDevice?
+    ) -> AudioInputCaptureResolution {
+        guard mode() == .priority else { return .systemDefault }
+        if let device = resolvedDevice(devices: devices) {
+            return .explicitDevice(uid: device.uid)
+        }
+        guard systemDefault?.category != .bluetooth else { return .unavailable }
+        return .systemDefault
+    }
+
+    static func cachedCaptureResolution() -> AudioInputCaptureResolution {
+        var snapshot = AudioInputDeviceMonitor.shared.currentSnapshot()
+        if snapshot.devices.isEmpty {
+            AudioInputDeviceMonitor.shared.refreshSynchronously()
+            snapshot = AudioInputDeviceMonitor.shared.currentSnapshot()
+        }
+        return captureResolution(
+            devices: snapshot.devices,
+            systemDefault: snapshot.systemDefaultInput
+        )
     }
 
     static func mode() -> AudioInputDevicePreferenceMode {
@@ -158,13 +192,41 @@ enum AudioInputDevicePreferenceStore {
     }
 
     /// The device Type4Me will use for the next recording. In priority mode,
-    /// an unavailable preferred device falls back to the current system input.
+    /// an unavailable preferred device may fall back to a non-Bluetooth system
+    /// input, but never implicitly activates a Bluetooth headset microphone.
     static func activeInputDevice(
         devices: [AudioInputDevice],
         systemDefault: AudioInputDevice?
     ) -> AudioInputDevice? {
         guard mode() == .priority else { return systemDefault }
-        return resolvedDevice(devices: devices) ?? systemDefault
+        if let resolved = resolvedDevice(devices: devices) {
+            return resolved
+        }
+        guard systemDefault?.category != .bluetooth else { return nil }
+        return systemDefault
+    }
+
+    /// Keep-alive is only useful for an actively selected Bluetooth microphone.
+    /// Built-in, wired and USB microphones must not open the system-default
+    /// Bluetooth input as a side effect.
+    static func keepAliveInputDevice(
+        devices: [AudioInputDevice],
+        systemDefault: AudioInputDevice?
+    ) -> AudioInputDevice? {
+        let active = activeInputDevice(devices: devices, systemDefault: systemDefault)
+        return active?.category == .bluetooth ? active : nil
+    }
+
+    static func cachedKeepAliveInputDevice() -> AudioInputDevice? {
+        var snapshot = AudioInputDeviceMonitor.shared.currentSnapshot()
+        if snapshot.devices.isEmpty {
+            AudioInputDeviceMonitor.shared.refreshSynchronously()
+            snapshot = AudioInputDeviceMonitor.shared.currentSnapshot()
+        }
+        return keepAliveInputDevice(
+            devices: snapshot.devices,
+            systemDefault: snapshot.systemDefaultInput
+        )
     }
 
     static func activeCachedInputDevice() -> AudioInputDevice? {

--- a/Type4Me/Services/AudioKeepAliveManager.swift
+++ b/Type4Me/Services/AudioKeepAliveManager.swift
@@ -10,6 +10,7 @@ enum AudioKeepAliveManager {
     private static let queue = DispatchQueue(label: "com.type4me.keepalive.mic", qos: .background)
 
     nonisolated(unsafe) private static var micSession: AVCaptureSession?
+    nonisolated(unsafe) private static var micDeviceUID: String?
 
     // MARK: - Public
 
@@ -20,21 +21,27 @@ enum AudioKeepAliveManager {
 
     static func syncMicState() {
         let enabled = UserDefaults.standard.bool(forKey: "tf_micKeepAlive")
+        let targetDevice = enabled ? AudioInputDevicePreferenceStore.cachedKeepAliveInputDevice() : nil
         queue.async {
-            if enabled { startMic() } else { stopMic() }
+            if let targetDevice {
+                startMic(deviceUID: targetDevice.uid)
+            } else {
+                stopMic()
+            }
         }
     }
 
     // MARK: - Microphone
 
-    private static func startMic() {
-        guard micSession == nil else { return }
+    private static func startMic(deviceUID: String) {
+        if micSession != nil, micDeviceUID == deviceUID { return }
+        stopMic()
         guard AVCaptureDevice.authorizationStatus(for: .audio) == .authorized else {
             logger.warning("Mic keep-alive skipped: no permission")
             return
         }
-        guard let device = AVCaptureDevice.default(for: .audio) else {
-            logger.warning("Mic keep-alive skipped: no input device")
+        guard let device = AVCaptureDevice(uniqueID: deviceUID) else {
+            logger.warning("Mic keep-alive skipped: selected input device is unavailable")
             return
         }
 
@@ -51,7 +58,8 @@ enum AudioKeepAliveManager {
 
             session.startRunning()
             micSession = session
-            logger.info("Mic keep-alive started")
+            micDeviceUID = deviceUID
+            logger.info("Mic keep-alive started for selected Bluetooth input")
         } catch {
             logger.error("Mic keep-alive failed: \(error.localizedDescription)")
         }
@@ -61,6 +69,7 @@ enum AudioKeepAliveManager {
         guard let session = micSession else { return }
         session.stopRunning()
         micSession = nil
+        micDeviceUID = nil
         logger.info("Mic keep-alive stopped")
     }
 }

--- a/Type4Me/Services/SystemVolumeManager.swift
+++ b/Type4Me/Services/SystemVolumeManager.swift
@@ -9,6 +9,8 @@ import os
 /// the caller (Bluetooth audio devices can stall AudioObject*PropertyData for seconds).
 enum SystemVolumeManager {
 
+    static let volumeReductionKey = "tf_volumeReduction"
+
     private static let logger = Logger(subsystem: "com.type4me.volume", category: "SystemVolumeManager")
 
     /// Dedicated serial queue for CoreAudio property access.
@@ -19,6 +21,16 @@ enum SystemVolumeManager {
 
     /// UserDefaults key for crash recovery.
     private static let savedVolumeKey = "tf_savedSystemVolume"
+
+    /// `UserDefaults.integer(forKey:)` returns zero for a missing key, which
+    /// accidentally mutes fresh installs. Missing means the documented default:
+    /// do not lower playback volume.
+    static func configuredReductionPercent(defaults: UserDefaults = .standard) -> Int {
+        guard let value = defaults.object(forKey: volumeReductionKey) as? NSNumber else {
+            return -1
+        }
+        return value.intValue
+    }
 
     /// Lower system volume to a fraction of the current level.
     /// Saves the current volume so it can be restored later.

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -1040,7 +1040,16 @@ actor RecognitionSession {
         }
 
         do {
-            let selectedDeviceUID = AudioInputDevicePreferenceStore.resolvedCachedDeviceUID()
+            let captureResolution = AudioInputDevicePreferenceStore.cachedCaptureResolution()
+            let selectedDeviceUID: String?
+            switch captureResolution {
+            case .explicitDevice(let uid):
+                selectedDeviceUID = uid
+            case .systemDefault:
+                selectedDeviceUID = nil
+            case .unavailable:
+                throw AudioCaptureError.preferredInputDeviceUnavailable
+            }
             let preferenceMode = AudioInputDevicePreferenceStore.mode().rawValue
             let priorityUIDs = AudioInputDevicePreferenceStore.priorityEntries().map(\.uid).joined(separator: ",")
             audioEngine.selectedDeviceUID = selectedDeviceUID

--- a/Type4Me/Type4MeApp.swift
+++ b/Type4Me/Type4MeApp.swift
@@ -251,7 +251,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                             // BT wake-up preamble is baked into the sound buffer itself.
                             SoundFeedback.playStart()
                             // Lower volume after start sound finishes playing
-                            let targetVolumePercent = UserDefaults.standard.integer(forKey: "tf_volumeReduction")
+                            let targetVolumePercent = SystemVolumeManager.configuredReductionPercent()
                             if targetVolumePercent >= 0 {
                                 let delayMs = SoundFeedback.startSoundDurationMs()
                                 if delayMs > 0 {
@@ -532,6 +532,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 queue: .main
             ) { [weak self] _ in
                 MainActor.assumeIsolated {
+                    AudioKeepAliveManager.syncMicState()
                     self?.updateEffectiveInputDevice(notify: true)
                 }
             }

--- a/Type4Me/UI/Settings/GeneralSettingsTab.swift
+++ b/Type4Me/UI/Settings/GeneralSettingsTab.swift
@@ -16,7 +16,7 @@ struct GeneralSettingsTab: View, SettingsCardHelpers {
 
     @AppStorage("tf_startSound") private var startSound = StartSoundStyle.chime.rawValue
     @AppStorage("tf_launchAtLogin") private var launchAtLogin = true
-    @AppStorage("tf_volumeReduction") private var volumeReduction = -1
+    @AppStorage(SystemVolumeManager.volumeReductionKey) private var volumeReduction = -1
     @AppStorage("tf_language") private var language = AppLanguage.systemDefault
     @AppStorage(ClipboardOutputPolicy.storageKey)
     private var clipboardOutputPolicyRaw = ClipboardOutputPolicy.defaultValue.rawValue

--- a/Type4MeTests/AudioInputDevicePreferenceTests.swift
+++ b/Type4MeTests/AudioInputDevicePreferenceTests.swift
@@ -11,7 +11,7 @@ final class AudioInputDevicePreferenceTests: XCTestCase {
         UserDefaults.standard.removeObject(forKey: AudioInputDevicePreferenceStore.backupUIDKey)
         UserDefaults.standard.removeObject(forKey: "tf_microphoneSelectionMode")
         UserDefaults.standard.removeObject(forKey: "tf_microphonePriorityOrder")
-        AudioInputDeviceMonitor.shared.replaceCachedDevices([])
+        AudioInputDeviceMonitor.shared.replaceCachedDevices([], systemDefaultInput: nil)
         super.tearDown()
     }
 
@@ -137,6 +137,24 @@ final class AudioInputDevicePreferenceTests: XCTestCase {
         XCTAssertEqual(active, systemDefault)
     }
 
+    func testActiveDeviceDoesNotImplicitlyFallBackToBluetooth() {
+        AudioInputDevicePreferenceStore.savePriorityEntries([
+            AudioInputDevicePreferenceEntry(uid: "built-in", name: "MacBook Pro Microphone"),
+        ])
+        let airPods = AudioInputDevice(
+            uid: "airpods",
+            name: "AirPods Pro",
+            category: .bluetooth
+        )
+
+        let active = AudioInputDevicePreferenceStore.activeInputDevice(
+            devices: [airPods],
+            systemDefault: airPods
+        )
+
+        XCTAssertNil(active)
+    }
+
     func testActiveDevicePrefersAvailablePriorityDeviceOverSystemDefault() {
         let airPods = AudioInputDevice(uid: "airpods", name: "AirPods Pro", category: .bluetooth)
         let systemDefault = AudioInputDevice(
@@ -154,6 +172,104 @@ final class AudioInputDevicePreferenceTests: XCTestCase {
         )
 
         XCTAssertEqual(active, airPods)
+    }
+
+    func testCaptureResolutionUsesExplicitPriorityDevice() {
+        let builtIn = AudioInputDevice(
+            uid: "built-in",
+            name: "MacBook Pro Microphone",
+            category: .builtIn
+        )
+        let airPods = AudioInputDevice(
+            uid: "airpods",
+            name: "AirPods Pro",
+            category: .bluetooth
+        )
+        AudioInputDevicePreferenceStore.savePriorityEntries([
+            AudioInputDevicePreferenceEntry(uid: builtIn.uid, name: builtIn.name),
+        ])
+
+        let resolution = AudioInputDevicePreferenceStore.captureResolution(
+            devices: [builtIn, airPods],
+            systemDefault: airPods
+        )
+
+        XCTAssertEqual(resolution, .explicitDevice(uid: builtIn.uid))
+    }
+
+    func testCaptureResolutionRejectsImplicitBluetoothFallback() {
+        let airPods = AudioInputDevice(
+            uid: "airpods",
+            name: "AirPods Pro",
+            category: .bluetooth
+        )
+        AudioInputDevicePreferenceStore.savePriorityEntries([
+            AudioInputDevicePreferenceEntry(uid: "built-in", name: "MacBook Pro Microphone"),
+        ])
+
+        let resolution = AudioInputDevicePreferenceStore.captureResolution(
+            devices: [airPods],
+            systemDefault: airPods
+        )
+
+        XCTAssertEqual(resolution, .unavailable)
+    }
+
+    func testCaptureResolutionAllowsExplicitFollowSystemBluetooth() {
+        let airPods = AudioInputDevice(
+            uid: "airpods",
+            name: "AirPods Pro",
+            category: .bluetooth
+        )
+        AudioInputDevicePreferenceStore.resetToSystemDefault()
+
+        let resolution = AudioInputDevicePreferenceStore.captureResolution(
+            devices: [airPods],
+            systemDefault: airPods
+        )
+
+        XCTAssertEqual(resolution, .systemDefault)
+    }
+
+    func testKeepAliveDoesNotOpenBluetoothWhenBuiltInMicIsSelected() {
+        let builtIn = AudioInputDevice(
+            uid: "built-in",
+            name: "MacBook Pro Microphone",
+            category: .builtIn
+        )
+        let airPods = AudioInputDevice(
+            uid: "airpods",
+            name: "AirPods Pro",
+            category: .bluetooth
+        )
+        AudioInputDevicePreferenceStore.savePriorityEntries([
+            AudioInputDevicePreferenceEntry(uid: builtIn.uid, name: builtIn.name),
+        ])
+
+        let keepAlive = AudioInputDevicePreferenceStore.keepAliveInputDevice(
+            devices: [builtIn, airPods],
+            systemDefault: airPods
+        )
+
+        XCTAssertNil(keepAlive)
+    }
+
+    func testKeepAliveUsesExplicitlySelectedBluetoothMic() {
+        let airPods = AudioInputDevice(
+            uid: "airpods",
+            name: "AirPods Pro",
+            category: .bluetooth
+        )
+        AudioInputDevicePreferenceStore.savePriorityEntries([
+            AudioInputDevicePreferenceEntry(uid: airPods.uid, name: airPods.name),
+        ])
+
+        let keepAlive = AudioInputDevicePreferenceStore.keepAliveInputDevice(
+            devices: [airPods],
+            systemDefault: nil
+        )
+
+        XCTAssertEqual(keepAlive, airPods)
     }
 
     func testPriorityEntryStoragePreservesDeviceNamesAndOrder() {

--- a/Type4MeTests/SystemVolumeManagerTests.swift
+++ b/Type4MeTests/SystemVolumeManagerTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import Type4Me
+
+final class SystemVolumeManagerTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "SystemVolumeManagerTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testMissingReductionPreferenceDoesNotLowerVolume() {
+        XCTAssertEqual(SystemVolumeManager.configuredReductionPercent(defaults: defaults), -1)
+    }
+
+    func testExplicitNoReductionPreferenceIsPreserved() {
+        defaults.set(-1, forKey: SystemVolumeManager.volumeReductionKey)
+
+        XCTAssertEqual(SystemVolumeManager.configuredReductionPercent(defaults: defaults), -1)
+    }
+
+    func testExplicitMutePreferenceIsPreserved() {
+        defaults.set(0, forKey: SystemVolumeManager.volumeReductionKey)
+
+        XCTAssertEqual(SystemVolumeManager.configuredReductionPercent(defaults: defaults), 0)
+    }
+
+    func testExplicitReductionPreferenceIsPreserved() {
+        defaults.set(30, forKey: SystemVolumeManager.volumeReductionKey)
+
+        XCTAssertEqual(SystemVolumeManager.configuredReductionPercent(defaults: defaults), 30)
+    }
+}


### PR DESCRIPTION
## Summary

- Treat a missing volume-reduction preference as “do not lower” instead of 0%, which previously muted playback on fresh or incomplete preference state.
- Bind microphone keep-alive to the actively selected Bluetooth input rather than AVCaptureDevice.default, and resync it when the input preference or device list changes.
- In priority mode, prevent an unavailable preferred microphone from silently falling back to a system-default Bluetooth microphone. Explicit Follow System and explicitly selected Bluetooth inputs continue to work.
- Fail safely if an explicitly selected microphone disappears during startup instead of switching to the default input.

## Why

Opening a Bluetooth headset microphone can move macOS audio to its call profile, interrupting or degrading media playback. Type4Me could open that microphone indirectly even when the user selected the MacBook built-in microphone, because mic keep-alive always used the system default. A separate defaults bug also interpreted an unset volume option as 0%.

The fixed route is the common split-device scenario: Bluetooth headphones remain the output while the MacBook microphone is the selected input, and starting dictation does not activate the Bluetooth microphone or lower playback volume.

## Test plan

- swift test --filter AudioInputDevicePreferenceTests\|AudioCaptureEngineTests\|SystemVolumeManagerTests (28 passed)
- swift test (1050 passed, 2 skipped)
- swift build -c release --arch arm64
- Added coverage for missing volume preferences, built-in input with Bluetooth system default, explicit Bluetooth selection, Follow System, keep-alive selection, and unavailable-device fallback.