### PR TITLE
perf(vocabulary): make the snippet replacement list lazy

### DIFF
--- a/Type4Me/UI/Settings/VocabularyTab.swift
+++ b/Type4Me/UI/Settings/VocabularyTab.swift
@@ -161,13 +161,13 @@ struct VocabularyTab: View {
 
     // Snippets (user file + built-in)
     @State private var snippets: [(trigger: String, value: String)] = SnippetStorage.load()
+    /// Grouped, filtered and sorted rows for the snippet list.
+    /// See `recomputeDisplaySnippets()` for why this is cached rather than computed.
+    @State private var displaySnippets: [SnippetGroup] = []
     @State private var editingGroupReplacement: String? = nil
-    @State private var editReplacementText: String = ""
-    @State private var newTriggerTexts: [String: String] = [:]
     @State private var newTrigger: String = ""
     @State private var newSnippetTriggers: [String] = []
     @State private var newValue: String = ""
-    @State private var hoveredSnippetGroup: String? = nil
     @State private var isAddAppHovered = false
     @State private var showBulkSnippetsSheet = false
     @State private var bulkSnippetsText = ""
@@ -242,6 +242,11 @@ struct VocabularyTab: View {
                     withAnimation(.easeInOut(duration: 0.4)) {
                         proxy.scrollTo("snippet-\(replacement)", anchor: .center)
                     }
+                    // The list is lazy, so the target row may only be built by
+                    // the scroll above. Re-anchor once it exists.
+                    DispatchQueue.main.async {
+                        proxy.scrollTo("snippet-\(replacement)", anchor: .center)
+                    }
                     withAnimation(.easeIn(duration: 0.3).delay(0.2)) {
                         highlightedGroup = replacement
                     }
@@ -258,9 +263,17 @@ struct VocabularyTab: View {
             snippets = SnippetStorage.load()
             registeredApps = SnippetStorage.loadRegistry()
             seedExampleIfNeeded()
+            recomputeDisplaySnippets()
             if let request = VocabularyNavigationCenter.shared.pendingRequest {
                 applyNavigationRequest(request)
             }
+        }
+        .task(id: searchQuery) {
+            // Debounce: without this, every keystroke re-grouped and re-filtered
+            // the whole snippet store before the next frame could be drawn.
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            guard !Task.isCancelled else { return }
+            recomputeDisplaySnippets()
         }
         .onReceive(NotificationCenter.default.publisher(for: SnippetStorage.didChangeNotification)) { _ in
             if let bundleId = selectedAppScope {
@@ -268,6 +281,7 @@ struct VocabularyTab: View {
             } else {
                 snippets = SnippetStorage.load()
             }
+            recomputeDisplaySnippets()
         }
         .onReceive(NotificationCenter.default.publisher(for: HotwordStorage.didChangeNotification)) { _ in
             hotwords = HotwordStorage.load()
@@ -375,6 +389,7 @@ struct VocabularyTab: View {
                 ) {
                     withAnimation(.easeInOut(duration: 0.15)) {
                         snippetSort.toggle()
+                        recomputeDisplaySnippets()
                     }
                 }
 
@@ -528,10 +543,27 @@ struct VocabularyTab: View {
                 .zIndex(3)
 
             ScrollView(.vertical, showsIndicators: true) {
-                VStack(alignment: .leading, spacing: 7) {
+                // Lazy on purpose: a plain VStack materialised every group up
+                // front, and each row carries a horizontal ScrollView plus a
+                // TextField, so a few hundred groups meant a few hundred
+                // NSScrollViews and NSTextFields built on the main thread the
+                // moment the tab was selected.
+                LazyVStack(alignment: .leading, spacing: 7) {
                     ForEach(displaySnippets) { group in
-                        snippetGroupView(group: group)
-                            .id("snippet-\(group.id)")
+                        SnippetGroupRow(
+                            group: group,
+                            isExample: group.replacement == Self.builtinExampleReplacement,
+                            isEditing: editingGroupReplacement == group.replacement,
+                            isHighlighted: highlightedGroup == group.replacement,
+                            onStartEdit: { editingGroupReplacement = group.replacement },
+                            onCommitEdit: { commitGroupEdit(oldReplacement: group.replacement, newText: $0) },
+                            onCancelEdit: { editingGroupReplacement = nil },
+                            onDeleteGroup: { removeGroup(replacement: group.replacement) },
+                            onRemoveTrigger: { removeTrigger(trigger: $0, replacement: group.replacement) },
+                            onAddTrigger: { addTrigger($0, to: group.replacement) }
+                        )
+                        .equatable()
+                        .id("snippet-\(group.id)")
                     }
 
                     if displaySnippets.isEmpty {
@@ -765,29 +797,13 @@ struct VocabularyTab: View {
         .settingsTooltip(help)
     }
 
-    // MARK: - Snippet Group View
-
-    private struct SnippetGroup: Identifiable {
-        var id: String { replacement }
-        let replacement: String
-        let triggers: [String]
-    }
+    // MARK: - Snippet List Data
 
     private var displayHotwords: [String] {
         let filtered = hotwords.filter(matchesSearch)
         switch hotwordSort {
         case .byTime: return filtered
         case .byAlpha: return filtered.sorted { $0.localizedAlphabeticalCompare($1) == .orderedAscending }
-        }
-    }
-
-    private var displaySnippets: [SnippetGroup] {
-        let groups = groupedSnippets.filter { group in
-            matchesSearch(group.replacement) || group.triggers.contains(where: matchesSearch)
-        }
-        switch snippetSort {
-        case .byTime: return groups
-        case .byAlpha: return groups.sorted { $0.replacement.localizedAlphabeticalCompare($1.replacement) == .orderedAscending }
         }
     }
 
@@ -798,208 +814,43 @@ struct VocabularyTab: View {
     private func matchesSearch(_ value: String) -> Bool {
         let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else { return true }
-        return value.range(
-            of: query,
-            options: [.caseInsensitive, .diacriticInsensitive]
-        ) != nil
+        return matches(value, query)
     }
 
-    private var groupedSnippets: [SnippetGroup] {
+    private func matches(_ value: String, _ query: String) -> Bool {
+        value.range(of: query, options: [.caseInsensitive, .diacriticInsensitive]) != nil
+    }
+
+    /// Rebuilds `displaySnippets` from the current entries, search query and sort.
+    ///
+    /// This used to be a computed property. Grouping is O(entries) and the store
+    /// can hold several hundred groups, so every hover and every keystroke
+    /// re-grouped the whole list before rendering it. Callers now drive the
+    /// recompute explicitly, from the few places that actually change the inputs.
+    private func recomputeDisplaySnippets() {
         var order: [String] = []
         var dict: [String: [String]] = [:]
-        for s in snippets {
-            if dict[s.value] == nil {
-                order.append(s.value)
-            }
-            dict[s.value, default: []].append(s.trigger)
+        order.reserveCapacity(snippets.count)
+        for entry in snippets {
+            if dict[entry.value] == nil { order.append(entry.value) }
+            dict[entry.value, default: []].append(entry.trigger)
         }
-        return order.map { SnippetGroup(replacement: $0, triggers: dict[$0]!) }
-    }
+        var groups = order.map { SnippetGroup(replacement: $0, triggers: dict[$0]!) }
 
-    private func newTriggerBinding(for replacement: String) -> Binding<String> {
-        Binding(
-            get: { newTriggerTexts[replacement, default: ""] },
-            set: { newTriggerTexts[replacement] = $0 }
-        )
-    }
-
-    private func snippetGroupView(group: SnippetGroup) -> some View {
-        let isHovered = hoveredSnippetGroup == group.replacement
-        let isEditing = editingGroupReplacement == group.replacement
-
-        return HStack(spacing: 10) {
-            Group {
-                if isEditing {
-                    TextField("", text: $editReplacementText)
-                        .textFieldStyle(.plain)
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(TF.settingsText)
-                        .padding(.horizontal, 9)
-                        .frame(height: 28)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                .fill(TF.settingsBg)
-                        )
-                        .onSubmit { commitGroupEdit(oldReplacement: group.replacement) }
-                } else {
-                    HStack(spacing: 6) {
-                        Text(group.replacement)
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundStyle(TF.settingsText)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-
-                        if group.replacement == Self.builtinExampleReplacement {
-                            Text(L("示例", "Example"))
-                                .font(.system(size: 8, weight: .semibold))
-                                .foregroundStyle(TF.settingsTextTertiary)
-                                .padding(.horizontal, 6)
-                                .frame(height: 18)
-                                .background(Capsule().fill(TF.settingsCardAlt))
-                        }
-                    }
-                }
-            }
-            .frame(width: 180, alignment: .leading)
-
-            Image(systemName: "arrow.left")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundStyle(TF.settingsTextTertiary)
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 7) {
-                    ForEach(group.triggers, id: \.self) { trigger in
-                        triggerTag(
-                            trigger: trigger,
-                            replacement: group.replacement,
-                            showsRemove: isHovered || isEditing
-                        )
-                    }
-
-                    HStack(spacing: 4) {
-                        Image(systemName: "plus")
-                            .font(.system(size: 8, weight: .bold))
-                            .foregroundStyle(TF.settingsTextTertiary)
-                        TextField(
-                            L("添加触发词", "Add trigger"),
-                            text: newTriggerBinding(for: group.replacement)
-                        )
-                        .textFieldStyle(.plain)
-                        .font(.system(size: 11))
-                        .foregroundStyle(TF.settingsTextSecondary)
-                        .frame(width: 82)
-                        .onSubmit { addTriggerToGroup(replacement: group.replacement) }
-                    }
-                    .padding(.horizontal, 9)
-                    .frame(height: 26)
-                    .background(
-                        Capsule()
-                            .stroke(
-                                TF.settingsTextTertiary.opacity(0.28),
-                                style: StrokeStyle(lineWidth: 1, dash: [4])
-                            )
-                    )
-                }
-            }
-            .frame(maxWidth: .infinity)
-            .frame(height: 28)
-
-            if isEditing {
-                snippetCardActionButton(
-                    icon: "checkmark",
-                    color: TF.settingsAccentGreen,
-                    tooltip: L("保存", "Save")
-                ) { commitGroupEdit(oldReplacement: group.replacement) }
-                snippetCardActionButton(
-                    icon: "xmark",
-                    color: TF.settingsTextTertiary,
-                    tooltip: L("取消", "Cancel")
-                ) { editingGroupReplacement = nil }
-            } else if isHovered {
-                snippetCardActionButton(
-                    icon: "pencil",
-                    color: TF.settingsTextSecondary,
-                    tooltip: L("编辑替换内容", "Edit replacement")
-                ) { startGroupEdit(replacement: group.replacement) }
-                snippetCardActionButton(
-                    icon: "trash",
-                    color: TF.settingsAccentRed,
-                    tooltip: L("删除整组", "Delete group")
-                ) { removeGroup(replacement: group.replacement) }
+        let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !query.isEmpty {
+            groups = groups.filter { group in
+                matches(group.replacement, query) || group.triggers.contains { matches($0, query) }
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 7)
-        .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(highlightedGroup == group.replacement
-                      ? TF.settingsAccentGreen.opacity(0.10)
-                      : (isHovered || isEditing
-                         ? TF.settingsRowHover
-                         : TF.settingsCard))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(
-                    highlightedGroup == group.replacement
-                        ? TF.settingsAccentGreen.opacity(0.32)
-                        : (isHovered || isEditing ? Color.black.opacity(0.11) : TF.settingsBorder),
-                    lineWidth: 1
-                )
-        )
-        .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .zIndex(isHovered || isEditing ? 3 : 0)
-        .onHover { hovering in
-            withAnimation(.easeOut(duration: 0.1)) {
-                hoveredSnippetGroup = hovering ? group.replacement : nil
-            }
+
+        if snippetSort == .byAlpha {
+            groups.sort { $0.replacement.localizedAlphabeticalCompare($1.replacement) == .orderedAscending }
         }
+
+        displaySnippets = groups
     }
 
-    private func snippetCardActionButton(
-        icon: String,
-        color: Color,
-        tooltip: String,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            Image(systemName: icon)
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(color)
-                .frame(width: 24, height: 24)
-                .background(Circle().fill(TF.settingsCardAlt))
-                .contentShape(Circle())
-        }
-        .buttonStyle(.plain)
-        .settingsTooltip(tooltip)
-    }
-
-    private func triggerTag(trigger: String, replacement: String, showsRemove: Bool) -> some View {
-        HStack(spacing: 6) {
-            Text(trigger)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(TF.settingsTextSecondary)
-
-            if showsRemove {
-                Button {
-                    removeTrigger(trigger: trigger, replacement: replacement)
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 7, weight: .bold))
-                        .foregroundStyle(TF.settingsTextTertiary)
-                        .frame(width: 14, height: 14)
-                        .contentShape(Circle())
-                }
-                .buttonStyle(.plain)
-                .settingsTooltip(L("删除触发词", "Remove trigger"))
-            }
-        }
-        .padding(.leading, 10)
-        .padding(.trailing, showsRemove ? 6 : 10)
-        .frame(height: 26)
-        .background(Capsule().fill(TF.settingsControl))
-        .overlay(Capsule().stroke(Color.black.opacity(0.045), lineWidth: 1))
-    }
 
     // MARK: - App Scope Bar
 
@@ -1103,6 +954,7 @@ struct VocabularyTab: View {
         } else {
             snippets = SnippetStorage.load()
         }
+        recomputeDisplaySnippets()
     }
 
     private func pickApp() {
@@ -1149,6 +1001,7 @@ struct VocabularyTab: View {
         } else {
             SnippetStorage.save(snippets)
         }
+        recomputeDisplaySnippets()
     }
 
     // MARK: - Example Seeding
@@ -1167,13 +1020,8 @@ struct VocabularyTab: View {
 
     // MARK: - Group Actions
 
-    private func startGroupEdit(replacement: String) {
-        editReplacementText = replacement
-        editingGroupReplacement = replacement
-    }
-
-    private func commitGroupEdit(oldReplacement: String) {
-        let newReplacement = editReplacementText.trimmingCharacters(in: .whitespaces)
+    private func commitGroupEdit(oldReplacement: String, newText: String) {
+        let newReplacement = newText.trimmingCharacters(in: .whitespaces)
         guard !newReplacement.isEmpty, newReplacement != oldReplacement else {
             editingGroupReplacement = nil
             return
@@ -1199,16 +1047,12 @@ struct VocabularyTab: View {
         }
     }
 
-    private func addTriggerToGroup(replacement: String) {
-        let trigger = (newTriggerTexts[replacement] ?? "").trimmingCharacters(in: .whitespaces)
+    private func addTrigger(_ rawTrigger: String, to replacement: String) {
+        let trigger = rawTrigger.trimmingCharacters(in: .whitespaces)
         guard !trigger.isEmpty else { return }
-        guard !snippets.contains(where: { $0.trigger.lowercased() == trigger.lowercased() }) else {
-            newTriggerTexts[replacement] = ""
-            return
-        }
+        guard !snippets.contains(where: { $0.trigger.lowercased() == trigger.lowercased() }) else { return }
         snippets.append((trigger: trigger, value: replacement))
         saveCurrentSnippets()
-        newTriggerTexts[replacement] = ""
     }
 
     // MARK: - Actions
@@ -1583,4 +1427,277 @@ struct VocabularyTab: View {
         .background(TF.settingsWindowBackground)
     }
 
+}
+
+// MARK: - Snippet Group Row
+
+private struct SnippetGroup: Identifiable, Equatable {
+    var id: String { replacement }
+    let replacement: String
+    let triggers: [String]
+}
+
+/// One row of the snippet replacement list.
+///
+/// Hover state and the "add trigger" draft deliberately live here instead of on
+/// `VocabularyTab`: while they sat on the parent, moving the mouse across a row
+/// — or typing a single character into one row's trigger field — invalidated the
+/// parent body and rebuilt every row in the list. The view is `Equatable` so
+/// `ForEach` can skip rows whose inputs did not change.
+private struct SnippetGroupRow: View, Equatable {
+    let group: SnippetGroup
+    let isExample: Bool
+    let isEditing: Bool
+    let isHighlighted: Bool
+    let onStartEdit: () -> Void
+    let onCommitEdit: (String) -> Void
+    let onCancelEdit: () -> Void
+    let onDeleteGroup: () -> Void
+    let onRemoveTrigger: (String) -> Void
+    let onAddTrigger: (String) -> Void
+
+    @State private var isHovered = false
+    @State private var newTriggerText = ""
+    @State private var editText = ""
+    /// Whether the real "add trigger" text field has been swapped in for its
+    /// placeholder. See `addTriggerControl`.
+    @State private var isAddingTrigger = false
+    @FocusState private var isTriggerFieldFocused: Bool
+
+    /// Closures are recreated on every parent render and carry no state of their
+    /// own, so only the rendered inputs take part in equality.
+    static func == (lhs: SnippetGroupRow, rhs: SnippetGroupRow) -> Bool {
+        lhs.group == rhs.group
+            && lhs.isExample == rhs.isExample
+            && lhs.isEditing == rhs.isEditing
+            && lhs.isHighlighted == rhs.isHighlighted
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Group {
+                if isEditing {
+                    TextField("", text: $editText)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(TF.settingsText)
+                        .padding(.horizontal, 9)
+                        .frame(height: 28)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .fill(TF.settingsBg)
+                        )
+                        .onSubmit { onCommitEdit(editText) }
+                } else {
+                    HStack(spacing: 6) {
+                        Text(group.replacement)
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(TF.settingsText)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+
+                        if isExample {
+                            Text(L("示例", "Example"))
+                                .font(.system(size: 8, weight: .semibold))
+                                .foregroundStyle(TF.settingsTextTertiary)
+                                .padding(.horizontal, 6)
+                                .frame(height: 18)
+                                .background(Capsule().fill(TF.settingsCardAlt))
+                        }
+                    }
+                }
+            }
+            .frame(width: 180, alignment: .leading)
+
+            Image(systemName: "arrow.left")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(TF.settingsTextTertiary)
+
+            triggerStrip
+                .frame(maxWidth: .infinity)
+                .frame(height: 28)
+
+            if isEditing {
+                actionButton(
+                    icon: "checkmark",
+                    color: TF.settingsAccentGreen,
+                    tooltip: L("保存", "Save")
+                ) { onCommitEdit(editText) }
+                actionButton(
+                    icon: "xmark",
+                    color: TF.settingsTextTertiary,
+                    tooltip: L("取消", "Cancel")
+                ) { onCancelEdit() }
+            } else if isHovered {
+                actionButton(
+                    icon: "pencil",
+                    color: TF.settingsTextSecondary,
+                    tooltip: L("编辑替换内容", "Edit replacement")
+                ) { onStartEdit() }
+                actionButton(
+                    icon: "trash",
+                    color: TF.settingsAccentRed,
+                    tooltip: L("删除整组", "Delete group")
+                ) { onDeleteGroup() }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(isHighlighted
+                      ? TF.settingsAccentGreen.opacity(0.10)
+                      : (isHovered || isEditing
+                         ? TF.settingsRowHover
+                         : TF.settingsCard))
+                .animation(.easeOut(duration: 0.1), value: isHovered)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(
+                    isHighlighted
+                        ? TF.settingsAccentGreen.opacity(0.32)
+                        : (isHovered || isEditing ? Color.black.opacity(0.11) : TF.settingsBorder),
+                    lineWidth: 1
+                )
+                .animation(.easeOut(duration: 0.1), value: isHovered)
+        )
+        .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .onChange(of: isEditing) { _, editing in
+            if editing { editText = group.replacement }
+        }
+    }
+
+    /// The trigger tags plus the "add trigger" control.
+    ///
+    /// A resting row lays the strip out in a plain, clipped `HStack`. The
+    /// horizontal `ScrollView` — an NSScrollView — is only built while the row
+    /// is hovered or being edited, which is also the only time the overflowing
+    /// triggers need to be reachable.
+    @ViewBuilder
+    private var triggerStrip: some View {
+        // The container must not change while a trigger is being typed: swapping
+        // it would rebuild the text field and drop the user's focus mid-entry.
+        let isActive = isHovered || isEditing || isAddingTrigger
+        let content = HStack(spacing: 7) {
+            ForEach(group.triggers, id: \.self) { trigger in
+                triggerTag(trigger: trigger, showsRemove: isHovered || isEditing)
+            }
+            addTriggerControl
+        }
+
+        if isActive {
+            ScrollView(.horizontal, showsIndicators: false) { content }
+        } else {
+            content
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .clipped()
+        }
+    }
+
+    /// The dashed "add trigger" pill.
+    ///
+    /// Rendered as static text until it is actually used. A live `TextField` is
+    /// an NSTextField, and one per row is the single most expensive thing in a
+    /// list this long, so the real field is only built once the row is engaged.
+    @ViewBuilder
+    private var addTriggerControl: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "plus")
+                .font(.system(size: 8, weight: .bold))
+                .foregroundStyle(TF.settingsTextTertiary)
+
+            if isAddingTrigger {
+                TextField(L("添加触发词", "Add trigger"), text: $newTriggerText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 11))
+                    .foregroundStyle(TF.settingsTextSecondary)
+                    .frame(width: 82)
+                    .focused($isTriggerFieldFocused)
+                    .onSubmit {
+                        onAddTrigger(newTriggerText)
+                        newTriggerText = ""
+                    }
+                    .onAppear {
+                        DispatchQueue.main.async { isTriggerFieldFocused = true }
+                    }
+                    .onChange(of: isTriggerFieldFocused) { _, focused in
+                        // Collapse back to the placeholder once the field is
+                        // done with, but never discard text in progress.
+                        if !focused && newTriggerText.isEmpty { isAddingTrigger = false }
+                    }
+            } else {
+                Text(L("添加触发词", "Add trigger"))
+                    .font(.system(size: 11))
+                    .foregroundStyle(TF.settingsTextTertiary)
+                    .frame(width: 82, alignment: .leading)
+            }
+        }
+        .padding(.horizontal, 9)
+        .frame(height: 26)
+        .background(
+            Capsule()
+                .stroke(
+                    TF.settingsTextTertiary.opacity(0.28),
+                    style: StrokeStyle(lineWidth: 1, dash: [4])
+                )
+        )
+        .contentShape(Capsule())
+        .onTapGesture {
+            if isAddingTrigger {
+                isTriggerFieldFocused = true
+            } else {
+                isAddingTrigger = true
+            }
+        }
+    }
+
+    private func actionButton(
+        icon: String,
+        color: Color,
+        tooltip: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(color)
+                .frame(width: 24, height: 24)
+                .background(Circle().fill(TF.settingsCardAlt))
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .settingsTooltip(tooltip)
+    }
+
+    private func triggerTag(trigger: String, showsRemove: Bool) -> some View {
+        HStack(spacing: 6) {
+            Text(trigger)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(TF.settingsTextSecondary)
+
+            if showsRemove {
+                Button {
+                    onRemoveTrigger(trigger)
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 7, weight: .bold))
+                        .foregroundStyle(TF.settingsTextTertiary)
+                        .frame(width: 14, height: 14)
+                        .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .settingsTooltip(L("删除触发词", "Remove trigger"))
+            }
+        }
+        .padding(.leading, 10)
+        .padding(.trailing, showsRemove ? 6 : 10)
+        .frame(height: 26)
+        .background(Capsule().fill(TF.settingsControl))
+        .overlay(Capsule().stroke(Color.black.opacity(0.045), lineWidth: 1))
+    }
 }

--- a/Type4Me/UI/Settings/VocabularyTab.swift
+++ b/Type4Me/UI/Settings/VocabularyTab.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Observation
 
 /// Chrome-style tab shape with concave bottom corners.
 ///
@@ -144,6 +145,7 @@ struct VocabularyTab: View {
         case snippetReplacement
     }
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var selectedSection: VocabularySection = .hotwords
     @State private var isSearchExpanded = false
     @State private var searchQuery = ""
@@ -164,7 +166,10 @@ struct VocabularyTab: View {
     /// Grouped, filtered and sorted rows for the snippet list.
     /// See `recomputeDisplaySnippets()` for why this is cached rather than computed.
     @State private var displaySnippets: [SnippetGroup] = []
-    @State private var editingGroupReplacement: String? = nil
+    @State private var replacementDraft: SnippetReplacementDraft? = nil
+    @State private var displayedSnippetQuery: String = ""
+    @State private var activeNavigationToken: UUID? = nil
+    @State private var isApplyingNavigation: Bool = false
     @State private var newTrigger: String = ""
     @State private var newSnippetTriggers: [String] = []
     @State private var newValue: String = ""
@@ -225,6 +230,9 @@ struct VocabularyTab: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
             .onReceive(NotificationCenter.default.publisher(for: .navigateToVocabulary)) { note in
+                let token = UUID()
+                activeNavigationToken = token
+
                 if let request = note.object as? VocabularyNavigationRequest {
                     applyNavigationRequest(request)
                     return
@@ -233,26 +241,48 @@ struct VocabularyTab: View {
                 // Quick Correction always writes to the global snippet store.
                 // Reset view-only filters before resolving the scroll target so
                 // the newly added group is guaranteed to exist in the hierarchy.
+                isApplyingNavigation = true
                 searchQuery = ""
                 switchScope(to: nil)
                 withAnimation(.easeInOut(duration: 0.18)) {
                     selectedSection = .snippets
                 }
+                DispatchQueue.main.async {
+                    isApplyingNavigation = false
+                }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                    withAnimation(.easeInOut(duration: 0.4)) {
+                    guard activeNavigationToken == token else { return }
+                    guard selectedSection == .snippets,
+                          selectedAppScope == nil,
+                          displaySnippets.contains(where: { $0.replacement == replacement })
+                    else { return }
+
+                    if reduceMotion {
                         proxy.scrollTo("snippet-\(replacement)", anchor: .center)
-                    }
-                    // The list is lazy, so the target row may only be built by
-                    // the scroll above. Re-anchor once it exists.
-                    DispatchQueue.main.async {
-                        proxy.scrollTo("snippet-\(replacement)", anchor: .center)
-                    }
-                    withAnimation(.easeIn(duration: 0.3).delay(0.2)) {
                         highlightedGroup = replacement
-                    }
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                        withAnimation(.easeOut(duration: 0.8)) {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                            guard activeNavigationToken == token else { return }
                             highlightedGroup = nil
+                        }
+                    } else {
+                        withAnimation(.easeInOut(duration: 0.4), completionCriteria: .removed) {
+                            proxy.scrollTo("snippet-\(replacement)", anchor: .center)
+                        } completion: {
+                            guard activeNavigationToken == token else { return }
+                            guard selectedSection == .snippets,
+                                  selectedAppScope == nil,
+                                  displaySnippets.contains(where: { $0.replacement == replacement })
+                            else { return }
+                            proxy.scrollTo("snippet-\(replacement)", anchor: .center)
+                        }
+                        withAnimation(.easeIn(duration: 0.3).delay(0.2)) {
+                            highlightedGroup = replacement
+                        }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                            guard activeNavigationToken == token else { return }
+                            withAnimation(.easeOut(duration: 0.8)) {
+                                highlightedGroup = nil
+                            }
                         }
                     }
                 }
@@ -268,10 +298,32 @@ struct VocabularyTab: View {
                 applyNavigationRequest(request)
             }
         }
+        .onChange(of: selectedSection) { _, _ in
+            if !isApplyingNavigation {
+                activeNavigationToken = nil
+            }
+        }
+        .onChange(of: selectedAppScope) { _, _ in
+            if !isApplyingNavigation {
+                activeNavigationToken = nil
+            }
+        }
+        .onChange(of: searchQuery) { _, newQuery in
+            if !isApplyingNavigation {
+                activeNavigationToken = nil
+            }
+            if newQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                recomputeDisplaySnippets()
+            }
+        }
         .task(id: searchQuery) {
-            // Debounce: without this, every keystroke re-grouped and re-filtered
-            // the whole snippet store before the next frame could be drawn.
-            try? await Task.sleep(nanoseconds: 200_000_000)
+            let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !query.isEmpty else { return }
+            do {
+                try await Task.sleep(nanoseconds: 200_000_000)
+            } catch {
+                return
+            }
             guard !Task.isCancelled else { return }
             recomputeDisplaySnippets()
         }
@@ -553,11 +605,11 @@ struct VocabularyTab: View {
                         SnippetGroupRow(
                             group: group,
                             isExample: group.replacement == Self.builtinExampleReplacement,
-                            isEditing: editingGroupReplacement == group.replacement,
+                            replacementDraft: replacementDraft?.replacement == group.replacement ? replacementDraft : nil,
                             isHighlighted: highlightedGroup == group.replacement,
-                            onStartEdit: { editingGroupReplacement = group.replacement },
+                            onStartEdit: { replacementDraft = SnippetReplacementDraft(replacement: group.replacement) },
                             onCommitEdit: { commitGroupEdit(oldReplacement: group.replacement, newText: $0) },
-                            onCancelEdit: { editingGroupReplacement = nil },
+                            onCancelEdit: { replacementDraft = nil },
                             onDeleteGroup: { removeGroup(replacement: group.replacement) },
                             onRemoveTrigger: { removeTrigger(trigger: $0, replacement: group.replacement) },
                             onAddTrigger: { addTrigger($0, to: group.replacement) }
@@ -678,16 +730,17 @@ struct VocabularyTab: View {
     }
 
     private var snippetEmptyState: some View {
-        VStack(spacing: 8) {
-            Image(systemName: isSearching ? "magnifyingglass" : "text.badge.plus")
+        let isSearchingSnippets = !displayedSnippetQuery.isEmpty
+        return VStack(spacing: 8) {
+            Image(systemName: isSearchingSnippets ? "magnifyingglass" : "text.badge.plus")
                 .font(.system(size: 22, weight: .regular))
                 .foregroundStyle(TF.settingsTextTertiary)
-            Text(isSearching
+            Text(isSearchingSnippets
                  ? L("没有匹配的片段", "No matching snippets")
                  : L("还没有片段替换规则", "No snippet rules yet"))
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(TF.settingsTextSecondary)
-            Text(isSearching
+            Text(isSearchingSnippets
                  ? L("尝试更换搜索关键词。", "Try a different search term.")
                  : L("添加触发词，让常用内容一说即用。", "Add a trigger phrase to insert frequently used text instantly."))
                 .font(.system(size: 11))
@@ -835,6 +888,9 @@ struct VocabularyTab: View {
             if dict[entry.value] == nil { order.append(entry.value) }
             dict[entry.value, default: []].append(entry.trigger)
         }
+        if let draft = replacementDraft, dict[draft.replacement] == nil {
+            replacementDraft = nil
+        }
         var groups = order.map { SnippetGroup(replacement: $0, triggers: dict[$0]!) }
 
         let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -849,6 +905,7 @@ struct VocabularyTab: View {
         }
 
         displaySnippets = groups
+        displayedSnippetQuery = query
     }
 
 
@@ -948,6 +1005,9 @@ struct VocabularyTab: View {
     }
 
     private func switchScope(to bundleId: String?) {
+        if selectedAppScope != bundleId {
+            replacementDraft = nil
+        }
         selectedAppScope = bundleId
         if let bundleId = bundleId {
             snippets = SnippetStorage.loadAppSnippets(bundleId: bundleId)
@@ -1023,7 +1083,7 @@ struct VocabularyTab: View {
     private func commitGroupEdit(oldReplacement: String, newText: String) {
         let newReplacement = newText.trimmingCharacters(in: .whitespaces)
         guard !newReplacement.isEmpty, newReplacement != oldReplacement else {
-            editingGroupReplacement = nil
+            replacementDraft = nil
             return
         }
         for i in snippets.indices {
@@ -1032,7 +1092,7 @@ struct VocabularyTab: View {
             }
         }
         saveCurrentSnippets()
-        editingGroupReplacement = nil
+        replacementDraft = nil
     }
 
     private func removeGroup(replacement: String) {
@@ -1058,6 +1118,7 @@ struct VocabularyTab: View {
     // MARK: - Actions
 
     private func applyNavigationRequest(_ request: VocabularyNavigationRequest) {
+        isApplyingNavigation = true
         searchQuery = ""
         isSearchExpanded = false
         switchScope(to: nil)
@@ -1074,6 +1135,7 @@ struct VocabularyTab: View {
 
         VocabularyNavigationCenter.shared.consume(request)
         DispatchQueue.main.async {
+            isApplyingNavigation = false
             switch request.focus {
             case .hotword: focusedVocabularyInput = .hotword
             case .snippetTrigger: focusedVocabularyInput = .snippetTrigger
@@ -1082,7 +1144,6 @@ struct VocabularyTab: View {
             }
         }
     }
-
     private func addHotword() {
         let word = newHotword.trimmingCharacters(in: .whitespaces)
         guard !word.isEmpty, !hotwords.contains(word) else {
@@ -1429,6 +1490,18 @@ struct VocabularyTab: View {
 
 }
 
+@MainActor
+@Observable
+fileprivate final class SnippetReplacementDraft {
+    let replacement: String
+    var text: String
+
+    init(replacement: String) {
+        self.replacement = replacement
+        self.text = replacement
+    }
+}
+
 // MARK: - Snippet Group Row
 
 private struct SnippetGroup: Identifiable, Equatable {
@@ -1447,7 +1520,7 @@ private struct SnippetGroup: Identifiable, Equatable {
 private struct SnippetGroupRow: View, Equatable {
     let group: SnippetGroup
     let isExample: Bool
-    let isEditing: Bool
+    let replacementDraft: SnippetReplacementDraft?
     let isHighlighted: Bool
     let onStartEdit: () -> Void
     let onCommitEdit: (String) -> Void
@@ -1456,28 +1529,33 @@ private struct SnippetGroupRow: View, Equatable {
     let onRemoveTrigger: (String) -> Void
     let onAddTrigger: (String) -> Void
 
+    @AppStorage("tf_language") private var language = AppLanguage.systemDefault
     @State private var isHovered = false
     @State private var newTriggerText = ""
-    @State private var editText = ""
     /// Whether the real "add trigger" text field has been swapped in for its
     /// placeholder. See `addTriggerControl`.
     @State private var isAddingTrigger = false
     @FocusState private var isTriggerFieldFocused: Bool
+    @FocusState private var isAddTriggerButtonFocused: Bool
+
+    private var isEditing: Bool { replacementDraft != nil }
 
     /// Closures are recreated on every parent render and carry no state of their
     /// own, so only the rendered inputs take part in equality.
     static func == (lhs: SnippetGroupRow, rhs: SnippetGroupRow) -> Bool {
         lhs.group == rhs.group
             && lhs.isExample == rhs.isExample
-            && lhs.isEditing == rhs.isEditing
+            && lhs.replacementDraft === rhs.replacementDraft
             && lhs.isHighlighted == rhs.isHighlighted
+            && lhs.language == rhs.language
     }
 
     var body: some View {
         HStack(spacing: 10) {
             Group {
-                if isEditing {
-                    TextField("", text: $editText)
+                if let draft = replacementDraft {
+                    @Bindable var draft = draft
+                    TextField("", text: $draft.text)
                         .textFieldStyle(.plain)
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundStyle(TF.settingsText)
@@ -1487,7 +1565,7 @@ private struct SnippetGroupRow: View, Equatable {
                             RoundedRectangle(cornerRadius: 8, style: .continuous)
                                 .fill(TF.settingsBg)
                         )
-                        .onSubmit { onCommitEdit(editText) }
+                        .onSubmit { onCommitEdit(draft.text) }
                 } else {
                     HStack(spacing: 6) {
                         Text(group.replacement)
@@ -1517,12 +1595,12 @@ private struct SnippetGroupRow: View, Equatable {
                 .frame(maxWidth: .infinity)
                 .frame(height: 28)
 
-            if isEditing {
+            if let draft = replacementDraft {
                 actionButton(
                     icon: "checkmark",
                     color: TF.settingsAccentGreen,
                     tooltip: L("保存", "Save")
-                ) { onCommitEdit(editText) }
+                ) { onCommitEdit(draft.text) }
                 actionButton(
                     icon: "xmark",
                     color: TF.settingsTextTertiary,
@@ -1566,9 +1644,6 @@ private struct SnippetGroupRow: View, Equatable {
         .onHover { hovering in
             isHovered = hovering
         }
-        .onChange(of: isEditing) { _, editing in
-            if editing { editText = group.replacement }
-        }
     }
 
     /// The trigger tags plus the "add trigger" control.
@@ -1581,7 +1656,7 @@ private struct SnippetGroupRow: View, Equatable {
     private var triggerStrip: some View {
         // The container must not change while a trigger is being typed: swapping
         // it would rebuild the text field and drop the user's focus mid-entry.
-        let isActive = isHovered || isEditing || isAddingTrigger
+        let isActive = isHovered || isEditing || isAddingTrigger || isAddTriggerButtonFocused
         let content = HStack(spacing: 7) {
             ForEach(group.triggers, id: \.self) { trigger in
                 triggerTag(trigger: trigger, showsRemove: isHovered || isEditing)
@@ -1601,17 +1676,17 @@ private struct SnippetGroupRow: View, Equatable {
 
     /// The dashed "add trigger" pill.
     ///
-    /// Rendered as static text until it is actually used. A live `TextField` is
+    /// Rendered as a keyboard-accessible button until it is actually used. A live `TextField` is
     /// an NSTextField, and one per row is the single most expensive thing in a
     /// list this long, so the real field is only built once the row is engaged.
     @ViewBuilder
     private var addTriggerControl: some View {
-        HStack(spacing: 4) {
-            Image(systemName: "plus")
-                .font(.system(size: 8, weight: .bold))
-                .foregroundStyle(TF.settingsTextTertiary)
+        if isAddingTrigger {
+            HStack(spacing: 4) {
+                Image(systemName: "plus")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(TF.settingsTextTertiary)
 
-            if isAddingTrigger {
                 TextField(L("添加触发词", "Add trigger"), text: $newTriggerText)
                     .textFieldStyle(.plain)
                     .font(.system(size: 11))
@@ -1630,29 +1705,49 @@ private struct SnippetGroupRow: View, Equatable {
                         // done with, but never discard text in progress.
                         if !focused && newTriggerText.isEmpty { isAddingTrigger = false }
                     }
-            } else {
-                Text(L("添加触发词", "Add trigger"))
-                    .font(.system(size: 11))
-                    .foregroundStyle(TF.settingsTextTertiary)
-                    .frame(width: 82, alignment: .leading)
             }
-        }
-        .padding(.horizontal, 9)
-        .frame(height: 26)
-        .background(
-            Capsule()
-                .stroke(
-                    TF.settingsTextTertiary.opacity(0.28),
-                    style: StrokeStyle(lineWidth: 1, dash: [4])
-                )
-        )
-        .contentShape(Capsule())
-        .onTapGesture {
-            if isAddingTrigger {
+            .padding(.horizontal, 9)
+            .frame(height: 26)
+            .background(
+                Capsule()
+                    .stroke(
+                        TF.settingsTextTertiary.opacity(0.28),
+                        style: StrokeStyle(lineWidth: 1, dash: [4])
+                    )
+            )
+            .contentShape(Capsule())
+            .onTapGesture {
                 isTriggerFieldFocused = true
-            } else {
-                isAddingTrigger = true
             }
+        } else {
+            Button {
+                isAddingTrigger = true
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(TF.settingsTextTertiary)
+                        .accessibilityHidden(true)
+
+                    Text(L("添加触发词", "Add trigger"))
+                        .font(.system(size: 11))
+                        .foregroundStyle(TF.settingsTextTertiary)
+                        .frame(width: 82, alignment: .leading)
+                }
+                .padding(.horizontal, 9)
+                .frame(height: 26)
+                .background(
+                    Capsule()
+                        .stroke(
+                            TF.settingsTextTertiary.opacity(0.28),
+                            style: StrokeStyle(lineWidth: 1, dash: [4])
+                        )
+                )
+                .contentShape(Capsule())
+            }
+            .buttonStyle(.plain)
+            .focused($isAddTriggerButtonFocused)
+            .accessibilityLabel(L("添加触发词", "Add trigger"))
         }
     }
 

--- a/Type4Me/UI/Settings/VocabularyTab.swift
+++ b/Type4Me/UI/Settings/VocabularyTab.swift
@@ -169,7 +169,6 @@ struct VocabularyTab: View {
     @State private var replacementDraft: SnippetReplacementDraft? = nil
     @State private var displayedSnippetQuery: String = ""
     @State private var activeNavigationToken: UUID? = nil
-    @State private var isApplyingNavigation: Bool = false
     @State private var newTrigger: String = ""
     @State private var newSnippetTriggers: [String] = []
     @State private var newValue: String = ""
@@ -232,6 +231,7 @@ struct VocabularyTab: View {
             .onReceive(NotificationCenter.default.publisher(for: .navigateToVocabulary)) { note in
                 let token = UUID()
                 activeNavigationToken = token
+                highlightedGroup = nil
 
                 if let request = note.object as? VocabularyNavigationRequest {
                     applyNavigationRequest(request)
@@ -241,14 +241,10 @@ struct VocabularyTab: View {
                 // Quick Correction always writes to the global snippet store.
                 // Reset view-only filters before resolving the scroll target so
                 // the newly added group is guaranteed to exist in the hierarchy.
-                isApplyingNavigation = true
                 searchQuery = ""
                 switchScope(to: nil)
                 withAnimation(.easeInOut(duration: 0.18)) {
                     selectedSection = .snippets
-                }
-                DispatchQueue.main.async {
-                    isApplyingNavigation = false
                 }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                     guard activeNavigationToken == token else { return }
@@ -261,8 +257,9 @@ struct VocabularyTab: View {
                         proxy.scrollTo("snippet-\(replacement)", anchor: .center)
                         highlightedGroup = replacement
                         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                            guard activeNavigationToken == token else { return }
-                            highlightedGroup = nil
+                            if highlightedGroup == replacement {
+                                highlightedGroup = nil
+                            }
                         }
                     } else {
                         withAnimation(.easeInOut(duration: 0.4), completionCriteria: .removed) {
@@ -279,9 +276,10 @@ struct VocabularyTab: View {
                             highlightedGroup = replacement
                         }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                            guard activeNavigationToken == token else { return }
-                            withAnimation(.easeOut(duration: 0.8)) {
-                                highlightedGroup = nil
+                            if highlightedGroup == replacement {
+                                withAnimation(.easeOut(duration: 0.8)) {
+                                    highlightedGroup = nil
+                                }
                             }
                         }
                     }
@@ -298,21 +296,23 @@ struct VocabularyTab: View {
                 applyNavigationRequest(request)
             }
         }
-        .onChange(of: selectedSection) { _, _ in
-            if !isApplyingNavigation {
+        .onChange(of: selectedSection) { _, newSection in
+            if newSection != .snippets {
                 activeNavigationToken = nil
+                highlightedGroup = nil
             }
         }
-        .onChange(of: selectedAppScope) { _, _ in
-            if !isApplyingNavigation {
+        .onChange(of: selectedAppScope) { _, newScope in
+            if newScope != nil {
                 activeNavigationToken = nil
+                highlightedGroup = nil
             }
         }
         .onChange(of: searchQuery) { _, newQuery in
-            if !isApplyingNavigation {
+            if !newQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 activeNavigationToken = nil
-            }
-            if newQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                highlightedGroup = nil
+            } else {
                 recomputeDisplaySnippets()
             }
         }
@@ -1118,7 +1118,6 @@ struct VocabularyTab: View {
     // MARK: - Actions
 
     private func applyNavigationRequest(_ request: VocabularyNavigationRequest) {
-        isApplyingNavigation = true
         searchQuery = ""
         isSearchExpanded = false
         switchScope(to: nil)
@@ -1135,7 +1134,6 @@ struct VocabularyTab: View {
 
         VocabularyNavigationCenter.shared.consume(request)
         DispatchQueue.main.async {
-            isApplyingNavigation = false
             switch request.focus {
             case .hotword: focusedVocabularyInput = .hotword
             case .snippetTrigger: focusedVocabularyInput = .snippetTrigger
@@ -1654,24 +1652,16 @@ private struct SnippetGroupRow: View, Equatable {
     /// triggers need to be reachable.
     @ViewBuilder
     private var triggerStrip: some View {
-        // The container must not change while a trigger is being typed: swapping
-        // it would rebuild the text field and drop the user's focus mid-entry.
         let isActive = isHovered || isEditing || isAddingTrigger || isAddTriggerButtonFocused
-        let content = HStack(spacing: 7) {
-            ForEach(group.triggers, id: \.self) { trigger in
-                triggerTag(trigger: trigger, showsRemove: isHovered || isEditing)
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 7) {
+                ForEach(group.triggers, id: \.self) { trigger in
+                    triggerTag(trigger: trigger, showsRemove: isHovered || isEditing)
+                }
+                addTriggerControl
             }
-            addTriggerControl
         }
-
-        if isActive {
-            ScrollView(.horizontal, showsIndicators: false) { content }
-        } else {
-            content
-                .fixedSize(horizontal: true, vertical: false)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .clipped()
-        }
+        .scrollDisabled(!isActive)
     }
 
     /// The dashed "add trigger" pill.
@@ -1746,6 +1736,7 @@ private struct SnippetGroupRow: View, Equatable {
                 .contentShape(Capsule())
             }
             .buttonStyle(.plain)
+            .focusable()
             .focused($isAddTriggerButtonFocused)
             .accessibilityLabel(L("添加触发词", "Add trigger"))
         }


### PR DESCRIPTION
## 问题

「词汇 → 片段替换」点击时会明显卡顿，列表滚动也不流畅。

本地实测数据量：`snippets.json` 537 条 → **394 个替换组**。

列表用的是普通 `VStack`，切到该 tab 的瞬间会**同步构建全部 394 行**；而每一行都带一个横向 `ScrollView` 和一个「添加触发词」`TextField`，也就是主线程上一次性创建约 394 个 NSScrollView + 394 个 NSTextField。这是点击卡顿的来源。

另外两个放大器：

- `hoveredSnippetGroup` 和 `newTriggerTexts` 挂在 `VocabularyTab` 上，鼠标划过任意一行、或在某行触发词输入框敲一个字，都会让父 body 失效并重建整张表。
- `displaySnippets` 是 computed property，每次 body 求值都重新分组 537 条并全量过滤，`matchesSearch` 还对每次调用重复 trim 一遍 query。

## 改动

**渲染**

- `LazyVStack` 替换 `VStack`，只构建可见行。
- 行内横向 `ScrollView` 改为只在 hover / 编辑时才构建 —— 也正是触发词需要滚动查看的唯一场景；静止的行用裁剪的 `HStack` 布局。
- 「添加触发词」胶囊在未使用前只是静态文本，点击后才换成真正的 `TextField`。输入过程中容器保持滚动形态，鼠标移开不会打断输入焦点。

**失效范围**

- 抽出 `SnippetGroupRow`（`View + Equatable`），hover 状态与输入草稿改为行内 `@State`，配合 `.equatable()` 让 `ForEach` 跳过输入未变化的行。
- `displaySnippets` 改为 `@State` + 显式重算（`recomputeDisplaySnippets()`），分组/过滤/排序合并为一次 pass，query 只 trim 一次；搜索加 200ms debounce。重算点覆盖 `onAppear`、`SnippetStorage.didChange`、`switchScope`、`saveCurrentSnippets`、排序切换 —— 所有修改 `snippets` 的路径最终都经过 `saveCurrentSnippets()`。
- 去掉逐行的 `zIndex` 变动；hover 过渡收敛到该行自己的填充与描边上，不再开启覆盖整个 hover 失效范围的动画事务。

懒加载的副作用一并处理：「快速纠正」深链跳转的 `proxy.scrollTo` 会在下一个 runloop 再对齐一次，避免目标行尚未实体化时滚空。

布局、视觉样式与存储格式均无变更。

## 验证

- `swift build` 通过。
- `scripts/dev-run.sh` 构建、签名、安装、启动 Dev 版正常，无崩溃报告，日志无 error/fault。
- 已在 Dev 版本上人工验证列表交互。
- 注：`swift test` 在我的开发机上报 `no such module 'XCTest'`，在未改动的 `main` 上同样复现，属本地环境问题，与本 PR 无关。