### PR TITLE
Make the recording orb speech reactive

### DIFF
--- a/Type4Me/UI/FloatingBar/FloatingBarView.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarView.swift
@@ -837,7 +837,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
             if action == .finish {
                 LiquidGlassOrb(
                     style: recordingVisualStyle,
-                    audioEnergy: state.audioLevel.current,
+                    audioLevelMeter: state.audioLevel,
                     isHovered: hoveredAction == .finish,
                     isPressed: pressedAction == .finish || recordingActionLocked
                 )

--- a/Type4Me/UI/FloatingBar/LiquidGlass/LiquidGlassMotion.swift
+++ b/Type4Me/UI/FloatingBar/LiquidGlass/LiquidGlassMotion.swift
@@ -25,3 +25,441 @@ struct LiquidGlassMotion: Equatable, Sendable {
         return LiquidGlassMotion(time: time, energy: clamped, isAnimated: true)
     }
 }
+
+// MARK: - Speech Envelope
+
+/// Turns the raw microphone meter into the two motion signals the orb needs.
+///
+/// The orb has two very different jobs. It must settle into a designed resting
+/// pose whenever nobody is talking, and it must feel alive per syllable while
+/// somebody is. A single smoothed level cannot do both: fast enough to track a
+/// syllable is also fast enough to flicker between words. So the envelope
+/// exposes two followers over the same gated signal.
+///
+/// - `activity` is slow and hysteretic. It decides *whether* the orb is awake,
+///   and drives the pose morph and the flow speed.
+/// - `transient` is fast. It decides *how hard* the orb is being pushed right
+///   now, and drives scale, outline deformation and exposure.
+///
+/// The gate rides an adaptive noise floor instead of a fixed threshold, so a
+/// quiet room and a noisy room both end up with the orb still at rest.
+struct OrbSpeechEnvelope: Equatable, Sendable {
+
+    // MARK: Tuning
+
+    /// The floor creeps upward slowly so sustained speech never raises it, but
+    /// drops quickly so the orb re-arms as soon as a room goes quiet. Real
+    /// speech dips to ambient between words, which is what keeps the fast fall
+    /// rate anchored on the room rather than on the voice.
+    static let noiseFloorRiseRate: Float = 0.30
+    static let noiseFloorFallRate: Float = 1.8
+    /// Right after recording starts there is no history to work from, so the
+    /// floor latches onto the room quickly for a moment. Levels above
+    /// `warmupSpeechGuard` are assumed to be a voice and are excluded, so
+    /// talking immediately cannot calibrate the room to your own volume.
+    static let warmupDuration: Float = 0.4
+    static let warmupFloorRate: Float = 8.0
+    static let warmupSpeechGuard: Float = 0.32
+    /// Never let the adaptive floor climb high enough to swallow real speech.
+    static let noiseFloorCeiling: Float = 0.30
+    static let noiseFloorInitial: Float = 0.04
+
+    /// Hysteresis: it takes more level to wake the orb than to keep it awake.
+    static let openMargin: Float = 0.10
+    static let closeMargin: Float = 0.055
+
+    /// Bridges the gaps between words so one sentence reads as one gesture.
+    static let holdDuration: Float = 0.13
+
+    static let activityAttackRate: Float = 11.0
+    static let activityReleaseRate: Float = 9.0
+    static let transientAttackRate: Float = 26.0
+    static let transientReleaseRate: Float = 8.5
+
+    /// `flux` measures how fast the level is *changing*, not how loud it is —
+    /// rapid, percussive speech agitates the fluid more than a held vowel at
+    /// the same volume. Averaged over ~170ms so it reads syllable rate rather
+    /// than waveform.
+    static let fluxFollowRate: Float = 6.0
+    /// Level change per second that counts as fully agitated speech.
+    static let fluxReference: Float = 3.0
+
+    /// Below this the orb is declared visually asleep and snaps to exact zero,
+    /// so silence is genuinely still rather than drifting at a fraction of a
+    /// percent forever. It sits at `livenessLow`, where the pose morph has
+    /// already bottomed out and nothing on screen is moving anyway.
+    static let idleEpsilon: Float = 0.02
+
+    /// The resting drift rate, as a fraction of the flow at conversational
+    /// volume. Low enough that nothing appears to react, high enough that the
+    /// orb is visibly a liquid rather than a screenshot.
+    /// A visible but unhurried drift — a lava lamp, not a reaction. Speech
+    /// runs this up by roughly thirteen times.
+    static let idlePhaseVelocity: Float = 0.42
+
+    /// How much `activity` counts as fully awake. A whisper lands part-way up
+    /// and gets a correspondingly partial response.
+    static let livenessLow: Float = 0.05
+    static let livenessHigh: Float = 0.45
+
+    /// The pose morph runs on its own, much slower follower than the reactive
+    /// signals. Two things depend on this being sluggish: the transition from
+    /// resting to speaking has to ease rather than snap, and a brief weak sound
+    /// must not be able to drive the pose far enough to be seen as a flash.
+    static let poseAttackRate: Float = 5.0
+    static let poseReleaseRate: Float = 3.2
+
+    // MARK: State
+
+    private(set) var noiseFloor: Float = OrbSpeechEnvelope.noiseFloorInitial
+    private(set) var activity: Float = 0
+    private(set) var transient: Float = 0
+    private(set) var phase: Float = 0
+    private var fluxFollower: Float = 0
+    private var previousLevel: Float = 0
+    private var pose: Float = 0
+    private(set) var isGateOpen: Bool = false
+    private(set) var holdRemaining: Float = 0
+    private(set) var warmupRemaining: Float = OrbSpeechEnvelope.warmupDuration
+
+    init() {}
+
+    var openThreshold: Float { min(0.92, noiseFloor + Self.openMargin) }
+    var closeThreshold: Float { min(0.90, noiseFloor + Self.closeMargin) }
+
+    /// 0 at rest, 1 while speaking. Blends every uniform between the resting
+    /// pose and the live pose. Eased on both ends: the raw follower is already
+    /// exponential, and the smoothstep adds the ease-in the start of a phrase
+    /// needs so the orb swells into motion instead of snapping into it.
+    var liveness: Float {
+        Self.smoothstep(0.0, 1.0, pose)
+    }
+
+    /// 1 at rest. Convenience inverse of `liveness`.
+    var idleBlend: Float { 1.0 - liveness }
+
+    /// 0...1 agitation from how quickly the voice is modulating. Gated by
+    /// `liveness` so a silent room's meter noise cannot register as fast speech.
+    var flux: Float {
+        min(1.0, fluxFollower / Self.fluxReference) * liveness
+    }
+
+    /// The per-syllable push, gated by the slow pose so that a faint or
+    /// momentary sound can never produce a visible pulse. This is what stops
+    /// the orb flickering at a voice too quiet to properly wake it.
+    var punch: Float { transient * liveness }
+
+    /// A resting orb is not frozen — a dead still frame reads as a hung app —
+    /// but it drifts an order of magnitude slower than it flows under a voice.
+    ///
+    /// The idle motion is deliberately the fluid field's own aperiodic drift
+    /// rather than a breathing scale or glow. Apple's Motion guidance calls out
+    /// sustained oscillations near 0.2 Hz (one cycle per five seconds) as the
+    /// uncomfortable band, and a slow "breathing" orb lands squarely in it.
+    /// Domain-warped noise has no such frequency to sit on.
+    var phaseVelocity: Float {
+        Self.idlePhaseVelocity
+            + activity * (1.3 + 2.4 * activity)
+            + 1.3 * flux
+    }
+
+    // MARK: Update
+
+    /// Advances the envelope by one render frame.
+    /// - Parameters:
+    ///   - rawLevel: the microphone meter, already normalised to 0...1.
+    ///   - deltaTime: seconds since the previous frame.
+    ///   - motionScale: per-preset speed character folded into the phase.
+    mutating func advance(rawLevel: Float, deltaTime: Float, motionScale: Float) {
+        let dt = max(0.0, min(0.05, deltaTime))
+        let level = max(0.0, min(1.0, rawLevel))
+
+        updateNoiseFloor(level: level, dt: dt)
+        updateFlux(level: level, dt: dt)
+        warmupRemaining = max(0.0, warmupRemaining - dt)
+        updateGate(level: level, dt: dt)
+
+        let drive = gatedDrive(level: level)
+        // While the hold is running the envelope refuses to fall, which is what
+        // keeps a pause inside a sentence from making the orb stutter.
+        let sustaining = holdRemaining > 0
+        let activityTarget = sustaining ? max(drive, activity) : drive
+        let transientTarget = sustaining ? max(drive, transient * 0.9) : drive
+
+        activity = Self.follow(
+            current: activity,
+            target: activityTarget,
+            dt: dt,
+            attackRate: Self.activityAttackRate,
+            releaseRate: Self.activityReleaseRate
+        )
+        transient = Self.follow(
+            current: transient,
+            target: transientTarget,
+            dt: dt,
+            attackRate: Self.transientAttackRate,
+            releaseRate: Self.transientReleaseRate
+        )
+
+        pose = Self.follow(
+            current: pose,
+            target: Self.smoothstep(Self.livenessLow, Self.livenessHigh, activity),
+            dt: dt,
+            attackRate: Self.poseAttackRate,
+            releaseRate: Self.poseReleaseRate
+        )
+
+        phase += dt * phaseVelocity * max(0.0, motionScale)
+    }
+
+    /// Returns the orb to its resting pose without a transition. Used when the
+    /// surface goes static (Reduce Motion, static preset, recording stopped).
+    mutating func reset() {
+        noiseFloor = Self.noiseFloorInitial
+        activity = 0
+        transient = 0
+        isGateOpen = false
+        holdRemaining = 0
+        fluxFollower = 0
+        previousLevel = 0
+        pose = 0
+        warmupRemaining = Self.warmupDuration
+    }
+
+    // MARK: Internals
+
+    /// The meter arrives at ~20Hz while this runs at 60-120Hz, so most frames
+    /// see no change at all. Low-passing `|delta| / dt` rather than `|delta|`
+    /// makes the estimate independent of how often either side ticks.
+    private mutating func updateFlux(level: Float, dt: Float) {
+        guard dt > 0 else { return }
+        let rate = abs(level - previousLevel) / dt
+        previousLevel = level
+        fluxFollower += (rate - fluxFollower) * min(1.0, dt * Self.fluxFollowRate)
+        fluxFollower = max(0.0, fluxFollower)
+    }
+
+    private mutating func updateNoiseFloor(level: Float, dt: Float) {
+        // Once speech has opened the gate (and while its inter-word hold is
+        // active), never learn a louder level as room noise. Otherwise a
+        // sustained soft phrase slowly pulls the floor upward until the gate
+        // closes on the speaker. We still allow a downward correction so a
+        // quieter room is picked up immediately between words.
+        if isGateOpen || holdRemaining > 0 {
+            guard level < noiseFloor else { return }
+            noiseFloor += (level - noiseFloor)
+                * min(1.0, dt * Self.noiseFloorFallRate)
+            noiseFloor = max(0.0, min(Self.noiseFloorCeiling, noiseFloor))
+            return
+        }
+
+        let isCalibrating = warmupRemaining > 0 && level < Self.warmupSpeechGuard
+        let rate = isCalibrating
+            ? Self.warmupFloorRate
+            : (level > noiseFloor ? Self.noiseFloorRiseRate : Self.noiseFloorFallRate)
+        noiseFloor += (level - noiseFloor) * min(1.0, dt * rate)
+        noiseFloor = max(0.0, min(Self.noiseFloorCeiling, noiseFloor))
+    }
+
+    private mutating func updateGate(level: Float, dt: Float) {
+        if isGateOpen {
+            if level < closeThreshold {
+                isGateOpen = false
+                holdRemaining = Self.holdDuration
+            } else {
+                holdRemaining = Self.holdDuration
+            }
+        } else if level >= openThreshold, canOpenGate(level: level) {
+            isGateOpen = true
+            holdRemaining = Self.holdDuration
+        } else {
+            holdRemaining = max(0.0, holdRemaining - dt)
+        }
+    }
+
+    /// While the noise floor is still calibrating, only a level loud enough to
+    /// be unambiguously a voice may open the gate. That is what stops a fan
+    /// from producing a blip in the first frames after recording starts.
+    private func canOpenGate(level: Float) -> Bool {
+        warmupRemaining <= 0 || level >= Self.warmupSpeechGuard
+    }
+
+    private func gatedDrive(level: Float) -> Float {
+        guard isGateOpen else { return 0 }
+        let base = closeThreshold
+        let span = max(0.05, 1.0 - base)
+        let normalized = max(0.0, min(1.0, (level - base) / span))
+        // Perceptual lift: a soft voice should still visibly move the orb.
+        return pow(normalized, 0.62)
+    }
+
+    static func follow(
+        current: Float,
+        target: Float,
+        dt: Float,
+        attackRate: Float,
+        releaseRate: Float
+    ) -> Float {
+        let from = max(0.0, min(1.0, current))
+        let to = max(0.0, min(1.0, target))
+        let rate = to > from ? attackRate : releaseRate
+        let next = from + (to - from) * min(1.0, max(0.0, dt) * rate)
+        if to <= 0, next < idleEpsilon { return 0 }
+        return max(0.0, min(1.0, next))
+    }
+
+    static func smoothstep(_ edge0: Float, _ edge1: Float, _ x: Float) -> Float {
+        guard edge1 > edge0 else { return x >= edge1 ? 1 : 0 }
+        let t = max(0.0, min(1.0, (x - edge0) / (edge1 - edge0)))
+        return t * t * (3.0 - 2.0 * t)
+    }
+}
+
+// MARK: - Uniform Shaping
+
+/// Maps the envelope onto the orb shader's uniform slots.
+///
+/// Nothing here touches the vendored Metal source. Every expressive change is a
+/// per-frame uniform write, which keeps `OrbMetalSource.swift` byte-identical to
+/// the pinned upstream commit.
+enum OrbUniformShaping {
+    // Uniform slot indices inside `OrbPreset.uniforms`.
+    static let sizeX = 0
+    static let sizeY = 1
+    static let time = 2
+    static let speed = 3
+    static let radius = 4
+    static let zoom = 5
+    static let warp = 6
+    static let ridgeAmt = 7
+    static let sharp = 8
+    static let exposure = 14
+    static let edgeSoftness = 16
+    static let contourDeform = 21
+    static let styleFlowIndex = 15
+
+    /// Flow index 9 is the Siri band shader, whose uniforms mean something
+    /// different from every other fluid's.
+    static func isBandStyle(_ base: [Float]) -> Bool {
+        abs(base[styleFlowIndex] - 9.0) < 0.5
+    }
+
+    /// How far inside the frame the orb sits when nobody is speaking, leaving
+    /// headroom for the scale pulse and the outline wobble.
+    static let restRadiusScale: Float = 0.945
+    /// The shader multiplies this by 0.09, so this caps the silhouette
+    /// undulation at roughly 3% of the radius. Past that the orb stops
+    /// reading as a button and starts reading as a dented potato.
+    static let maxContourDeform: Float = 0.34
+    /// Roughly 0.9% of the radius — an organic outline, not a reaction.
+    static let restContourDeform: Float = 0.10
+
+    /// Visual change per second that a preset should produce at a
+    /// conversational phase velocity. Chosen so the set lands near where the
+    /// liveliest original preset already sat.
+    static let referenceFlow: Float = 22.0
+
+    /// Converts a preset's measured `flowResponse` into the phase multiplier
+    /// that makes every preset flow at a comparable perceived rate.
+    ///
+    /// The preset's own `speed` field is deliberately not used: it is a phase
+    /// multiplier, not a measure of how much the image actually moves, and the
+    /// two turned out to be nearly uncorrelated. `frost` ships at speed 2.22
+    /// yet moves a twelfth as much per unit phase as `siri` at 0.82.
+    static func motionScale(flowResponse: Float) -> Float {
+        max(0.35, min(6.0, referenceFlow / max(0.5, flowResponse)))
+    }
+
+    /// The shader's alpha cut is `smoothstep(0.99 - d, 1.01 + d, pd)` with
+    /// `d = edgeSoftness - 0.005`, i.e. a transition band of `0.01 + 2 * soft`
+    /// in units of the orb radius. Solving that for a fixed pixel width gives a
+    /// properly resolution-aware edge instead of the preset's 13px mush.
+    static func edgeSoftness(
+        drawableMinDimension: Float,
+        orbRadius: Float,
+        featherPixels: Float = 2.4
+    ) -> Float {
+        let radiusPixels = max(1.0, orbRadius * drawableMinDimension * 0.5)
+        let bandInRadii = featherPixels / radiusPixels
+        return max(0.002, min(0.06, (bandInRadii - 0.01) * 0.5))
+    }
+
+    /// Builds the frame's uniforms from the preset plus the live envelope.
+    ///
+    /// The resting pose is not a frozen random frame: it is the same field
+    /// evaluated with a deliberately calmer parameterisation — less domain
+    /// warp, softer ridges, a perfectly circular outline. Because every one of
+    /// those is continuous, going quiet reads as the liquid settling rather
+    /// than as a video being paused.
+    static func shape(
+        base: [Float],
+        envelope: OrbSpeechEnvelope,
+        drawableWidth: Float,
+        drawableHeight: Float,
+        isAnimated: Bool
+    ) -> [Float] {
+        var u = base
+        u[sizeX] = drawableWidth
+        u[sizeY] = drawableHeight
+
+        let minDimension = max(1.0, min(drawableWidth, drawableHeight))
+        u[edgeSoftness] = edgeSoftness(
+            drawableMinDimension: minDimension,
+            orbRadius: base[radius]
+        )
+
+        guard isAnimated else {
+            // Static presets and Reduce Motion keep the original pose exactly.
+            u[time] = 0
+            return u
+        }
+
+        let punch = envelope.punch
+
+        u[time] = envelope.phase
+        // The preset's speed is folded into the integrated phase instead, so
+        // the shader multiplies by 1 and the flow rate is ours to drive.
+        u[speed] = 1.0
+
+        // Resting is *slow*, not flattened.
+        //
+        // The obvious way to make a resting orb look calm is to wind down the
+        // domain warp and the ridge amount. It backfires: `lqRamp` spreads the
+        // four palette colours across the full range of the field value, so
+        // compressing the field collapses the palette onto its middle two
+        // stops. The highlight and the deep tone drop out, and the orb reads as
+        // dim and muddy rather than calm. So the preset's own field parameters
+        // are left alone at rest and every one of these is an *overdrive* that
+        // only engages once there is a voice.
+
+        // The orb rests slightly inside the frame so the pulse and the outline
+        // wobble have somewhere to expand into.
+        u[radius] = base[radius] * Self.restRadiusScale * (1.0 + 0.05 * punch)
+
+        // Volume drives turbulence: `punch` pushes the domain warp above the
+        // preset's own value so a loud syllable visibly churns.
+        u[warp] = base[warp] * (1.0 + 0.35 * punch)
+
+        // The Siri band shader reads `ridgeAmt` as the wave's height and its
+        // line softness, so overdriving it is what makes the wave swell and
+        // sharpen with the voice — the behaviour of the real Siri orb. Every
+        // other fluid feeds `ridgeAmt` into a `mix()`, where values above 1
+        // extrapolate, so those stay clamped.
+        u[ridgeAmt] = isBandStyle(base)
+            ? base[ridgeAmt] * (1.0 + 2.2 * punch)
+            : min(1.0, base[ridgeAmt] * (1.0 + 0.4 * punch))
+
+        // A lift only, never a dip. Dimming at rest was read as the orb simply
+        // going dark, which is the one thing it must not do.
+        u[exposure] = base[exposure] * (1.0 + 0.12 * punch)
+
+        // Always faintly organic; undulating with the voice on top. The shader
+        // scales this by 0.09, so the cap is a ~3% radius wobble.
+        u[contourDeform] = min(
+            Self.maxContourDeform,
+            base[contourDeform] + Self.restContourDeform + 0.20 * punch
+        )
+
+        return u
+    }
+}

--- a/Type4Me/UI/FloatingBar/LiquidGlass/LiquidGlassOrb.swift
+++ b/Type4Me/UI/FloatingBar/LiquidGlass/LiquidGlassOrb.swift
@@ -6,6 +6,10 @@
 //  Copyright (c) 2026 LerSent001 (MIT License)
 //  Pinned commit: fbf6eb81ad85e1125ed62027769bcfefc01d3613
 //
+//  The shader source is kept byte-identical to upstream. Everything Type4Me
+//  adds — speech reactivity, the resting pose, the resolution-aware edge — is
+//  expressed as per-frame uniform writes in `OrbUniformShaping`.
+//
 
 import AppKit
 import MetalKit
@@ -51,6 +55,82 @@ private final class LiquidOrbPipelineManager {
     }
 }
 
+// MARK: - Supersampled MTKView
+
+/// An `MTKView` that renders above native resolution and lets the compositor
+/// filter it back down.
+///
+/// At 45pt the orb is only ~90 native pixels across, which is not enough for
+/// the shader's own edge to look clean and leaves the internal fluid detail
+/// visibly stair-stepped. Rendering at 2x the backing scale and letting the
+/// layer minify is a cheap, exact supersample for a surface this small.
+private final class LiquidOrbMetalView: MTKView {
+    /// Supersampling factor on top of the display's backing scale.
+    static let superSample: CGFloat = 2.0
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        NotificationCenter.default.removeObserver(
+            self,
+            name: NSWindow.didChangeScreenNotification,
+            object: nil
+        )
+        if let window {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(windowScreenDidChange(_:)),
+                name: NSWindow.didChangeScreenNotification,
+                object: window
+            )
+        }
+        syncDrawableSize()
+        syncRefreshRate()
+    }
+
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        syncDrawableSize()
+        syncRefreshRate()
+    }
+
+    override func layout() {
+        super.layout()
+        syncDrawableSize()
+    }
+
+    @objc private func windowScreenDidChange(_ notification: Notification) {
+        syncDrawableSize()
+        syncRefreshRate()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    private func syncDrawableSize() {
+        let backingScale = window?.backingScaleFactor
+            ?? NSScreen.main?.backingScaleFactor
+            ?? 2.0
+        layer?.contentsScale = backingScale
+        let scale = backingScale * Self.superSample
+        let width = max(1.0, bounds.width * scale)
+        let height = max(1.0, bounds.height * scale)
+        let target = CGSize(width: min(width, 4096), height: min(height, 4096))
+        if drawableSize != target {
+            drawableSize = target
+        }
+    }
+
+    private func syncRefreshRate() {
+        // Matching the display avoids the beat frequency a fixed 60 produces on
+        // a 120Hz panel, which is a large part of why the orb reads as jittery.
+        let maxFPS = window?.screen?.maximumFramesPerSecond
+            ?? NSScreen.main?.maximumFramesPerSecond
+            ?? 60
+        preferredFramesPerSecond = max(30, min(120, maxFPS))
+    }
+}
+
 // MARK: - Metal MTKView Renderer
 
 private final class LiquidOrbRenderer: NSObject, MTKViewDelegate {
@@ -59,13 +139,13 @@ private final class LiquidOrbRenderer: NSObject, MTKViewDelegate {
     private var baseUniforms: [Float]
     private var currentUniforms: [Float]
     private var lastFrameTime: CFTimeInterval = CACurrentMediaTime()
-    private var integratedTime: Float = 0.0
-    private var smoothedEnergy: Float = 0.0
+    private var envelope = OrbSpeechEnvelope()
+    private var motionScale: Float
 
-    var audioEnergy: Float = 0.0
-    var isAnimated: Bool = true
+    private let audioLevelMeter: AudioLevelMeter
+    private(set) var isAnimated: Bool
 
-    init?(view: MTKView, preset: OrbPreset) {
+    init?(view: MTKView, preset: OrbPreset, audioLevelMeter: AudioLevelMeter) {
         guard let device = LiquidOrbPipelineManager.shared.device,
               let pipeline = LiquidOrbPipelineManager.shared.pipeline,
               let queue = device.makeCommandQueue() else {
@@ -75,24 +155,38 @@ private final class LiquidOrbRenderer: NSObject, MTKViewDelegate {
         self.pipeline = pipeline
         self.baseUniforms = preset.uniforms
         self.currentUniforms = preset.uniforms
+        self.audioLevelMeter = audioLevelMeter
         self.isAnimated = preset.isAnimated
+        self.motionScale = OrbUniformShaping.motionScale(
+            flowResponse: preset.flowResponse
+        )
 
         super.init()
 
         view.device = device
         view.colorPixelFormat = .bgra8Unorm
         view.framebufferOnly = true
-        view.preferredFramesPerSecond = 60
+        view.autoResizeDrawable = false
         view.enableSetNeedsDisplay = !preset.isAnimated
         view.isPaused = !preset.isAnimated
         view.layer?.isOpaque = false
         view.clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 0)
     }
 
-    func updatePreset(_ preset: OrbPreset, audioEnergy: Float, isAnimated: Bool) {
-        self.baseUniforms = preset.uniforms
-        self.audioEnergy = audioEnergy
-        self.isAnimated = isAnimated
+    func updatePreset(_ preset: OrbPreset, isAnimated: Bool) {
+        if baseUniforms != preset.uniforms {
+            baseUniforms = preset.uniforms
+            motionScale = OrbUniformShaping.motionScale(
+                flowResponse: preset.flowResponse
+            )
+        }
+        if self.isAnimated != isAnimated {
+            self.isAnimated = isAnimated
+            if !isAnimated {
+                envelope.reset()
+            }
+            lastFrameTime = CACurrentMediaTime()
+        }
     }
 
     func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {}
@@ -109,34 +203,27 @@ private final class LiquidOrbRenderer: NSObject, MTKViewDelegate {
         let dt = Float(min(0.05, max(0.0, now - lastFrameTime)))
         lastFrameTime = now
 
-        // 1. Noise gate & dynamic curve: filter background room noise below 0.15
-        let gate: Float = 0.15
-        let rawNormalized = max(0.0, (audioEnergy - gate) / (1.0 - gate))
-        let targetEnergy = pow(min(1.0, rawNormalized * 1.25), 1.2)
-
-        // 2. Attack / decay ballistics for organic elasticity (snappy attack, soft decay)
-        let decayRate: Float = targetEnergy > smoothedEnergy ? 22.0 : 7.0
-        smoothedEnergy += (targetEnergy - smoothedEnergy) * min(1.0, dt * decayRate)
-
-        // 3. Continuous numerical integration of phase velocity (1.0x baseline -> up to 2.5x during speech)
         if isAnimated {
-            let speedMultiplier = 1.0 + smoothedEnergy * 1.5
-            integratedTime += dt * speedMultiplier
+            // The meter is read every render frame. Passing a Float through
+            // SwiftUI only ever produced an occasional snapshot, because the
+            // meter is deliberately not observable at audio-callback rate.
+            envelope.advance(
+                rawLevel: audioLevelMeter.current,
+                deltaTime: dt,
+                motionScale: motionScale
+            )
         }
 
-        let w = Float(view.drawableSize.width > 0 ? view.drawableSize.width : 90.0)
-        let h = Float(view.drawableSize.height > 0 ? view.drawableSize.height : 90.0)
+        let w = Float(view.drawableSize.width > 0 ? view.drawableSize.width : 180.0)
+        let h = Float(view.drawableSize.height > 0 ? view.drawableSize.height : 180.0)
 
-        currentUniforms = baseUniforms
-        currentUniforms[0] = w
-        currentUniforms[1] = h
-        currentUniforms[2] = integratedTime
-
-        // 4. Modulate exposure smoothly with audio energy (+70% boost on speech peaks)
-        if isAnimated {
-            let baseExposure = baseUniforms[14]
-            currentUniforms[14] = baseExposure * (1.0 + smoothedEnergy * 0.70)
-        }
+        currentUniforms = OrbUniformShaping.shape(
+            base: baseUniforms,
+            envelope: envelope,
+            drawableWidth: w,
+            drawableHeight: h,
+            isAnimated: isAnimated
+        )
 
         encoder.setRenderPipelineState(pipeline)
         currentUniforms.withUnsafeBytes { bytes in
@@ -153,8 +240,9 @@ private final class LiquidOrbRenderer: NSObject, MTKViewDelegate {
 
 private struct LiquidOrbMetalSurface: NSViewRepresentable {
     let preset: OrbPreset
-    let audioEnergy: Float
+    let audioLevelMeter: AudioLevelMeter
     let isAnimated: Bool
+    let size: CGFloat
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -164,9 +252,15 @@ private struct LiquidOrbMetalSurface: NSViewRepresentable {
         if let existingView = context.coordinator.mtkView {
             return existingView
         }
-        let view = MTKView(frame: CGRect(x: 0, y: 0, width: 45, height: 45), device: LiquidOrbPipelineManager.shared.device)
-        view.drawableSize = CGSize(width: 90, height: 90)
-        if let renderer = LiquidOrbRenderer(view: view, preset: preset) {
+        let view = LiquidOrbMetalView(
+            frame: CGRect(x: 0, y: 0, width: size, height: size),
+            device: LiquidOrbPipelineManager.shared.device
+        )
+        if let renderer = LiquidOrbRenderer(
+            view: view,
+            preset: preset,
+            audioLevelMeter: audioLevelMeter
+        ) {
             context.coordinator.renderer = renderer
             context.coordinator.mtkView = view
             view.delegate = renderer
@@ -179,7 +273,6 @@ private struct LiquidOrbMetalSurface: NSViewRepresentable {
         view.enableSetNeedsDisplay = !isAnimated
         context.coordinator.renderer?.updatePreset(
             preset,
-            audioEnergy: audioEnergy,
             isAnimated: isAnimated
         )
         if !isAnimated {
@@ -197,7 +290,7 @@ private struct LiquidOrbMetalSurface: NSViewRepresentable {
 
 struct LiquidGlassOrb: View {
     let style: RecordingVisualStyle
-    let audioEnergy: Float
+    let audioLevelMeter: AudioLevelMeter
     var isHovered: Bool = false
     var isPressed: Bool = false
 
@@ -207,13 +300,16 @@ struct LiquidGlassOrb: View {
 
     var body: some View {
         ZStack {
+            // No `clipShape(Circle())`. The shader already fades its own alpha
+            // to zero inside the frame, and SwiftUI's mask was cutting through
+            // that gradient — which is where the visible jaggies came from.
             LiquidOrbMetalSurface(
                 preset: style.preset,
-                audioEnergy: max(0.0, min(1.0, audioEnergy)),
-                isAnimated: style.isAnimated && !reduceMotion
+                audioLevelMeter: audioLevelMeter,
+                isAnimated: style.isAnimated && !reduceMotion,
+                size: orbSize
             )
             .frame(width: orbSize, height: orbSize)
-            .clipShape(Circle())
 
             // Stop Affordance on hover / press
             RoundedRectangle(cornerRadius: 2.5, style: .continuous)

--- a/Type4Me/UI/FloatingBar/LiquidGlass/OrbPreset.swift
+++ b/Type4Me/UI/FloatingBar/LiquidGlass/OrbPreset.swift
@@ -12,6 +12,22 @@ import Foundation
 public struct OrbPreset: Equatable {
     public let styleID: Int
     public let isAnimated: Bool
+    /// How much the rendered image changes per unit of shader phase.
+    ///
+    /// Measured offscreen: each fluid is rendered at 120x120 at eight spread-out
+    /// phases, each against the same fluid advanced by 0.05, and the mean
+    /// absolute per-channel difference inside the orb is averaged and divided by
+    /// the step. The numbers are stable to about +/-2% across runs.
+    ///
+    /// The fluids differ by more than 12x here — `frost` at 3.9 barely moves
+    /// for the same phase advance that carries `siri` at 50.7 through a whole
+    /// gesture. The preset `speed` field is not a usable substitute: it is a
+    /// phase multiplier, and it is nearly uncorrelated with this (frost ships at
+    /// speed 2.22, siri at 0.82). Without this, one flow-speed curve makes some
+    /// presets frantic and leaves others looking like a still image.
+    ///
+    /// Re-measure if a preset's zoom/warp/ridge/sharp or its fluid changes.
+    public let flowResponse: Float
     public let uniforms: [Float]
 
     private static func rgb(_ hex: String) -> (Float, Float, Float, Float) {
@@ -122,6 +138,7 @@ public struct OrbPreset: Equatable {
     public static let siri = OrbPreset(
         styleID: 0,
         isAnimated: true,
+        flowResponse: 50.72,
         uniforms: makeSeed(
             speed: 0.82,
             radius: 0.94,
@@ -151,6 +168,7 @@ public struct OrbPreset: Equatable {
     public static let blueDrop = OrbPreset(
         styleID: 1,
         isAnimated: true,
+        flowResponse: 4.93,
         uniforms: makeSeed(
             speed: 0.9,
             radius: 0.94,
@@ -185,6 +203,7 @@ public struct OrbPreset: Equatable {
     public static let chromaticMetal = OrbPreset(
         styleID: 2,
         isAnimated: true,
+        flowResponse: 27.67,
         uniforms: makeSeed(
             speed: 1.12,
             radius: 0.94,
@@ -216,6 +235,7 @@ public struct OrbPreset: Equatable {
     public static let frost = OrbPreset(
         styleID: 3,
         isAnimated: true,
+        flowResponse: 3.93,
         uniforms: makeSeed(
             speed: 2.22,
             radius: 0.94,
@@ -246,6 +266,7 @@ public struct OrbPreset: Equatable {
     public static let opal = OrbPreset(
         styleID: 4,
         isAnimated: true,
+        flowResponse: 21.59,
         uniforms: makeSeed(
             speed: 1.5,
             radius: 0.94,
@@ -275,6 +296,7 @@ public struct OrbPreset: Equatable {
     public static let voiceWave = OrbPreset(
         styleID: 5,
         isAnimated: true,
+        flowResponse: 21.85,
         uniforms: makeSeed(
             speed: 0.95,
             radius: 0.94,
@@ -307,13 +329,17 @@ public struct OrbPreset: Equatable {
     public static let violetEmber = OrbPreset(
         styleID: 6,
         isAnimated: true,
+        flowResponse: 30.83,
         uniforms: makeSeed(
             speed: 1.12,
             radius: 0.94,
-            zoom: 0.58,
-            warp: 4.7,
-            ridgeAmt: 0.73,
-            sharp: 3.3,
+            // Trimmed from zoom 0.58 / warp 4.7 / ridge 0.73 / sharp 3.3. At
+            // 45pt those pushed the detail below one pixel and the ember read
+            // as static rather than as flowing plasma.
+            zoom: 0.44,
+            warp: 3.6,
+            ridgeAmt: 0.56,
+            sharp: 2.5,
             shade: 0.18,
             sheen: 0.2,
             gloss: 0.34,
@@ -341,6 +367,7 @@ public struct OrbPreset: Equatable {
     public static let aurora = OrbPreset(
         styleID: 7,
         isAnimated: true,
+        flowResponse: 8.83,
         uniforms: makeSeed(
             speed: 3.0,
             radius: 0.94,
@@ -368,14 +395,17 @@ public struct OrbPreset: Equatable {
     public static let chrome = OrbPreset(
         styleID: 8,
         isAnimated: true,
+        flowResponse: 38.64,
         uniforms: makeSeed(
             speed: 2.0,
             radius: 0.94,
             zoom: 0.36,
             warp: 3.8,
             ridgeAmt: 0.44,
-            sharp: 5.2,
-            shade: 0.58,
+            // Softened from sharp 5.2 / shade 0.58: the hard black-and-white
+            // break was the harshest edge in the set at this size.
+            sharp: 3.6,
+            shade: 0.44,
             shellEdgeAlpha: 1.0,
             exposure: 1.08,
             styleFlowIndex: 12.0,
@@ -394,6 +424,7 @@ public struct OrbPreset: Equatable {
     public static let spectrum = OrbPreset(
         styleID: 9,
         isAnimated: true,
+        flowResponse: 60.16,
         uniforms: makeSeed(
             speed: 1.8,
             radius: 0.94,
@@ -404,6 +435,11 @@ public struct OrbPreset: Equatable {
             sheen: 0.26,
             gloss: 0.24,
             shellEdgeAlpha: 1.0,
+            // Deliberately left on makeSeed's default flow index of 9.0, the
+            // Siri band shader. It looks like an oversight next to the unused
+            // spectrum fluid at index 14, but index 14 renders a far plainer
+            // band and this preset's whole appeal is the spectral palette
+            // running through the Siri wave. Do not "fix" this.
             glassOpacity: 1.0,
             contourDeform: 0.03,
             colorA: "#FFFFFF",
@@ -420,6 +456,7 @@ public struct OrbPreset: Equatable {
     public static let staticSiri = OrbPreset(
         styleID: 10,
         isAnimated: false,
+        flowResponse: 50.72,
         uniforms: makeSeed(
             speed: 0.0,
             radius: 0.94,

--- a/Type4MeTests/LiquidGlassVisualTests.swift
+++ b/Type4MeTests/LiquidGlassVisualTests.swift
@@ -104,6 +104,381 @@ final class LiquidGlassVisualTests: XCTestCase {
         XCTAssertEqual(reduceMotion, LiquidGlassMotion.staticFallback)
     }
 
+    // MARK: - OrbSpeechEnvelope Tests
+
+    /// Drives the envelope at 60fps for `seconds` at a constant meter level.
+    private func run(
+        _ envelope: inout OrbSpeechEnvelope,
+        level: Float,
+        seconds: Float,
+        motionScale: Float = 1.0
+    ) {
+        let dt: Float = 1.0 / 60.0
+        var elapsed: Float = 0
+        while elapsed < seconds {
+            envelope.advance(rawLevel: level, deltaTime: dt, motionScale: motionScale)
+            elapsed += dt
+        }
+    }
+
+    func testEnvelope_twoSecondsOfSilenceProducesNoReactionOnlySlowDrift() {
+        var envelope = OrbSpeechEnvelope()
+        run(&envelope, level: 0.0, seconds: 2.0)
+
+        XCTAssertEqual(envelope.activity, 0)
+        XCTAssertEqual(envelope.transient, 0)
+        XCTAssertEqual(envelope.liveness, 0)
+        XCTAssertEqual(envelope.idleBlend, 1)
+        // Alive, but only just: the field drifts, nothing reacts.
+        XCTAssertEqual(envelope.phaseVelocity, OrbSpeechEnvelope.idlePhaseVelocity)
+        XCTAssertEqual(envelope.phase, 2.0 * OrbSpeechEnvelope.idlePhaseVelocity,
+                       accuracy: 0.02)
+    }
+
+    func testEnvelope_speakingFlowsFarFasterThanResting() {
+        var resting = OrbSpeechEnvelope()
+        run(&resting, level: 0.0, seconds: 1.0)
+
+        var speaking = OrbSpeechEnvelope()
+        run(&speaking, level: 0.02, seconds: 0.5)
+        run(&speaking, level: 0.8, seconds: 1.0)
+
+        XCTAssertGreaterThan(speaking.phaseVelocity, resting.phaseVelocity * 6)
+    }
+
+    func testEnvelope_steadyRoomNoiseNeverWakesTheOrb() {
+        // A fan sitting well above the old fixed 0.15 gate.
+        var envelope = OrbSpeechEnvelope()
+        run(&envelope, level: 0.22, seconds: 3.0)
+
+        XCTAssertFalse(envelope.isGateOpen)
+        XCTAssertEqual(envelope.activity, 0)
+        XCTAssertEqual(envelope.liveness, 0)
+    }
+
+    func testEnvelope_flowRespondsFastWhilePoseEasesIn() {
+        var envelope = OrbSpeechEnvelope()
+        run(&envelope, level: 0.02, seconds: 0.5) // quiet room first
+        run(&envelope, level: 0.6, seconds: 0.15)
+
+        // Flow speed is the immediate response: a change of rate reads as
+        // smooth no matter how fast it arrives.
+        XCTAssertTrue(envelope.isGateOpen)
+        XCTAssertGreaterThan(envelope.phaseVelocity,
+                             OrbSpeechEnvelope.idlePhaseVelocity * 5)
+
+        // The pose is deliberately still on its way up at this point — that is
+        // what keeps the start of a phrase from snapping.
+        XCTAssertGreaterThan(envelope.liveness, 0.25)
+        XCTAssertLessThan(envelope.liveness, 0.9)
+
+        run(&envelope, level: 0.6, seconds: 0.3)
+        XCTAssertGreaterThan(envelope.liveness, 0.85, "and fully arrived by ~450ms")
+    }
+
+    func testEnvelope_aVeryQuietSoundCannotFlashTheOrb() {
+        var envelope = OrbSpeechEnvelope()
+        run(&envelope, level: 0.02, seconds: 0.6)
+
+        // A faint, fluttering sound just above the gate.
+        let dt: Float = 1.0 / 60.0
+        var t: Float = 0
+        var peakPunch: Float = 0
+        var peakSwing: Float = 0
+        var previous: Float = 0
+        while t < 2.0 {
+            let level: Float = (Int(t / 0.11) % 2 == 0) ? 0.16 : 0.05
+            envelope.advance(rawLevel: level, deltaTime: dt, motionScale: 1.0)
+            peakPunch = max(peakPunch, envelope.punch)
+            peakSwing = max(peakSwing, abs(envelope.punch - previous) / dt)
+            previous = envelope.punch
+            t += dt
+        }
+
+        // `punch` is what drives scale, exposure and outline. Near zero here
+        // means a weak voice produces flow, never a flash.
+        XCTAssertLessThan(peakPunch, 0.10)
+        XCTAssertLessThan(peakSwing, 1.0)
+    }
+
+    func testEnvelope_loudSpeechDrivesHarderThanQuietSpeech() {
+        var quiet = OrbSpeechEnvelope()
+        run(&quiet, level: 0.02, seconds: 0.5)
+        run(&quiet, level: 0.22, seconds: 0.6)
+
+        var loud = OrbSpeechEnvelope()
+        run(&loud, level: 0.02, seconds: 0.5)
+        run(&loud, level: 0.85, seconds: 0.6)
+
+        XCTAssertGreaterThan(quiet.activity, 0, "a soft voice must still register")
+        XCTAssertGreaterThan(loud.activity, quiet.activity)
+        XCTAssertGreaterThan(loud.transient, quiet.transient)
+        XCTAssertGreaterThan(loud.phaseVelocity, quiet.phaseVelocity)
+    }
+
+    func testEnvelope_sustainedSoftSpeechDoesNotBecomeRoomNoise() {
+        var envelope = OrbSpeechEnvelope()
+        run(&envelope, level: 0.02, seconds: 0.5)
+        run(&envelope, level: 0.22, seconds: 6.0)
+
+        XCTAssertTrue(envelope.isGateOpen)
+        XCTAssertGreaterThan(envelope.activity, 0)
+        XCTAssertGreaterThan(envelope.liveness, 0)
+        XCTAssertLessThan(envelope.noiseFloor, envelope.closeThreshold)
+    }
+
+    func testEnvelope_shortPauseInsideASentenceDoesNotDropTheOrb() {
+        var envelope = OrbSpeechEnvelope()
+        run(&envelope, level: 0.02, seconds: 0.5)
+        run(&envelope, level: 0.7, seconds: 0.5)
+        let speaking = envelope.activity
+
+        run(&envelope, level: 0.0, seconds: 0.12) // gap between words
+
+        XCTAssertGreaterThan(envelope.activity, speaking * 0.9)
+        XCTAssertGreaterThan(envelope.liveness, 0.97)
+    }
+
+    func testEnvelope_settlesBackToRestWithinHalfASecondOfSilence() {
+        var envelope = OrbSpeechEnvelope()
+        run(&envelope, level: 0.02, seconds: 0.5)
+        run(&envelope, level: 0.7, seconds: 1.0)
+        XCTAssertGreaterThan(envelope.liveness, 0.97)
+
+        run(&envelope, level: 0.0, seconds: 0.6)
+
+        // Motion stops promptly...
+        XCTAssertEqual(envelope.activity, 0)
+        XCTAssertEqual(envelope.phaseVelocity, OrbSpeechEnvelope.idlePhaseVelocity,
+                       accuracy: 0.02, "settled orbs drift, they do not react")
+        XCTAssertEqual(envelope.punch, 0)
+
+        // ...while the pose keeps easing back for a beat longer, which is what
+        // makes the orb look like it is relaxing rather than being switched off.
+        XCTAssertGreaterThan(envelope.liveness, 0)
+        run(&envelope, level: 0.0, seconds: 0.9)
+        XCTAssertEqual(envelope.liveness, 0)
+    }
+
+    func testEnvelope_gateUsesHysteresisSoBorderlineLevelsDoNotChatter() {
+        var envelope = OrbSpeechEnvelope()
+        run(&envelope, level: 0.02, seconds: 0.5)
+        XCTAssertGreaterThan(envelope.openThreshold, envelope.closeThreshold)
+
+        run(&envelope, level: envelope.openThreshold + 0.01, seconds: 0.2)
+        XCTAssertTrue(envelope.isGateOpen)
+
+        // Between the two thresholds the gate must stay open.
+        run(&envelope, level: envelope.closeThreshold + 0.005, seconds: 0.2)
+        XCTAssertTrue(envelope.isGateOpen)
+    }
+
+    func testEnvelope_resetReturnsToTheRestingState() {
+        var envelope = OrbSpeechEnvelope()
+        run(&envelope, level: 0.8, seconds: 0.5)
+        envelope.reset()
+
+        XCTAssertEqual(envelope.activity, 0)
+        XCTAssertEqual(envelope.transient, 0)
+        XCTAssertFalse(envelope.isGateOpen)
+        XCTAssertEqual(envelope.liveness, 0)
+    }
+
+    // MARK: - OrbUniformShaping Tests
+
+    func testUniformShaping_restingPoseIsCircularAndCalmerThanTheLivePose() {
+        let base = RecordingVisualStyle.siri.preset.uniforms
+        var envelope = OrbSpeechEnvelope()
+        run(&envelope, level: 0.0, seconds: 1.0)
+
+        let rest = OrbUniformShaping.shape(
+            base: base,
+            envelope: envelope,
+            drawableWidth: 180,
+            drawableHeight: 180,
+            isAnimated: true
+        )
+
+        XCTAssertEqual(rest[OrbUniformShaping.contourDeform],
+                       base[OrbUniformShaping.contourDeform]
+                           + OrbUniformShaping.restContourDeform,
+                       accuracy: 0.0001, "a silent orb is organic, not reactive")
+        XCTAssertEqual(
+            rest[OrbUniformShaping.radius],
+            base[OrbUniformShaping.radius] * OrbUniformShaping.restRadiusScale,
+            accuracy: 0.0001, "no scale pulse without a voice"
+        )
+
+        // The resting orb must keep the preset's own field parameters. Winding
+        // them down collapses `lqRamp` onto its middle two palette stops, which
+        // reads as the orb going dim and muddy instead of calm.
+        XCTAssertEqual(rest[OrbUniformShaping.warp], base[OrbUniformShaping.warp],
+                       accuracy: 0.0001)
+        XCTAssertEqual(rest[OrbUniformShaping.ridgeAmt], base[OrbUniformShaping.ridgeAmt],
+                       accuracy: 0.0001)
+        XCTAssertEqual(rest[OrbUniformShaping.exposure], base[OrbUniformShaping.exposure],
+                       accuracy: 0.0001, "resting must never be darker than the preset")
+
+        run(&envelope, level: 0.8, seconds: 0.6)
+        let live = OrbUniformShaping.shape(
+            base: base,
+            envelope: envelope,
+            drawableWidth: 180,
+            drawableHeight: 180,
+            isAnimated: true
+        )
+
+        XCTAssertGreaterThan(live[OrbUniformShaping.warp], rest[OrbUniformShaping.warp])
+        XCTAssertGreaterThan(live[OrbUniformShaping.exposure], rest[OrbUniformShaping.exposure])
+        XCTAssertGreaterThan(live[OrbUniformShaping.contourDeform], 0)
+        XCTAssertGreaterThan(live[OrbUniformShaping.radius], rest[OrbUniformShaping.radius])
+        XCTAssertGreaterThan(live[OrbUniformShaping.time], 0)
+    }
+
+    func testUniformShaping_exposureLiftStaysRestrained() {
+        let base = RecordingVisualStyle.siri.preset.uniforms
+        var envelope = OrbSpeechEnvelope()
+        run(&envelope, level: 0.02, seconds: 0.5)
+        run(&envelope, level: 1.0, seconds: 1.0)
+
+        let live = OrbUniformShaping.shape(
+            base: base,
+            envelope: envelope,
+            drawableWidth: 180,
+            drawableHeight: 180,
+            isAnimated: true
+        )
+        let ratio = live[OrbUniformShaping.exposure] / base[OrbUniformShaping.exposure]
+        XCTAssertGreaterThan(ratio, 1.0)
+        XCTAssertLessThanOrEqual(ratio, 1.13, "the old +70% blew every preset to white")
+    }
+
+    func testUniformShaping_staticSurfacesKeepTheOriginalPose() {
+        let base = RecordingVisualStyle.staticGlass.preset.uniforms
+        var envelope = OrbSpeechEnvelope()
+        run(&envelope, level: 0.9, seconds: 1.0)
+
+        let shaped = OrbUniformShaping.shape(
+            base: base,
+            envelope: envelope,
+            drawableWidth: 180,
+            drawableHeight: 180,
+            isAnimated: false
+        )
+
+        XCTAssertEqual(shaped[OrbUniformShaping.time], 0)
+        for index in 0..<base.count {
+            switch index {
+            case OrbUniformShaping.sizeX, OrbUniformShaping.sizeY,
+                 OrbUniformShaping.time, OrbUniformShaping.edgeSoftness:
+                continue
+            default:
+                XCTAssertEqual(shaped[index], base[index], accuracy: 0.0001,
+                               "static preset uniform \(index) must be untouched")
+            }
+        }
+    }
+
+    func testUniformShaping_edgeSoftnessTightensAsResolutionRises() {
+        let coarse = OrbUniformShaping.edgeSoftness(
+            drawableMinDimension: 90, orbRadius: 0.94
+        )
+        let fine = OrbUniformShaping.edgeSoftness(
+            drawableMinDimension: 180, orbRadius: 0.94
+        )
+        XCTAssertLessThan(fine, coarse, "a denser drawable needs a narrower feather")
+        // Both must be dramatically crisper than the preset's own 0.15 mush.
+        XCTAssertLessThan(coarse, 0.03)
+        XCTAssertGreaterThan(fine, 0.002)
+    }
+
+    func testUniformShaping_motionScaleEqualisesMeasuredFlow() {
+        // A sluggish fluid must be driven harder than a lively one.
+        let sluggish = OrbUniformShaping.motionScale(flowResponse: 3.93)  // frost
+        let lively = OrbUniformShaping.motionScale(flowResponse: 50.72)   // siri
+        XCTAssertGreaterThan(sluggish, lively * 5)
+
+        // Perceived flow — response times scale — lands near the reference.
+        for style in RecordingVisualStyle.allCases where style.preset.isAnimated {
+            let preset = style.preset
+            let perceived = preset.flowResponse
+                * OrbUniformShaping.motionScale(flowResponse: preset.flowResponse)
+            XCTAssertEqual(perceived, OrbUniformShaping.referenceFlow,
+                           accuracy: OrbUniformShaping.referenceFlow * 0.15,
+                           "\(style.rawValue) flows off-pace")
+        }
+    }
+
+    func testOrbPresets_spectrumIntentionallySharesTheSiriBandShader() {
+        // Spectrum is the spectral palette running through the Siri wave. The
+        // unused spectrum fluid at index 14 renders a much plainer band, so
+        // this is a deliberate choice, not the oversight it looks like.
+        XCTAssertEqual(
+            RecordingVisualStyle.spectrum.preset.uniforms[OrbUniformShaping.styleFlowIndex],
+            9.0
+        )
+        XCTAssertNotEqual(
+            RecordingVisualStyle.spectrum.preset.uniforms,
+            RecordingVisualStyle.siri.preset.uniforms,
+            "it must still differ from siri everywhere else"
+        )
+    }
+
+    func testEnvelope_fastSpeechFlowsFasterThanASteadyToneAtTheSameVolume() {
+        let dt: Float = 1.0 / 60.0
+
+        var steady = OrbSpeechEnvelope()
+        run(&steady, level: 0.02, seconds: 0.5)
+        run(&steady, level: 0.7, seconds: 1.2)
+
+        var rapid = OrbSpeechEnvelope()
+        run(&rapid, level: 0.02, seconds: 0.5)
+        var t: Float = 0
+        while t < 1.2 {
+            // Same mean level, modulated at a syllable rate.
+            let level: Float = (Int(t / 0.09) % 2 == 0) ? 0.95 : 0.45
+            rapid.advance(rawLevel: level, deltaTime: dt, motionScale: 1.0)
+            t += dt
+        }
+
+        XCTAssertGreaterThan(rapid.flux, steady.flux * 3)
+        XCTAssertGreaterThan(rapid.phaseVelocity, steady.phaseVelocity)
+    }
+
+    func testEnvelope_fluxIsZeroWhenNobodyIsSpeaking() {
+        var envelope = OrbSpeechEnvelope()
+        run(&envelope, level: 0.0, seconds: 1.5)
+        XCTAssertEqual(envelope.flux, 0)
+    }
+
+    func testUniformShaping_everyAnimatedPresetIsUnreactiveAtRest() {
+        var envelope = OrbSpeechEnvelope()
+        run(&envelope, level: 0.0, seconds: 1.0)
+
+        for style in RecordingVisualStyle.allCases where style.preset.isAnimated {
+            let base = style.preset.uniforms
+            let rest = OrbUniformShaping.shape(
+                base: base,
+                envelope: envelope,
+                drawableWidth: 180,
+                drawableHeight: 180,
+                isAnimated: true
+            )
+            XCTAssertLessThanOrEqual(
+                rest[OrbUniformShaping.contourDeform],
+                base[OrbUniformShaping.contourDeform] + OrbUniformShaping.restContourDeform + 0.0001,
+                "\(style.rawValue) must not deform reactively at rest"
+            )
+            XCTAssertEqual(
+                rest[OrbUniformShaping.radius],
+                base[OrbUniformShaping.radius] * OrbUniformShaping.restRadiusScale,
+                accuracy: 0.0001, "\(style.rawValue) must not pulse at rest"
+            )
+            XCTAssertEqual(rest[OrbUniformShaping.speed], 1.0, accuracy: 0.0001,
+                           "\(style.rawValue) folds preset speed into the phase")
+        }
+    }
+
     // MARK: - DemoState Preview Segment Tests
 
     func testDemoState_makePreviewSegments_splitsConfirmedAndActive() {


### PR DESCRIPTION
## Summary

- drive the Metal recording orb from the live `AudioLevelMeter` instead of a stale SwiftUI float snapshot
- add an adaptive noise floor, hysteretic speech gate, separate activity/transient followers, and motion shaping so silence stays calm while speech responds per syllable
- improve the 45 pt orb with 2× supersampling, resolution-aware edge softness, and display-aware refresh/backing-scale updates
- normalize perceived motion across animated presets and refine the two harshest small-size presets without modifying the vendored Metal shader
- preserve the existing behavior for static presets and Reduce Motion

## Testing

- `swift test --filter LiquidGlassVisualTests` (28 tests, 0 failures)
- verified the isolated PR diff contains only the five recording-orb files and no ASR/session or floating-bar material changes

## Notes

`OrbMetalSource.swift` remains byte-for-byte unchanged. Speech reactivity and visual shaping are implemented through per-frame uniform updates.