### PR TITLE
Fix Meta Muse keyword length

### DIFF
--- a/Type4Me/Protocol/MetaMuseASRProtocol.swift
+++ b/Type4Me/Protocol/MetaMuseASRProtocol.swift
@@ -82,7 +82,7 @@ enum MetaMuseASRProtocol {
 
     static let defaultEndpoint = "wss://api.meta.ai/v1/asr/realtime"
     static let maxKeywordsCount = 100
-    static let maxKeywordLength = 100
+    static let maxKeywordLength = 20
 
     static func buildWebSocketURL(override: String? = nil, sessionId: String? = nil) throws -> URL {
         let base = override ?? defaultEndpoint

--- a/Type4MeTests/MetaMuseASRProtocolTests.swift
+++ b/Type4MeTests/MetaMuseASRProtocolTests.swift
@@ -29,8 +29,11 @@ final class MetaMuseASRProtocolTests: XCTestCase {
         XCTAssertEqual(sanitized, ["Type4Me", "Swift 6", "macOS"])
 
         let longWord = String(repeating: "a", count: 150)
-        let capped = MetaMuseASRProtocol.sanitizedKeywords(from: [longWord], maxLength: 50)
-        XCTAssertEqual(capped.first?.count, 50)
+        let defaultCapped = MetaMuseASRProtocol.sanitizedKeywords(from: [longWord])
+        XCTAssertEqual(defaultCapped.first?.count, 20)
+
+        let customCapped = MetaMuseASRProtocol.sanitizedKeywords(from: [longWord], maxLength: 50)
+        XCTAssertEqual(customCapped.first?.count, 50)
 
         let manyWords = (0..<120).map { "term_\($0)" }
         let limited = MetaMuseASRProtocol.sanitizedKeywords(from: manyWords, maxCount: 100)


### PR DESCRIPTION

<img width="642" height="367" alt="image" src="https://github.com/user-attachments/assets/1df5dfd8-7341-46c3-b1b8-fc1eb84bebc9" />

## Summary
- Cap Meta Muse ASR keywords at the service limit of 20 characters.
- Add regression coverage for the default keyword length.

## Verification
- MetaMuseASRProtocolTests: 11 passed
- swift build -c release: passed