### PR TITLE
fix: keep the light floating bar legible over dark host pages

### DIFF
--- a/Type4Me/UI/DesignSystem.swift
+++ b/Type4Me/UI/DesignSystem.swift
@@ -58,6 +58,16 @@ enum TF {
     /// makes the un-sampled first frames flash harder, and a tint inside the
     /// glass style cannot hold the theme either.
     static let glassDarkContrastFloor: Double = 0.52
+    /// Contrast floor beneath light Liquid Glass, mirroring
+    /// `glassDarkContrastFloor`. Native glass samples whatever sits behind the
+    /// panel, so over a dark host page (a dark-mode web app, a full-screen
+    /// editor) the light capsule renders dark while its near-black foreground
+    /// colours stay put and vanish. The floor keeps legibility independent of
+    /// the host application's background.
+    ///
+    /// The same placement rule as the dark floor applies: keep it beneath the
+    /// glass rather than above it or inside `Glass.tint`.
+    static let glassLightContrastFloor: Double = 0.68
     /// A translucent highlight that takes on the material beneath it instead of reading as a flat white rule.
     /// Only used by the macOS 14/15 fallback; native Liquid Glass draws its own rim.
     static let recordingGlassRim = LinearGradient(
@@ -196,6 +206,10 @@ enum TF {
 
     static let compactIndicatorActive = floatingControlLight
     static let compactIndicatorInactive = recordingTooltipBadge
+    /// Quiescent waveform dots on the light capsule. Kept heavier than the
+    /// original 0.18 so the idle track still reads against a glass surface that
+    /// the host page's backdrop has darkened.
+    static let compactIndicatorInactiveLight = Color.black.opacity(0.28)
 
     // MARK: Animation
 

--- a/Type4Me/UI/FloatingBar/CompactAudioIndicator.swift
+++ b/Type4Me/UI/FloatingBar/CompactAudioIndicator.swift
@@ -86,7 +86,7 @@ struct CompactAudioIndicator: View {
                 let totalColumns = Int(ceil((size.width + pitch) / pitch)) + 1
 
                 let activeColor = theme == .light ? TF.floatingTextLight : TF.compactIndicatorActive
-                let inactiveColor = theme == .light ? Color.black.opacity(0.18) : TF.compactIndicatorInactive
+                let inactiveColor = theme == .light ? TF.compactIndicatorInactiveLight : TF.compactIndicatorInactive
 
                 for i in 0..<totalColumns {
                     let x = rightEdge - CGFloat(i) * pitch

--- a/Type4Me/UI/FloatingBar/CorrectionLearningPanel.swift
+++ b/Type4Me/UI/FloatingBar/CorrectionLearningPanel.swift
@@ -34,7 +34,16 @@ private final class CorrectionLearningPanel: NSPanel {
         hidesOnDeactivate = false
         ignoresMouseEvents = false
         animationBehavior = .utilityWindow
-        appearance = NSAppearance(named: .darkAqua)
+        updateAppearance()
+    }
+
+    // Mirrors FloatingBarPanel's lookup rather than sharing one, so this file
+    // stays clear of the recording-theme refactor in flight on PR #288.
+    func updateAppearance() {
+        let themeRaw = UserDefaults.standard.string(forKey: RecordingTheme.storageKey)
+            ?? RecordingTheme.defaultValue.rawValue
+        let theme = RecordingTheme(rawValue: themeRaw) ?? .dark
+        appearance = theme == .light ? NSAppearance(named: .aqua) : NSAppearance(named: .darkAqua)
     }
 
     override var canBecomeKey: Bool { false }
@@ -83,6 +92,7 @@ final class CorrectionLearningPanelController {
         state.isPresented = true
         state.onLearn = onLearn
         state.onIgnore = onIgnore
+        panel.updateAppearance()
         panel.positionAboveFloatingBar()
         panel.alphaValue = 0
         panel.orderFrontRegardless()
@@ -156,6 +166,9 @@ final class CorrectionLearningPanelController {
 
 private struct CorrectionLearningCardView: View {
     @ObservedObject var state: CorrectionLearningPanelState
+    @AppStorage(RecordingTheme.storageKey) private var storedTheme = RecordingTheme.defaultValue
+
+    private var theme: RecordingTheme { storedTheme }
 
     var body: some View {
         ZStack {
@@ -207,12 +220,14 @@ private struct CorrectionLearningCardView: View {
                         Button(L("忽略 (\(state.remainingSeconds)s)", "Ignore (\(state.remainingSeconds)s)")) {
                             state.onIgnore?()
                         }
-                        .buttonStyle(CorrectionCardButtonStyle(isPrimary: false, fixedWidth: 96))
+                        .buttonStyle(
+                            CorrectionCardButtonStyle(isPrimary: false, theme: theme, fixedWidth: 96)
+                        )
 
                         Button(state.status == .saveFailed ? L("重试", "Retry") : L("添加", "Add")) {
                             state.onLearn?()
                         }
-                        .buttonStyle(CorrectionCardButtonStyle(isPrimary: true))
+                        .buttonStyle(CorrectionCardButtonStyle(isPrimary: true, theme: theme))
                     }
                     .frame(maxWidth: .infinity, alignment: .trailing)
                 }
@@ -223,13 +238,36 @@ private struct CorrectionLearningCardView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(
             RoundedRectangle(cornerRadius: 11, style: .continuous)
-                .fill(Color(red: 0.095, green: 0.095, blue: 0.095).opacity(0.98))
+                .fill(cardFill)
+                .overlay {
+                    // The dark card separates itself from any host window by
+                    // luminance alone; the light one needs a rim or it dissolves
+                    // into a white page underneath.
+                    if theme == .light {
+                        RoundedRectangle(cornerRadius: 11, style: .continuous)
+                            .strokeBorder(TF.floatingBorderLight, lineWidth: 0.5)
+                    }
+                }
         )
         .padding(6)
+        .environment(\.colorScheme, theme == .light ? .light : .dark)
     }
 
-    private let primaryText = Color(red: 1, green: 1, blue: 1)
-    private let secondaryText = Color(red: 138 / 255, green: 138 / 255, blue: 138 / 255)
+    private var cardFill: Color {
+        theme == .light
+            ? TF.floatingBackgroundLight.opacity(0.98)
+            : Color(red: 0.095, green: 0.095, blue: 0.095).opacity(0.98)
+    }
+
+    private var primaryText: Color {
+        theme == .light ? TF.floatingTextLight : Color(red: 1, green: 1, blue: 1)
+    }
+
+    private var secondaryText: Color {
+        theme == .light
+            ? TF.floatingTextSecondaryLight
+            : Color(red: 138 / 255, green: 138 / 255, blue: 138 / 255)
+    }
 
     @ViewBuilder
     private var animatedStatusIcon: some View {
@@ -270,22 +308,43 @@ private struct CorrectionLearningCardView: View {
 
 private struct CorrectionCardButtonStyle: ButtonStyle {
     let isPrimary: Bool
+    var theme: RecordingTheme = .dark
     var fixedWidth: CGFloat? = nil
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.system(size: 11, weight: .semibold))
-            .foregroundStyle(isPrimary ? Color.black : Color.white)
+            .foregroundStyle(labelColor)
             .padding(.horizontal, fixedWidth == nil ? 14 : 0)
             .frame(width: fixedWidth, height: 34)
             .background(
-                Capsule().fill(
-                    isPrimary
-                        ? Color(red: 251 / 255, green: 251 / 255, blue: 251 / 255)
-                            .opacity(configuration.isPressed ? 0.78 : 1)
-                        : Color(red: 51 / 255, green: 51 / 255, blue: 51 / 255)
-                            .opacity(configuration.isPressed ? 0.76 : 1)
-                )
+                Capsule().fill(fillColor(isPressed: configuration.isPressed))
             )
+    }
+
+    /// The primary button is the card's one high-contrast element, so it stays
+    /// inverted against the card fill in both themes.
+    private var labelColor: Color {
+        switch (theme, isPrimary) {
+        case (.dark, true): Color.black
+        case (.dark, false): Color.white
+        case (.light, true): Color.white
+        case (.light, false): TF.floatingTextLight
+        }
+    }
+
+    private func fillColor(isPressed: Bool) -> Color {
+        switch (theme, isPrimary) {
+        case (.dark, true):
+            TF.floatingControlLight.opacity(isPressed ? 0.78 : 1)
+        case (.dark, false):
+            TF.floatingControl.opacity(isPressed ? 0.76 : 1)
+        case (.light, true):
+            TF.floatingTextLight.opacity(isPressed ? 0.78 : 1)
+        // The light secondary fill is a wash over the card rather than an opaque
+        // capsule, so pressing has to deepen it instead of fading it out.
+        case (.light, false):
+            Color.black.opacity(isPressed ? 0.13 : 0.07)
+        }
     }
 }

--- a/Type4Me/UI/FloatingBar/FloatingBarView.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarView.swift
@@ -1425,7 +1425,7 @@ struct RecordingGlassSurface: View {
     let cornerRadius: CGFloat
     var theme: RecordingTheme = .dark
     /// Only consumed by the macOS 14/15 fallback; the native glass path uses
-    /// `TF.glassDarkContrastFloor` instead.
+    /// `TF.glassDarkContrastFloor` / `TF.glassLightContrastFloor` instead.
     let tintOpacity: Double
 
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
@@ -1439,7 +1439,11 @@ struct RecordingGlassSurface: View {
             shape.fill(theme == .light ? TF.floatingBackgroundLight : TF.floatingBackground)
         } else if #available(macOS 26.0, *) {
             ZStack {
-                shape.fill(theme == .dark ? Color.black.opacity(TF.glassDarkContrastFloor) : Color.clear)
+                shape.fill(
+                    theme == .dark
+                        ? Color.black.opacity(TF.glassDarkContrastFloor)
+                        : Color.white.opacity(TF.glassLightContrastFloor)
+                )
                 Color.clear.glassEffect(.regular, in: shape)
             }
             .id(theme)

--- a/Type4MeTests/AppearancePreviewTests.swift
+++ b/Type4MeTests/AppearancePreviewTests.swift
@@ -409,4 +409,16 @@ final class AppearancePreviewTests: XCTestCase {
         XCTAssertFalse(tab.subtitle.isEmpty)
         XCTAssertTrue(SettingsTab.allCases.contains(.appearance))
     }
+
+    // MARK: - Recording Glass Contrast
+
+    /// Native Liquid Glass samples the host application's backdrop, so a light
+    /// capsule over a dark page renders dark while its near-black foreground
+    /// colours stay put. Both themes must therefore carry a contrast floor.
+    func testGlassContrastFloors_areSetForBothThemes() {
+        XCTAssertGreaterThan(TF.glassLightContrastFloor, 0.5)
+        XCTAssertLessThan(TF.glassLightContrastFloor, 1.0)
+        XCTAssertGreaterThan(TF.glassDarkContrastFloor, 0.5)
+        XCTAssertLessThan(TF.glassDarkContrastFloor, 1.0)
+    }
 }


### PR DESCRIPTION
## Problem

With the **Light** recording theme, the floating bar becomes unreadable over a dark host page (a dark-mode web app, a full-screen editor). The capsule renders dark while its foreground colours stay near-black, so the live transcript and the waveform disappear.

## Cause

`RecordingGlassSurface` gives the dark theme a contrast floor but the light theme nothing:

```swift
shape.fill(theme == .dark ? Color.black.opacity(TF.glassDarkContrastFloor) : Color.clear)
Color.clear.glassEffect(.regular, in: shape)
```

Native Liquid Glass samples whatever sits behind the panel, so on a black page the light capsule is rendered dark — while `TF.floatingTextLight` (#1C1C1E) stays put.

The macOS 14/15 fallback in the same view was never affected: it applies `Color.white.opacity(tintOpacity)` with `tintOpacity` already at 0.68. The native glass path had simply dropped that tint.

## Changes

- Add `TF.glassLightContrastFloor` (0.68, matching the value the fallback path already used) and apply it in the macOS 26 path instead of `Color.clear`.
- Raise the light quiescent waveform dots from 18% to 28% black as `TF.compactIndicatorInactiveLight`; at 18% they were barely visible even on a correctly light surface.
- Make `CorrectionLearningPanel` follow the recording theme instead of pinning `.darkAqua`: theme-aware panel appearance, card fill, rim, text and button styles. It observes the theme via `@AppStorage`, so switching themes updates it without a relaunch. The light card gets a rim so it does not dissolve into a white page, and the light secondary button deepens on press rather than fading out.

Since v2.7.0 made `RecordingGlassSurface` internal for `ManualInputPanel`, that panel picks up the same fix.

## Notes

The panel repeats `FloatingBarPanel`'s defaults lookup rather than sharing one accessor. That keeps `RecordingTheme.swift` and `FloatingBarPanel.swift` untouched so this does not collide with the recording-theme rework in #288; the two can be unified once that lands.

## Testing

Full suite green (1106 tests, 0 failures). Verified to merge cleanly with #288.

Visual verification is the one thing worth a second pair of eyes: 0.68 is carried over from the fallback path, and native Liquid Glass may not read identically at the same value.