### PR TITLE
feat: let compact-style users hide the stop button

### DIFF
--- a/Type4Me/UI/AppState.swift
+++ b/Type4Me/UI/AppState.swift
@@ -54,6 +54,12 @@ enum AppearancePreferenceDefaults {
 
     static let showCancelButtonKey = "tf_showCancelButton"
     static let showCancelButtonDefault = true
+
+    /// The finish control: the stop square in the compact capsule, and the
+    /// tappable orb in the regular bar. Hiding it leaves the hotkey as the way
+    /// to end a recording.
+    static let showFinishButtonKey = "tf_showFinishButton"
+    static let showFinishButtonDefault = true
 }
 
 enum RecordingVisualStyle: String, CaseIterable {

--- a/Type4Me/UI/AppState.swift
+++ b/Type4Me/UI/AppState.swift
@@ -55,9 +55,11 @@ enum AppearancePreferenceDefaults {
     static let showCancelButtonKey = "tf_showCancelButton"
     static let showCancelButtonDefault = true
 
-    /// The finish control: the stop square in the compact capsule, and the
-    /// tappable orb in the regular bar. Hiding it leaves the hotkey as the way
-    /// to end a recording.
+    /// The compact capsule's stop square. Hiding it leaves the waveform on its
+    /// own and the hotkey as the way to end a recording.
+    ///
+    /// Compact only: the regular bar's finish control is the audio-metering orb,
+    /// which stays put.
     static let showFinishButtonKey = "tf_showFinishButton"
     static let showFinishButtonDefault = true
 }

--- a/Type4Me/UI/DesignSystem.swift
+++ b/Type4Me/UI/DesignSystem.swift
@@ -158,31 +158,15 @@ enum TF {
     )
     // Fixed control chrome. FloatingBarView adds the text inset for the
     // actual trailing boundary: the visible cancel circle or the capsule edge.
-    //
-    // Either control can be hidden from Settings, so the width is summed from
-    // whichever ones are actually drawn rather than picked from a fixed pair.
-    static func recordingChromeWidth(
-        showsFinishButton: Bool,
-        showsCancelButton: Bool
-    ) -> CGFloat {
-        var width = recordingLeadingInset + recordingTrailingInset
-        if showsFinishButton {
-            width += recordingFinishControlSize + recordingControlGap
-        }
-        if showsCancelButton {
-            width += recordingCancelControlSize + recordingControlGap
-        }
-        return width
-    }
-
-    static let recordingChromeWidth: CGFloat = recordingChromeWidth(
-        showsFinishButton: true,
-        showsCancelButton: true
-    )
-    static let recordingSingleButtonChromeWidth: CGFloat = recordingChromeWidth(
-        showsFinishButton: true,
-        showsCancelButton: false
-    )
+    static let recordingChromeWidth: CGFloat = recordingFinishControlSize
+        + recordingCancelControlSize
+        + recordingLeadingInset
+        + recordingTrailingInset
+        + recordingControlGap * 2
+    static let recordingSingleButtonChromeWidth: CGFloat = recordingFinishControlSize
+        + recordingLeadingInset
+        + recordingTrailingInset
+        + recordingControlGap
 
     // MARK: Transcript Popup (hover preview above bar)
 
@@ -202,6 +186,9 @@ enum TF {
     static let compactTranscriptHorizontalInset: CGFloat = 8
     static let compactTranscriptLeadingFadeWidth: CGFloat = 10
     static let compactIndicatorControlVisualSize: CGFloat = 15
+    /// Width of a compact control's tap lane. The capsule is balanced only when
+    /// the lanes on both edges match, so hiding one control skews the waveform.
+    static let compactIndicatorControlWidth: CGFloat = 32
     static let compactIndicatorWaveBarWidth: CGFloat = 2
     static let compactIndicatorWaveMinHeight: CGFloat = 2
     static let compactIndicatorWaveMaxHeight: CGFloat = 18

--- a/Type4Me/UI/DesignSystem.swift
+++ b/Type4Me/UI/DesignSystem.swift
@@ -158,15 +158,31 @@ enum TF {
     )
     // Fixed control chrome. FloatingBarView adds the text inset for the
     // actual trailing boundary: the visible cancel circle or the capsule edge.
-    static let recordingChromeWidth: CGFloat = recordingFinishControlSize
-        + recordingCancelControlSize
-        + recordingLeadingInset
-        + recordingTrailingInset
-        + recordingControlGap * 2
-    static let recordingSingleButtonChromeWidth: CGFloat = recordingFinishControlSize
-        + recordingLeadingInset
-        + recordingTrailingInset
-        + recordingControlGap
+    //
+    // Either control can be hidden from Settings, so the width is summed from
+    // whichever ones are actually drawn rather than picked from a fixed pair.
+    static func recordingChromeWidth(
+        showsFinishButton: Bool,
+        showsCancelButton: Bool
+    ) -> CGFloat {
+        var width = recordingLeadingInset + recordingTrailingInset
+        if showsFinishButton {
+            width += recordingFinishControlSize + recordingControlGap
+        }
+        if showsCancelButton {
+            width += recordingCancelControlSize + recordingControlGap
+        }
+        return width
+    }
+
+    static let recordingChromeWidth: CGFloat = recordingChromeWidth(
+        showsFinishButton: true,
+        showsCancelButton: true
+    )
+    static let recordingSingleButtonChromeWidth: CGFloat = recordingChromeWidth(
+        showsFinishButton: true,
+        showsCancelButton: false
+    )
 
     // MARK: Transcript Popup (hover preview above bar)
 

--- a/Type4Me/UI/FloatingBar/FloatingBarView.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarView.swift
@@ -200,23 +200,20 @@ struct FloatingBarView<S: FloatingBarState>: View {
         presentationOverride?.showsCancelButton ?? showCancelButton
     }
 
-    private var effectiveShowsFinishButton: Bool {
+    /// Compact only. The regular bar's finish control is the `LiquidGlassOrb`,
+    /// which is also that style's only audio-level feedback while recording, so
+    /// it is never hidden. The compact capsule draws its waveform separately.
+    private var effectiveShowsCompactFinishButton: Bool {
         presentationOverride?.showsFinishButton ?? showFinishButton
     }
 
     private var currentRecordingChromeWidth: CGFloat {
-        TF.recordingChromeWidth(
-            showsFinishButton: effectiveShowsFinishButton,
-            showsCancelButton: effectiveShowsCancelButton
-        ) + recordingTextTrailingInset
+        (effectiveShowsCancelButton ? TF.recordingChromeWidth : TF.recordingSingleButtonChromeWidth)
+            + recordingTextTrailingInset
     }
 
     private var recordingTextTrailingInset: CGFloat {
-        // The compensation below exists only to balance the orb against the
-        // cancel circle, so it applies only while both are actually drawn.
-        guard effectiveShowsCancelButton, effectiveShowsFinishButton else {
-            return TF.recordingTextEdgeInset
-        }
+        guard effectiveShowsCancelButton else { return TF.recordingTextEdgeInset }
 
         // The orb sits inside its Metal frame; the cancel circle fills its
         // frame. Match the orb's transparent inset on the cancel side so the
@@ -622,9 +619,9 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
     private var compactRecordingControls: some View {
         HStack(spacing: 0) {
-            if effectiveShowsFinishButton {
+            if effectiveShowsCompactFinishButton {
                 compactRecordingButton(.finish)
-                    .frame(width: 32, height: TF.compactIndicatorHeight)
+                    .frame(width: TF.compactIndicatorControlWidth, height: TF.compactIndicatorHeight)
             } else {
                 Spacer().frame(width: TF.recordingEdgeInset)
             }
@@ -634,7 +631,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
             if effectiveShowsCancelButton {
                 compactRecordingButton(.cancel)
-                    .frame(width: 32, height: TF.compactIndicatorHeight)
+                    .frame(width: TF.compactIndicatorControlWidth, height: TF.compactIndicatorHeight)
             } else {
                 Spacer().frame(width: TF.recordingEdgeInset)
             }
@@ -794,9 +791,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
     private var recordingContent: some View {
         HStack(spacing: TF.recordingControlGap) {
-            if effectiveShowsFinishButton {
-                recordingButton(.finish)
-            }
+            recordingButton(.finish)
 
             recordingText
 

--- a/Type4Me/UI/FloatingBar/FloatingBarView.swift
+++ b/Type4Me/UI/FloatingBar/FloatingBarView.swift
@@ -98,6 +98,7 @@ struct FloatingBarPresentation: Equatable {
     var enablesHoverTranscriptPreview: Bool = true
     var showsTooltips: Bool = true
     var showsCancelButton: Bool = true
+    var showsFinishButton: Bool = true
     var showsModeName: Bool = RecordingMetadataDisplayPreference.showModeNameDefault
     var showsProviderName: Bool = RecordingMetadataDisplayPreference.showProviderNameDefault
     var showsModelName: Bool = RecordingMetadataDisplayPreference.showModelNameDefault
@@ -152,6 +153,7 @@ struct FloatingBarView<S: FloatingBarState>: View {
     @AppStorage("tf_hoverTranscriptPreview") private var hoverTranscriptPreview = true
     @AppStorage(AppearancePreferenceDefaults.showTooltipsKey) private var showTooltips = AppearancePreferenceDefaults.showTooltipsDefault
     @AppStorage(AppearancePreferenceDefaults.showCancelButtonKey) private var showCancelButton = AppearancePreferenceDefaults.showCancelButtonDefault
+    @AppStorage(AppearancePreferenceDefaults.showFinishButtonKey) private var showFinishButton = AppearancePreferenceDefaults.showFinishButtonDefault
     @AppStorage(RecordingVisualStyle.storageKey) private var visualStyle = RecordingVisualStyle.defaultValue
     @AppStorage(RecordingMetadataDisplayPreference.showModeNameKey)
     private var showModeName = RecordingMetadataDisplayPreference.showModeNameDefault
@@ -198,13 +200,23 @@ struct FloatingBarView<S: FloatingBarState>: View {
         presentationOverride?.showsCancelButton ?? showCancelButton
     }
 
+    private var effectiveShowsFinishButton: Bool {
+        presentationOverride?.showsFinishButton ?? showFinishButton
+    }
+
     private var currentRecordingChromeWidth: CGFloat {
-        (effectiveShowsCancelButton ? TF.recordingChromeWidth : TF.recordingSingleButtonChromeWidth)
-            + recordingTextTrailingInset
+        TF.recordingChromeWidth(
+            showsFinishButton: effectiveShowsFinishButton,
+            showsCancelButton: effectiveShowsCancelButton
+        ) + recordingTextTrailingInset
     }
 
     private var recordingTextTrailingInset: CGFloat {
-        guard effectiveShowsCancelButton else { return TF.recordingTextEdgeInset }
+        // The compensation below exists only to balance the orb against the
+        // cancel circle, so it applies only while both are actually drawn.
+        guard effectiveShowsCancelButton, effectiveShowsFinishButton else {
+            return TF.recordingTextEdgeInset
+        }
 
         // The orb sits inside its Metal frame; the cancel circle fills its
         // frame. Match the orb's transparent inset on the cancel side so the
@@ -610,8 +622,12 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
     private var compactRecordingControls: some View {
         HStack(spacing: 0) {
-            compactRecordingButton(.finish)
-                .frame(width: 32, height: TF.compactIndicatorHeight)
+            if effectiveShowsFinishButton {
+                compactRecordingButton(.finish)
+                    .frame(width: 32, height: TF.compactIndicatorHeight)
+            } else {
+                Spacer().frame(width: TF.recordingEdgeInset)
+            }
 
             CompactAudioIndicator(meter: state.audioLevel, theme: effectiveTheme)
                 .frame(maxWidth: .infinity, maxHeight: TF.compactIndicatorHeight)
@@ -778,7 +794,9 @@ struct FloatingBarView<S: FloatingBarState>: View {
 
     private var recordingContent: some View {
         HStack(spacing: TF.recordingControlGap) {
-            recordingButton(.finish)
+            if effectiveShowsFinishButton {
+                recordingButton(.finish)
+            }
 
             recordingText
 

--- a/Type4Me/UI/Settings/AppearanceSettingsTab.swift
+++ b/Type4Me/UI/Settings/AppearanceSettingsTab.swift
@@ -30,6 +30,9 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
     @AppStorage(AppearancePreferenceDefaults.showCancelButtonKey)
     private var showCancelButton = AppearancePreferenceDefaults.showCancelButtonDefault
 
+    @AppStorage(AppearancePreferenceDefaults.showFinishButtonKey)
+    private var showFinishButton = AppearancePreferenceDefaults.showFinishButtonDefault
+
     @AppStorage(RecordingMetadataDisplayPreference.showModeNameKey)
     private var showModeName = RecordingMetadataDisplayPreference.showModeNameDefault
 
@@ -68,6 +71,7 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
             enablesHoverTranscriptPreview: hoverTranscriptPreview,
             showsTooltips: showTooltips,
             showsCancelButton: showCancelButton,
+            showsFinishButton: showFinishButton,
             showsModeName: showModeName,
             showsProviderName: showProviderName,
             showsModelName: showModelName
@@ -135,6 +139,8 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
                     hoverPreviewRow
                 }
 
+                SettingsDivider()
+                showFinishButtonRow
                 SettingsDivider()
                 showCancelButtonRow
                 SettingsDivider()
@@ -216,6 +222,17 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
         settingsToggleRow(
             L("悬停文字预览", "Hover Text Preview"),
             isOn: $hoverTranscriptPreview
+        )
+    }
+
+    private var showFinishButtonRow: some View {
+        settingsToggleRow(
+            L("显示录制按钮", "Show Record Button"),
+            subtitle: L(
+                "关闭后隐藏录制按钮（常规样式下同时隐藏光球动效），仍可通过快捷键结束录制",
+                "Hide the record button (also hides the orb in Regular style); you can still finish recording with the hotkey"
+            ),
+            isOn: $showFinishButton
         )
     }
 

--- a/Type4Me/UI/Settings/AppearanceSettingsTab.swift
+++ b/Type4Me/UI/Settings/AppearanceSettingsTab.swift
@@ -139,8 +139,11 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
                     hoverPreviewRow
                 }
 
-                SettingsDivider()
-                showFinishButtonRow
+                if isCompact {
+                    SettingsDivider()
+                    showFinishButtonRow
+                }
+
                 SettingsDivider()
                 showCancelButtonRow
                 SettingsDivider()
@@ -229,8 +232,8 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
         settingsToggleRow(
             L("显示录制按钮", "Show Record Button"),
             subtitle: L(
-                "关闭后隐藏录制按钮（常规样式下同时隐藏光球动效），仍可通过快捷键结束录制",
-                "Hide the record button (also hides the orb in Regular style); you can still finish recording with the hotkey"
+                "关闭后隐藏停止按钮，音波居中显示，仍可通过快捷键结束录制",
+                "Hide the stop button and centre the waveform; you can still finish recording with the hotkey"
             ),
             isOn: $showFinishButton
         )

--- a/Type4MeTests/AppearancePreviewTests.swift
+++ b/Type4MeTests/AppearancePreviewTests.swift
@@ -86,28 +86,28 @@ final class AppearancePreviewTests: XCTestCase {
         XCTAssertTrue(presentation.showsCancelButton)
     }
 
-    /// Either control can now be hidden, so the chrome width is summed from the
-    /// ones actually drawn instead of chosen from a fixed pair of constants.
-    func testRecordingChromeWidth_summedFromVisibleControls() {
-        XCTAssertEqual(
-            TF.recordingChromeWidth(showsFinishButton: true, showsCancelButton: true),
-            TF.recordingChromeWidth
-        )
-        XCTAssertEqual(
-            TF.recordingChromeWidth(showsFinishButton: true, showsCancelButton: false),
-            TF.recordingSingleButtonChromeWidth
-        )
-        // Hiding the finish control drops exactly its size plus one gap.
-        XCTAssertEqual(
-            TF.recordingChromeWidth(showsFinishButton: true, showsCancelButton: true)
-                - TF.recordingChromeWidth(showsFinishButton: false, showsCancelButton: true),
-            TF.recordingFinishControlSize + TF.recordingControlGap
-        )
-        // With neither control only the capsule insets remain.
-        XCTAssertEqual(
-            TF.recordingChromeWidth(showsFinishButton: false, showsCancelButton: false),
-            TF.recordingLeadingInset + TF.recordingTrailingInset
-        )
+    /// The compact capsule is balanced only when the lanes on its two edges
+    /// match. With exactly one control visible the waveform sits off-centre —
+    /// which is the reason hiding the stop button exists, rather than saving
+    /// space. Regular is unaffected: its finish control is the metering orb and
+    /// is never hidden.
+    func testCompactWaveformIsCentredOnlyWhenBothEdgesMatch() {
+        func waveformCentreOffset(showsFinish: Bool, showsCancel: Bool) -> CGFloat {
+            let leading = showsFinish ? TF.compactIndicatorControlWidth : TF.recordingEdgeInset
+            let trailing = showsCancel ? TF.compactIndicatorControlWidth : TF.recordingEdgeInset
+            let waveform = TF.compactIndicatorWidth - leading - trailing
+            return (leading + waveform / 2) - TF.compactIndicatorWidth / 2
+        }
+
+        XCTAssertEqual(waveformCentreOffset(showsFinish: true, showsCancel: true), 0)
+        XCTAssertEqual(waveformCentreOffset(showsFinish: false, showsCancel: false), 0)
+
+        // Exactly one control skews the waveform by half the difference between
+        // a control lane and a bare edge inset.
+        let skew = (TF.compactIndicatorControlWidth - TF.recordingEdgeInset) / 2
+        XCTAssertEqual(waveformCentreOffset(showsFinish: true, showsCancel: false), skew)
+        XCTAssertEqual(waveformCentreOffset(showsFinish: false, showsCancel: true), -skew)
+        XCTAssertEqual(skew, 11)
     }
 
     func testRecordingMetadataDisplayPreferenceDefaults() {

--- a/Type4MeTests/AppearancePreviewTests.swift
+++ b/Type4MeTests/AppearancePreviewTests.swift
@@ -70,6 +70,46 @@ final class AppearancePreviewTests: XCTestCase {
         XCTAssertTrue(AppearancePreferenceDefaults.showCancelButtonDefault)
     }
 
+    // MARK: - Optional Record Button
+
+    func testShowFinishButtonPreferenceDefaults() {
+        XCTAssertEqual(AppearancePreferenceDefaults.showFinishButtonKey, "tf_showFinishButton")
+        // Existing users must keep the control until they opt out.
+        XCTAssertTrue(AppearancePreferenceDefaults.showFinishButtonDefault)
+        XCTAssertTrue(FloatingBarPresentation().showsFinishButton)
+    }
+
+    func testFinishAndCancelButtonsHideIndependently() {
+        var presentation = FloatingBarPresentation()
+        presentation.showsFinishButton = false
+        XCTAssertFalse(presentation.showsFinishButton)
+        XCTAssertTrue(presentation.showsCancelButton)
+    }
+
+    /// Either control can now be hidden, so the chrome width is summed from the
+    /// ones actually drawn instead of chosen from a fixed pair of constants.
+    func testRecordingChromeWidth_summedFromVisibleControls() {
+        XCTAssertEqual(
+            TF.recordingChromeWidth(showsFinishButton: true, showsCancelButton: true),
+            TF.recordingChromeWidth
+        )
+        XCTAssertEqual(
+            TF.recordingChromeWidth(showsFinishButton: true, showsCancelButton: false),
+            TF.recordingSingleButtonChromeWidth
+        )
+        // Hiding the finish control drops exactly its size plus one gap.
+        XCTAssertEqual(
+            TF.recordingChromeWidth(showsFinishButton: true, showsCancelButton: true)
+                - TF.recordingChromeWidth(showsFinishButton: false, showsCancelButton: true),
+            TF.recordingFinishControlSize + TF.recordingControlGap
+        )
+        // With neither control only the capsule insets remain.
+        XCTAssertEqual(
+            TF.recordingChromeWidth(showsFinishButton: false, showsCancelButton: false),
+            TF.recordingLeadingInset + TF.recordingTrailingInset
+        )
+    }
+
     func testRecordingMetadataDisplayPreferenceDefaults() {
         XCTAssertTrue(RecordingMetadataDisplayPreference.showModeNameDefault)
         XCTAssertFalse(RecordingMetadataDisplayPreference.showProviderNameDefault)


### PR DESCRIPTION
## Motivation

The compact capsule is a fixed 180pt with a 32pt control lane on each edge: the stop button on the left, the cancel button on the right. Hiding the cancel button does not leave 32pt on the right — that side collapses to `recordingEdgeInset` (10pt). The waveform becomes 138pt with its centre at 101pt against a capsule centre of 90pt, leaving it **11pt off-centre**.

The skew is a property of having *exactly one* control visible, in either direction. A hotkey user who doesn't want the cancel button has therefore had two choices: keep a button they never press purely to restore symmetry, or accept a lopsided waveform. This adds the missing third option — hiding both, for a symmetric 10 / 160 / 10 capsule with the waveform centred and at its widest.

## Scope: compact only

Regular style is deliberately excluded. Its finish control is the `LiquidGlassOrb`, which is also that style's only audio-level feedback while recording; hiding it would leave a static text capsule with no sign that input is still being captured. Compact does not have that problem, because its waveform is a separate element from the stop button. (See the discussion below — an earlier revision of this PR covered both styles.)

## Changes

- Add the `tf_showFinishButton` preference, defaulting to **on** so existing capsules are unchanged.
- Honour it in the compact capsule only: the stop button is replaced by an edge inset matching the other side.
- Add a **Show Record Button** row to Appearance settings, wrapped in `if isCompact` so it does not appear in Regular — following the existing `visualStyleRow` / `hoverPreviewRow` pattern. Chinese and English label and subtitle.
- Extract the compact control lane width, previously a literal in the view, into `TF.compactIndicatorControlWidth` so the balance property can be asserted.

Regular's layout maths is untouched: the original `recordingChromeWidth` / `recordingSingleButtonChromeWidth` pair still covers every permutation, and the orb/cancel centring compensation is unchanged.

## Testing

Full suite green (1108 tests, 0 failures), including a test pinning that the compact waveform is centred only when both edges match, and that exactly one visible control skews it by 11pt in the corresponding direction.

Settings row copy has no automated coverage, matching every other row in the tab — the labels are private computed properties of the view and are not reachable from tests.