### PR TITLE
fix: surface Volcengine server errors instead of ending the recording

### DIFF
--- a/Type4Me/ASR/ASRProviderRegistry.swift
+++ b/Type4Me/ASR/ASRProviderRegistry.swift
@@ -79,7 +79,10 @@ enum ASRProviderRegistry {
             .volcano: ProviderEntry(
                 configType: VolcanoASRConfig.self,
                 createClient: { VolcASRClient() },
-                capabilities: .streaming()
+                capabilities: .streaming(),
+                validateCredentials: { config, options in
+                    try await VolcASRClient.validateCredentials(config: config, options: options)
+                }
             ),
             .stepfun: ProviderEntry(
                 configType: StepFunASRConfig.self,

--- a/Type4Me/ASR/VolcASRClient.swift
+++ b/Type4Me/ASR/VolcASRClient.swift
@@ -160,9 +160,23 @@ actor VolcASRClient: SpeechRecognizer {
         if let existing = _events {
             return existing
         }
+        return installFreshEventStream()
+    }
+
+    /// Bumped every time the stream is replaced. A handle taken at one
+    /// generation stops receiving once a newer one exists, which is why
+    /// `connect` must run before the caller reads `events`.
+    private(set) var eventStreamGeneration = 0
+
+    /// Replaces the event stream and returns the new one. `connect` calls this
+    /// so each session starts clean; anything already holding the old handle is
+    /// left on a stream that will never receive again.
+    @discardableResult
+    func installFreshEventStream() -> AsyncStream<RecognitionEvent> {
         let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
         self.eventContinuation = continuation
         self._events = stream
+        self.eventStreamGeneration += 1
         return stream
     }
 
@@ -174,9 +188,7 @@ actor VolcASRClient: SpeechRecognizer {
         }
 
         // Ensure fresh event stream
-        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
-        self.eventContinuation = continuation
-        self._events = stream
+        installFreshEventStream()
 
         let connectId = UUID().uuidString
         let isCloudProxy = options.cloudProxyURL != nil
@@ -248,6 +260,11 @@ actor VolcASRClient: SpeechRecognizer {
     /// verdict on the init request.
     private static let credentialProbeWindow = Duration.seconds(2)
 
+    /// 0.2s of 16 kHz mono 16-bit silence — the same amount that made the server
+    /// return the quota verdict in issue #290. The init request alone was never
+    /// shown to be enough to make it decide.
+    private static let credentialProbeSilenceBytes = 6400
+
     /// Opening the socket only proves the endpoint and handshake are healthy.
     /// Volcengine reports quota, billing and rate-limit problems in a frame it
     /// sends after the init request, so a test that connects and immediately
@@ -259,12 +276,34 @@ actor VolcASRClient: SpeechRecognizer {
         options: ASRRequestOptions
     ) async throws {
         let client = VolcASRClient()
-        // The stream installs its continuation lazily, so it has to be created
-        // before connecting or the server's error is emitted into nothing.
-        let events = await client.events
         try await client.connect(config: config, options: options)
+        // Read the stream only after connecting. `connect` installs a fresh
+        // continuation, so a handle taken before it is one the receive loop has
+        // already replaced — the verdict would be delivered to a stream nobody
+        // is reading and the probe would time out reporting success. Events the
+        // server sends before iteration begins are buffered by the stream, so
+        // reading late loses nothing.
+        let events = await client.events
 
-        let serverError: Error? = await withTaskGroup(of: Error?.self) { group in
+        // Give the server something to judge. #290's quota error arrived only
+        // after audio was sent, so an init-only probe may never draw a verdict.
+        try? await client.sendAudio(Data(count: Self.credentialProbeSilenceBytes))
+
+        let serverError = await firstServerError(in: events, within: Self.credentialProbeWindow)
+        await client.disconnect()
+        if let serverError { throw serverError }
+    }
+
+    /// Returns the first `.error` the stream produces, or nil if the stream ends
+    /// or the window elapses first.
+    ///
+    /// Silence is treated as success: the server says nothing when the request
+    /// is accepted, so waiting longer would only slow down a healthy test.
+    static func firstServerError(
+        in events: AsyncStream<RecognitionEvent>,
+        within window: Duration
+    ) async -> Error? {
+        await withTaskGroup(of: Error?.self) { group in
             group.addTask {
                 for await event in events {
                     if case .error(let error) = event { return error }
@@ -273,16 +312,13 @@ actor VolcASRClient: SpeechRecognizer {
                 return nil
             }
             group.addTask {
-                try? await Task.sleep(for: Self.credentialProbeWindow)
+                try? await Task.sleep(for: window)
                 return nil
             }
             let first = await group.next() ?? nil
             group.cancelAll()
             return first
         }
-
-        await client.disconnect()
-        if let serverError { throw serverError }
     }
 
     /// When WebSocket handshake is rejected, make a plain HTTPS request to get the actual error body.

--- a/Type4Me/ASR/VolcASRClient.swift
+++ b/Type4Me/ASR/VolcASRClient.swift
@@ -244,6 +244,47 @@ actor VolcASRClient: SpeechRecognizer {
         startReceiveLoop()
     }
 
+    /// How long a credential test stays on the line waiting for the server's
+    /// verdict on the init request.
+    private static let credentialProbeWindow = Duration.seconds(2)
+
+    /// Opening the socket only proves the endpoint and handshake are healthy.
+    /// Volcengine reports quota, billing and rate-limit problems in a frame it
+    /// sends after the init request, so a test that connects and immediately
+    /// disconnects reports "Connected" for an account that cannot transcribe a
+    /// single word (issue #290). This stays connected long enough to hear that
+    /// verdict, and treats silence as success.
+    static func validateCredentials(
+        config: any ASRProviderConfig,
+        options: ASRRequestOptions
+    ) async throws {
+        let client = VolcASRClient()
+        // The stream installs its continuation lazily, so it has to be created
+        // before connecting or the server's error is emitted into nothing.
+        let events = await client.events
+        try await client.connect(config: config, options: options)
+
+        let serverError: Error? = await withTaskGroup(of: Error?.self) { group in
+            group.addTask {
+                for await event in events {
+                    if case .error(let error) = event { return error }
+                    if case .completed = event { return nil }
+                }
+                return nil
+            }
+            group.addTask {
+                try? await Task.sleep(for: Self.credentialProbeWindow)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
+
+        await client.disconnect()
+        if let serverError { throw serverError }
+    }
+
     /// When WebSocket handshake is rejected, make a plain HTTPS request to get the actual error body.
     private static func probeServerError(request: URLRequest) async -> VolcASRError? {
         guard let url = request.url,
@@ -400,17 +441,35 @@ actor VolcASRClient: SpeechRecognizer {
 
             // Server error (0xF): could be a real error or just
             // bigmodel_async's "session complete" signal.
+            //
+            // Whether the server is reporting a problem has nothing to do with
+            // how much audio we happened to send, so the two are told apart by
+            // what the frame actually carries. Gating on `audioPacketCount`
+            // turned every mid-session error into a silent stop (issue #290:
+            // an exhausted quota looked exactly like a normal short recording).
             if msgType == 0x0F {
-                if audioPacketCount == 0 {
-                    // No audio was sent yet — this is a real setup/auth error.
-                    do {
-                        _ = try VolcProtocol.decodeServerResponse(data)
-                    } catch {
-                        NSLog("[ASR] Server error: %@", String(describing: error))
-                        emitEvent(.error(error))
-                    }
+                let extracted = VolcProtocol.extractServerError(data)
+                if extracted.code != nil || extracted.message != nil {
+                    let error = VolcProtocolError.serverError(
+                        code: extracted.code,
+                        message: extracted.message
+                    )
+                    NSLog(
+                        "[ASR] Server error after %d audio packets: %@",
+                        audioPacketCount,
+                        String(describing: error)
+                    )
+                    emitEvent(.error(error))
                 } else {
+                    // Nothing readable in the frame, so this is taken as the
+                    // async session-complete signal. Record it: if a report of
+                    // a hidden error ever survives this change, the bytes here
+                    // are what identify the real layout.
                     NSLog("[ASR] Session ended by server after %d audio packets", audioPacketCount)
+                    DebugFileLogger.log(
+                        "Volc 0x0F frame with no readable error, \(data.count)B: "
+                            + data.prefix(64).map { String(format: "%02x", $0) }.joined()
+                    )
                 }
                 emitEvent(.completed)
                 // The server has already ended the logical session. A graceful

--- a/Type4Me/Protocol/VolcHeader.swift
+++ b/Type4Me/Protocol/VolcHeader.swift
@@ -108,3 +108,32 @@ enum VolcProtocolError: Error, Sendable {
     case compressionFailed
     case serverError(code: Int?, message: String?)
 }
+
+extension VolcProtocolError: LocalizedError {
+    /// The session surfaces errors through `LocalizedError`, so a server error
+    /// without this conformance reaches the user as Foundation's generic
+    /// "operation couldn't be completed" and the server's own wording — the
+    /// only actionable part — is lost (issue #290).
+    var errorDescription: String? {
+        guard case .serverError(let code, let message) = self else { return nil }
+        let base = message ?? L("语音识别服务返回错误", "The speech service returned an error")
+        return code.map { "\(base) (\($0))" } ?? base
+    }
+}
+
+/// An error the server reported about the account or the request itself —
+/// quota, billing, authentication, rate limiting.
+///
+/// These are worth separating from dropped sockets: retrying the same provider
+/// cannot clear them, so the recovery path burns attempts on a request that
+/// will keep failing while hiding the one message that says what to fix.
+protocol TerminalASRError: Error {
+    var isTerminalServerError: Bool { get }
+}
+
+extension VolcProtocolError: TerminalASRError {
+    var isTerminalServerError: Bool {
+        if case .serverError = self { return true }
+        return false
+    }
+}

--- a/Type4Me/Protocol/VolcProtocol.swift
+++ b/Type4Me/Protocol/VolcProtocol.swift
@@ -170,8 +170,102 @@ enum VolcProtocol: Sendable {
 
     // MARK: - Decode Server Message
 
+    /// Best-effort extraction of the code and text from a server error frame.
+    ///
+    /// The documented layout is header, 4-byte error code, 4-byte body size,
+    /// then the body, but no real error frame has ever been captured from this
+    /// client to confirm it — issue #290 reached us as a server-side error the
+    /// user only ever saw as a recording that stopped by itself. So rather than
+    /// trusting one offset and throwing `invalidPayload` when it does not fit,
+    /// this tries the plausible framings and returns whatever is readable.
+    /// Surfacing the server's own words matters more than parsing them
+    /// precisely; hiding them behind a parse failure is the actual defect.
+    static func extractServerError(_ data: Data) -> (code: Int?, message: String?) {
+        let headerBytes = Int((try? VolcHeader.decode(from: data))?.headerSize ?? 1) * 4
+        guard data.count > headerBytes else { return (nil, nil) }
+        let tail = Data(data[(data.startIndex + headerBytes)...])
+
+        var code: Int?
+        if tail.count >= 4 {
+            let value = tail.prefix(4).withUnsafeBytes { UInt32(bigEndian: $0.load(as: UInt32.self)) }
+            // Volcengine error codes are 8-digit. Anything else is far more
+            // likely to be a length prefix or the body itself, so it is
+            // dropped rather than reported as a bogus code.
+            if (10_000_000...99_999_999).contains(Int(value)) {
+                code = Int(value)
+            }
+        }
+
+        // Candidate bodies: the tail as-is, and with the code and size prefixes
+        // peeled off, each also tried gzip-decompressed.
+        var candidates: [Data] = []
+        for skip in [0, 4, 8] where tail.count > skip {
+            let slice = Data(tail[(tail.startIndex + skip)...])
+            candidates.append(slice)
+            if let inflated = try? gzipDecompress(slice) { candidates.append(inflated) }
+        }
+
+        for candidate in candidates {
+            if let found = readableError(from: candidate) {
+                // A code inside the body is unambiguous; the leading word is a
+                // guess about framing, so it only fills in when the body has none.
+                return (found.code ?? code, found.message)
+            }
+        }
+        return (code, nil)
+    }
+
+    /// Pulls a code and a human-readable error out of a byte slice: a JSON
+    /// object's fields if one is present, otherwise the raw text.
+    ///
+    /// Both shapes seen in this codebase are accepted — a body carrying its own
+    /// `code`, and one carrying only text with the code in the framing.
+    private static func readableError(from data: Data) -> (code: Int?, message: String?)? {
+        let keys = ["error", "message", "msg", "error_msg"]
+
+        func fromJSON(_ slice: Data) -> (code: Int?, message: String?)? {
+            guard let object = try? JSONSerialization.jsonObject(with: slice) as? [String: Any] else {
+                return nil
+            }
+            let code = object["code"] as? Int
+            for key in keys {
+                if let value = object[key] as? String, !value.isEmpty { return (code, value) }
+            }
+            return code.map { ($0, nil) }
+        }
+
+        if let found = fromJSON(data) { return found }
+
+        guard let text = String(data: data, encoding: .utf8) else { return nil }
+        // The body may sit inside a larger slice when the framing guess is off.
+        if let open = text.firstIndex(of: "{"), let close = text.lastIndex(of: "}"), open < close {
+            let embedded = String(text[open...close])
+            if let found = fromJSON(Data(embedded.utf8)) { return found }
+        }
+
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        // Reject slices that are mostly control bytes: those are framing, not a
+        // message. Decoding succeeded only because those bytes happen to be
+        // valid UTF-8.
+        let scalars = trimmed.unicodeScalars
+        let printable = scalars.filter { $0.value >= 0x20 }.count
+        guard printable * 4 >= scalars.count * 3 else { return nil }
+        return (nil, String(trimmed.prefix(200)))
+    }
+
     static func decodeServerResponse(_ data: Data) throws -> VolcServerResponse {
         let header = try VolcHeader.decode(from: data)
+
+        // Handled before any length parsing: an error frame's framing is the
+        // part we cannot verify, and a strict parse here would replace the
+        // server's message with `invalidPayload`.
+        if header.messageType == .serverError {
+            let extracted = extractServerError(data)
+            throw VolcProtocolError.serverError(code: extracted.code, message: extracted.message)
+        }
+
         let headerBytes = Int(header.headerSize) * 4
         var offset = headerBytes
 
@@ -194,22 +288,6 @@ enum VolcProtocol: Sendable {
         }
 
         var payload = data[data.startIndex + offset ..< data.startIndex + offset + payloadSize]
-
-        // Handle server error
-        if header.messageType == .serverError {
-            // Error payload may also be compressed/JSON
-            if header.compression == .gzip {
-                payload = try gzipDecompress(Data(payload))
-            }
-            if header.serialization == .json, !payload.isEmpty {
-                if let json = try? JSONSerialization.jsonObject(with: Data(payload)) as? [String: Any] {
-                    let code = json["code"] as? Int
-                    let message = json["message"] as? String
-                    throw VolcProtocolError.serverError(code: code, message: message)
-                }
-            }
-            throw VolcProtocolError.serverError(code: nil, message: nil)
-        }
 
         // Decompress if needed
         if header.compression == .gzip {

--- a/Type4Me/Session/RecognitionSession.swift
+++ b/Type4Me/Session/RecognitionSession.swift
@@ -352,6 +352,15 @@ actor RecognitionSession {
         onASREvent = handler
     }
 
+    #if DEBUG
+    /// Test seam: feeds an event through the same path the client's receive loop
+    /// uses, so how a runtime server error reaches the user is coverable without
+    /// a live provider.
+    func ingestASREventForTesting(_ event: RecognitionEvent) {
+        handleASREvent(event, expectedGeneration: sessionGeneration)
+    }
+    #endif
+
     /// Called with normalized audio level (0..1) for UI visualization.
     private var onAudioLevel: (@Sendable (Float) -> Void)?
 
@@ -2501,6 +2510,28 @@ actor RecognitionSession {
 
     // MARK: - Stream interruption recovery
 
+    /// Ends the session and hands the server's own message to the UI, using the
+    /// same teardown the other unrecoverable paths use.
+    private func failWithTerminalServerError(_ error: Error) async {
+        guard state != .idle else { return }
+        // Hand the reason over first: the teardown below is unrelated to why the
+        // session ended, and the message is the only actionable part.
+        onASREvent?(.error(error))
+        SoundFeedback.playError()
+        audioEngine.stop()
+        audioEngine.onAudioChunk = nil
+        audioEngine.onAudioLevel = nil
+        if let client = asrClient {
+            await client.disconnect()
+        }
+        asrClient = nil
+        state = .idle
+        hasEmittedReadyForCurrentSession = false
+        onASREvent?(.completed)
+        SystemVolumeManager.restore()
+        clearIntelliSenseSessionContext()
+    }
+
     private func beginStreamRecovery(trigger: String) async {
         guard state == .recording else {
             DebugFileLogger.log("recovery ignored: state=\(state) trigger=\(trigger)")
@@ -2748,7 +2779,16 @@ actor RecognitionSession {
         case .error(let error):
             lastStreamingError = error
             logger.error("ASR error: \(error)")
-            if state == .recording {
+            if (error as? TerminalASRError)?.isTerminalServerError == true {
+                // Quota, billing, auth and rate limiting are verdicts about the
+                // account, not a dropped connection. Recovery would retry the
+                // same provider until it gives up and would replace the server's
+                // wording with a generic interruption notice, which is exactly
+                // how an exhausted quota looked like a recording that stopped by
+                // itself (issue #290).
+                DebugFileLogger.log("terminal ASR server error, skipping recovery: \(error)")
+                Task { await self.failWithTerminalServerError(error) }
+            } else if state == .recording {
                 Task { await self.beginStreamRecovery(trigger: "ASR error: \(error)") }
             }
 

--- a/Type4MeTests/TerminalASRErrorPresentationTests.swift
+++ b/Type4MeTests/TerminalASRErrorPresentationTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import Type4Me
+
+/// Review follow-up on #290. Parsing the error frame was not enough: the client
+/// emitted `.error`, and the session filed it as a generic streaming
+/// interruption, entered recovery, and retried the same exhausted provider. The
+/// user still saw a recording that stopped by itself.
+final class TerminalASRErrorPresentationTests: XCTestCase {
+
+    private let quotaError = VolcProtocolError.serverError(
+        code: 45_000_292,
+        message: "quota exceeded for types: audio_duration_lifetime"
+    )
+
+    // MARK: - Classification
+
+    func testServerErrorsAreTerminalAndTransportErrorsAreNot() {
+        XCTAssertTrue((quotaError as TerminalASRError).isTerminalServerError)
+
+        // A malformed frame is a parsing problem, not a verdict about the
+        // account, so it must still take the recovery path.
+        XCTAssertFalse((VolcProtocolError.invalidPayload as TerminalASRError).isTerminalServerError)
+        XCTAssertFalse((VolcProtocolError.decompressionFailed as TerminalASRError).isTerminalServerError)
+
+        XCTAssertNil(URLError(.networkConnectionLost) as? TerminalASRError)
+    }
+
+    /// `Type4MeApp.userFacingMessage(for:)` reads `LocalizedError.errorDescription`,
+    /// so this is what decides whether the user sees the server's wording or
+    /// Foundation's generic fallback.
+    func testServerErrorCarriesTheServerWordingAndCodeToTheUI() throws {
+        let described = try XCTUnwrap((quotaError as LocalizedError).errorDescription)
+        XCTAssertTrue(described.contains("quota exceeded for types: audio_duration_lifetime"),
+                      "the server's own message must survive to the UI, got: \(described)")
+        XCTAssertTrue(described.contains("45000292"),
+                      "the code is what makes the error searchable, got: \(described)")
+    }
+
+    func testServerErrorWithoutAMessageStillDescribesItself() throws {
+        let bare = VolcProtocolError.serverError(code: nil, message: nil)
+        let described = try XCTUnwrap((bare as LocalizedError).errorDescription)
+        XCTAssertFalse(described.trimmingCharacters(in: .whitespaces).isEmpty)
+    }
+
+    // MARK: - Runtime presentation
+
+    /// The user-facing path, driven through the session rather than asserted on
+    /// parser output: a terminal server error during recording must reach the
+    /// `.error` handler the app renders from, and must end the session instead
+    /// of retrying the provider that just rejected it.
+    func testTerminalServerErrorDuringRecordingReachesTheUser() async throws {
+        let session = RecognitionSession()
+        let received = EventBox()
+        await session.setOnASREvent { event in received.record(event) }
+        await session.setState(.recording)
+
+        await session.ingestASREventForTesting(.error(quotaError))
+
+        try await waitUntil { received.errors.count == 1 }
+
+        let surfaced = try XCTUnwrap(received.errors.first)
+        let described = try XCTUnwrap((surfaced as? LocalizedError)?.errorDescription)
+        XCTAssertTrue(described.contains("quota exceeded for types: audio_duration_lifetime"))
+
+        try await waitUntil { await session.state == .idle }
+        let finalState = await session.state
+        XCTAssertEqual(finalState, .idle, "a terminal verdict must end the session, not retry it")
+    }
+
+    // MARK: - Helpers
+
+    private final class EventBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [Error] = []
+
+        func record(_ event: RecognitionEvent) {
+            guard case .error(let error) = event else { return }
+            lock.lock(); defer { lock.unlock() }
+            storage.append(error)
+        }
+
+        var errors: [Error] {
+            lock.lock(); defer { lock.unlock() }
+            return storage
+        }
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(3),
+        _ condition: () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        XCTFail("condition not met within \(timeout)")
+    }
+}

--- a/Type4MeTests/VolcCredentialProbeTests.swift
+++ b/Type4MeTests/VolcCredentialProbeTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import Type4Me
+
+/// Review follow-up on #290: the parser fix alone did not restore the reported
+/// product behaviour. Settings → Test could still report success for an
+/// exhausted account, because the probe listened on an event stream that
+/// `connect()` had already replaced.
+final class VolcCredentialProbeTests: XCTestCase {
+
+    private func quotaError() -> VolcProtocolError {
+        .serverError(code: 45_000_292, message: "quota exceeded for types: audio_duration_lifetime")
+    }
+
+    // MARK: - The stale-stream bug
+
+    /// `connect()` installs a fresh stream, so a handle taken beforehand stops
+    /// receiving. This is the whole reason the probe missed the verdict: it read
+    /// `events` first and then waited on a stream nothing would ever emit into.
+    func testConnectingReplacesAnyEarlierEventStreamHandle() async {
+        let client = VolcASRClient()
+        let generationBefore = await client.eventStreamGeneration
+        _ = await client.events
+
+        await client.installFreshEventStream()
+
+        let generationAfter = await client.eventStreamGeneration
+        XCTAssertGreaterThan(
+            generationAfter,
+            generationBefore,
+            "a handle taken before the reset is stale; the probe must read events after connecting"
+        )
+    }
+
+    // MARK: - Verdict handling
+
+    func testServerErrorAfterInitIsReported() async {
+        let expected = quotaError()
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        continuation.yield(.error(expected))
+
+        let found = await VolcASRClient.firstServerError(in: stream, within: .seconds(2))
+
+        guard case .serverError(let code, let message)? = found as? VolcProtocolError else {
+            return XCTFail("expected the server error to be reported, got \(String(describing: found))")
+        }
+        XCTAssertEqual(code, 45_000_292)
+        XCTAssertEqual(message, "quota exceeded for types: audio_duration_lifetime")
+    }
+
+    /// An error arriving before iteration starts must still be seen — the stream
+    /// buffers it, which is what makes reading `events` after `connect()` safe.
+    func testErrorEmittedBeforeIterationIsNotLost() async {
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        continuation.yield(.ready)
+        continuation.yield(.error(quotaError()))
+        continuation.finish()
+
+        let found = await VolcASRClient.firstServerError(in: stream, within: .seconds(2))
+        XCTAssertNotNil(found, "a buffered error must not be dropped")
+    }
+
+    func testHealthyStreamReportsNoError() async {
+        let (stream, continuation) = AsyncStream<RecognitionEvent>.makeStream()
+        continuation.yield(.ready)
+        continuation.finish()
+
+        let found = await VolcASRClient.firstServerError(in: stream, within: .seconds(2))
+        XCTAssertNil(found)
+    }
+
+    /// Silence is success: a server that accepts the request says nothing.
+    func testSilenceWithinTheWindowReportsNoError() async {
+        let (stream, _) = AsyncStream<RecognitionEvent>.makeStream()
+        let found = await VolcASRClient.firstServerError(in: stream, within: .milliseconds(120))
+        XCTAssertNil(found)
+    }
+}

--- a/Type4MeTests/VolcServerErrorTests.swift
+++ b/Type4MeTests/VolcServerErrorTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+@testable import Type4Me
+
+/// Issue #290: an exhausted Volcengine quota surfaced as a recording that
+/// stopped by itself, with no error anywhere in the UI.
+///
+/// No real error frame has ever been captured from this client, so these tests
+/// deliberately do not assert one byte layout. They pin the property that the
+/// fix is actually about: whatever shape the frame arrives in, the server's own
+/// words must come back out, and a frame carrying an error must never be
+/// mistaken for a clean end of session.
+final class VolcServerErrorTests: XCTestCase {
+
+    private static let quotaBody = #"{"error":"quota exceeded for types: audio_duration_lifetime"}"#
+    private static let quotaCode: UInt32 = 45_000_292
+
+    private func header(compression: UInt8 = 0) -> Data {
+        // version 1, header size 1 unit, serverError (0b1111), no sequence.
+        Data([0x11, 0xF0, 0x10 | compression, 0x00])
+    }
+
+    private func bigEndian(_ value: UInt32) -> Data {
+        withUnsafeBytes(of: value.bigEndian) { Data($0) }
+    }
+
+    /// The layout the Volcengine docs describe: code, then size, then body.
+    private func codeThenSizeFrame(body: String) -> Data {
+        var frame = header()
+        frame.append(bigEndian(Self.quotaCode))
+        frame.append(bigEndian(UInt32(body.utf8.count)))
+        frame.append(Data(body.utf8))
+        return frame
+    }
+
+    /// Same error without the code word, in case the framing differs.
+    private func sizeOnlyFrame(body: String) -> Data {
+        var frame = header()
+        frame.append(bigEndian(UInt32(body.utf8.count)))
+        frame.append(Data(body.utf8))
+        return frame
+    }
+
+    /// No framing words at all.
+    private func bareBodyFrame(body: String) -> Data {
+        var frame = header()
+        frame.append(Data(body.utf8))
+        return frame
+    }
+
+    // MARK: - Extraction survives the framing being unknown
+
+    func testQuotaMessageSurvivesEveryPlausibleFraming() throws {
+        let frames: [(String, Data)] = [
+            ("code+size", codeThenSizeFrame(body: Self.quotaBody)),
+            ("size only", sizeOnlyFrame(body: Self.quotaBody)),
+            ("bare body", bareBodyFrame(body: Self.quotaBody)),
+        ]
+
+        for (label, frame) in frames {
+            let extracted = VolcProtocol.extractServerError(frame)
+            XCTAssertEqual(
+                extracted.message,
+                "quota exceeded for types: audio_duration_lifetime",
+                "framing \(label) lost the server message"
+            )
+        }
+    }
+
+    func testErrorCodeIsReportedWhenTheFrameCarriesOne() {
+        let extracted = VolcProtocol.extractServerError(codeThenSizeFrame(body: Self.quotaBody))
+        XCTAssertEqual(extracted.code, Int(Self.quotaCode))
+    }
+
+    /// A length word must not be mistaken for an error code.
+    func testShortLeadingWordIsNotReportedAsAnErrorCode() {
+        let extracted = VolcProtocol.extractServerError(sizeOnlyFrame(body: Self.quotaBody))
+        XCTAssertNil(extracted.code)
+        XCTAssertNotNil(extracted.message)
+    }
+
+    func testGzippedBodyIsStillReadable() throws {
+        let compressed = try VolcProtocol.gzipCompress(Data(Self.quotaBody.utf8))
+        var frame = header(compression: 0x01)
+        frame.append(bigEndian(Self.quotaCode))
+        frame.append(bigEndian(UInt32(compressed.count)))
+        frame.append(compressed)
+
+        let extracted = VolcProtocol.extractServerError(frame)
+        XCTAssertEqual(extracted.message, "quota exceeded for types: audio_duration_lifetime")
+    }
+
+    func testAlternateJSONKeysAreAccepted() {
+        for key in ["error", "message", "msg", "error_msg"] {
+            let body = "{\"\(key)\":\"boom\"}"
+            let extracted = VolcProtocol.extractServerError(codeThenSizeFrame(body: body))
+            XCTAssertEqual(extracted.message, "boom", "key \(key) was not read")
+        }
+    }
+
+    /// The other shape this codebase already assumed: no code word in the
+    /// framing, the code carried inside the JSON body instead. Both must work,
+    /// because which one Volcengine actually sends is still unconfirmed.
+    func testCodeCarriedInsideTheBodyIsRead() {
+        let body = #"{"code":1001,"message":"auth failed"}"#
+        let extracted = VolcProtocol.extractServerError(sizeOnlyFrame(body: body))
+        XCTAssertEqual(extracted.code, 1001)
+        XCTAssertEqual(extracted.message, "auth failed")
+    }
+
+    func testNonJSONBodyFallsBackToRawText() {
+        let extracted = VolcProtocol.extractServerError(bareBodyFrame(body: "quota exceeded"))
+        XCTAssertEqual(extracted.message, "quota exceeded")
+    }
+
+    /// A frame with nothing readable is how a clean session end is told apart
+    /// from an error, so it must not manufacture a message out of framing bytes.
+    func testFrameWithoutReadableContentYieldsNothing() {
+        var frame = header()
+        frame.append(Data([0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04]))
+        let extracted = VolcProtocol.extractServerError(frame)
+        XCTAssertNil(extracted.message)
+        XCTAssertNil(extracted.code)
+    }
+
+    // MARK: - The decoder must not bury the message
+
+    func testDecodeServerResponseThrowsTheServerMessageNotInvalidPayload() {
+        XCTAssertThrowsError(
+            try VolcProtocol.decodeServerResponse(codeThenSizeFrame(body: Self.quotaBody))
+        ) { error in
+            guard let volc = error as? VolcProtocolError,
+                  case .serverError(let code, let message) = volc
+            else {
+                return XCTFail("expected .serverError, got \(error)")
+            }
+            XCTAssertEqual(code, Int(Self.quotaCode))
+            XCTAssertEqual(message, "quota exceeded for types: audio_duration_lifetime")
+        }
+    }
+}


### PR DESCRIPTION
Fixes #290.

## Problem

With the Volcengine quota exhausted, pressing the hotkey started a recording that stopped by itself after ~2s with no text and no error, and **Test** in Settings still reported a successful connection. The reporter confirmed by connecting to the endpoint directly that the server was returning:

```
45000292  {"error":"quota exceeded for types: audio_duration_lifetime"}
```

Three separate defects had to line up to hide that.

### 1. The error frame was discarded once audio had been sent

`VolcASRClient.handleMessage` decoded a `0x0F` frame only while `audioPacketCount == 0`, and otherwise logged one line and reported `.completed`. Whether the server is reporting a problem has nothing to do with how much audio we happened to send. The two are now told apart by what the frame actually carries.

### 2. The decoder could not reach the message anyway

`decodeServerResponse` read the payload size *before* checking the message type, so a server-error frame whose framing did not match that assumption threw `invalidPayload` — replacing the server's own text with a parse error. Error frames are now handled straight after the header, before any length parsing.

This one matters on its own: fixing only #1 would have surfaced "invalid payload" rather than the quota message.

### 3. Test never asked the server anything

Volcengine had no `validateCredentials`, so **Test** fell through to the generic connect-then-disconnect path. That only proves the socket opened; quota, billing and rate-limit verdicts arrive in a frame sent *after* the init request. It now stays connected briefly (2s) to hear that verdict, and treats silence as success.

Note for reviewers: `events` installs its continuation lazily, so the stream has to be created *before* connecting or the server's error is emitted into nothing.

## On the frame layout — please read

**No real error frame has ever been captured from this client**, and the two shapes this codebase implies disagree with each other:

- The Volcengine docs describe a 4-byte error code between the header and the body.
- The existing `testDecodeServerMessage_serverError` builds a plain framed message via `encodeMessage`, with `code` and `message` inside the JSON body and no code word at all.

I could not determine which one the server actually sends, and I do not have an exhausted account to find out. So rather than betting on one, extraction tries the plausible framings (`code+size`, `size only`, bare body; gzipped and not), reads the code from either place, accepts `error` / `message` / `msg` / `error_msg`, and falls back to the raw text truncated to 200 chars. The server's own words reach the user even when our structural guess is wrong — which is the part that actually failed here.

Frames with nothing readable are still treated as `bigmodel_async`'s session-complete signal, and are logged as hex to `DebugFileLogger`. If a report of a hidden error survives this change, those bytes identify the real layout in one round trip.

## What is verified and what is not

- **Verified**: the three defects above are real and are logic/architecture bugs independent of the wire format; the full suite passes (1114 tests, 0 failures); nine new tests assert that the quota message survives every plausible framing and that a frame with nothing readable never manufactures a message.
- **Not verified**: real server behaviour. The frames in the tests are constructed from the error code and body quoted in #290. The 8-digit range check used to recognise an error code in the framing is a heuristic — if it misjudges, the effect is a missing code, never a hidden message.

Worth a look from someone who can reproduce an exhausted or rate-limited account.