### PR TITLE
fix: adopt window theme in selection ask panel

### DIFF
--- a/Type4Me/UI/SelectionAsk/SelectionAskController.swift
+++ b/Type4Me/UI/SelectionAsk/SelectionAskController.swift
@@ -190,6 +190,23 @@ final class SelectionAskPanel: NSPanel {
 }
 
 @MainActor
+private struct SelectionAskThemedRoot: View {
+    let content: SelectionAskView
+    let onThemeChange: @MainActor (SettingsTheme) -> Void
+
+    @AppStorage(SettingsTheme.storageKey)
+    private var themeRaw = SettingsTheme.defaultValue.rawValue
+
+    var body: some View {
+        content
+            .preferredColorScheme(SettingsTheme.resolve(themeRaw).colorScheme)
+            .onChange(of: themeRaw) { _, newValue in
+                onThemeChange(SettingsTheme.resolve(newValue))
+            }
+    }
+}
+
+@MainActor
 final class SelectionAskController {
     let coordinator: AskAnythingCoordinator
     private var state: SelectionAskState { coordinator.state }
@@ -227,7 +244,11 @@ final class SelectionAskController {
             onCancelFollowUp: onCancelFollowUp
         )
         let size = NSSize(width: 680, height: 560)
-        panel = SelectionAskPanel(contentRect: NSRect(origin: .zero, size: size))
+        let panel = SelectionAskPanel(contentRect: NSRect(origin: .zero, size: size))
+        panel.appearance = SettingsTheme.resolve(
+            UserDefaults.standard.string(forKey: SettingsTheme.storageKey) ?? SettingsTheme.defaultValue.rawValue
+        ).appearance
+        self.panel = panel
 
         let view = SelectionAskView(state: self.coordinator.state) { [weak self] in
             self?.close()
@@ -238,7 +259,11 @@ final class SelectionAskController {
         } onOpenInType4Me: { [weak self] in
             self?.openInType4Me()
         }
-        let hosting = NSHostingView(rootView: view)
+        let targetPanel = panel
+        let themedRoot = SelectionAskThemedRoot(content: view) { [weak targetPanel] theme in
+            targetPanel?.appearance = theme.appearance
+        }
+        let hosting = NSHostingView(rootView: themedRoot)
         hosting.frame = NSRect(origin: .zero, size: size)
         hosting.autoresizingMask = [.width, .height]
         panel.contentView = hosting

--- a/Type4Me/UI/Settings/AppearanceSettingsTab.swift
+++ b/Type4Me/UI/Settings/AppearanceSettingsTab.swift
@@ -84,10 +84,10 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            settingsGroupCard(L("设置窗口", "Settings Window"), icon: "paintpalette") {
+            settingsGroupCard(L("窗口外观", "Window Appearance"), icon: "paintpalette") {
                 settingsOptionRow(
                     L("窗口主题", "Window Theme"),
-                    subtitle: L("立即生效，录音浮条主题独立设置。", "Applies immediately. The recording bar has its own theme."),
+                    subtitle: L("应用于 Type4Me 窗口；录音浮条主题独立设置。", "Applies to Type4Me windows. The recording bar has its own theme."),
                     controlWidth: themeControlWidth
                 ) {
                     settingsInlineSegmentedPicker(

--- a/Type4Me/UI/Settings/AppearanceSettingsTab.swift
+++ b/Type4Me/UI/Settings/AppearanceSettingsTab.swift
@@ -51,8 +51,8 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
     @AppStorage("tf_language")
     private var language = AppLanguage.systemDefault
 
-    // Equal thirds, with enough room for “Follow System” in English.
-    private var themeSegmentWidth: CGFloat { language == AppLanguage.zh.rawValue ? 80 : 108 }
+    // Compact square-proportioned icon segments following Apple segmented button standards.
+    private let themeSegmentWidth: CGFloat = 40
     private var themeControlWidth: CGFloat { themeSegmentWidth * 3 + 8 }
 
     private var isCompact: Bool {
@@ -90,13 +90,13 @@ struct AppearanceSettingsTab: View, SettingsCardHelpers {
                     subtitle: L("应用于 Type4Me 窗口；录音浮条主题独立设置。", "Applies to Type4Me windows. The recording bar has its own theme."),
                     controlWidth: themeControlWidth
                 ) {
-                    settingsInlineSegmentedPicker(
+                    settingsInlineIconSegmentedPicker(
                         selection: Binding(
                             get: { SettingsTheme.resolve(settingsTheme).rawValue },
                             set: { settingsTheme = $0 }
                         ),
-                        options: [SettingsTheme.light, .system, .dark].map {
-                            ($0.rawValue, $0.displayName(language: AppLanguage(rawValue: language) ?? .en))
+                        options: [SettingsTheme.system, .light, .dark].map {
+                            ($0.rawValue, $0.iconName, $0.displayName(language: AppLanguage(rawValue: language) ?? .en))
                         },
                         segmentWidth: themeSegmentWidth
                     )

--- a/Type4Me/UI/Settings/SettingsCardHelpers.swift
+++ b/Type4Me/UI/Settings/SettingsCardHelpers.swift
@@ -645,6 +645,15 @@ extension SettingsCardHelpers {
         SettingsInlineSegmentedPicker(selection: selection, options: options, segmentWidth: segmentWidth)
     }
 
+    /// Compact Apple-style inline segmented picker with icons and tooltips.
+    func settingsInlineIconSegmentedPicker(
+        selection: Binding<String>,
+        options: [(value: String, icon: String, label: String)],
+        segmentWidth: CGFloat? = nil
+    ) -> some View {
+        SettingsInlineSegmentedPicker(selection: selection, iconOptions: options, segmentWidth: segmentWidth)
+    }
+
     func primaryButton(
         _ title: String,
         icon: String? = nil,
@@ -846,9 +855,41 @@ struct SettingsSecureInputField: View {
 
 /// Apple-grade inline segmented capsule picker with smooth matched-geometry sliding spring pill.
 struct SettingsInlineSegmentedPicker: View {
+    struct Option {
+        let value: String
+        let label: String
+        let icon: String?
+
+        init(value: String, label: String, icon: String? = nil) {
+            self.value = value
+            self.label = label
+            self.icon = icon
+        }
+    }
+
     @Binding var selection: String
-    let options: [(value: String, label: String)]
+    let options: [Option]
     var segmentWidth: CGFloat? = nil
+
+    init(
+        selection: Binding<String>,
+        options: [(value: String, label: String)],
+        segmentWidth: CGFloat? = nil
+    ) {
+        self._selection = selection
+        self.options = options.map { Option(value: $0.value, label: $0.label) }
+        self.segmentWidth = segmentWidth
+    }
+
+    init(
+        selection: Binding<String>,
+        iconOptions: [(value: String, icon: String, label: String)],
+        segmentWidth: CGFloat? = nil
+    ) {
+        self._selection = selection
+        self.options = iconOptions.map { Option(value: $0.value, label: $0.label, icon: $0.icon) }
+        self.segmentWidth = segmentWidth
+    }
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Namespace private var selectionNamespace
@@ -870,15 +911,26 @@ struct SettingsInlineSegmentedPicker: View {
                         }
                     }
                 } label: {
-                    Text(option.label)
-                        .font(.system(size: 11, weight: isSelected ? .semibold : .medium))
-                        .foregroundStyle(isSelected ? TF.settingsText : TF.settingsTextSecondary)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 5)
-                        .frame(width: segmentWidth)
-                        .contentShape(Rectangle())
+                    Group {
+                        if let icon = option.icon {
+                            Image(systemName: icon)
+                                .font(.system(size: 12, weight: isSelected ? .semibold : .medium))
+                                .frame(height: 14)
+                        } else {
+                            Text(option.label)
+                                .font(.system(size: 11, weight: isSelected ? .semibold : .medium))
+                        }
+                    }
+                    .foregroundStyle(isSelected ? TF.settingsText : TF.settingsTextSecondary)
+                    .padding(.horizontal, option.icon != nil ? 8 : 12)
+                    .padding(.vertical, 5)
+                    .frame(width: segmentWidth)
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(SettingsSegmentedButtonStyle())
+                .help(option.label)
+                .accessibilityLabel(option.label)
+                .accessibilityAddTraits(isSelected ? [.isSelected] : [])
                 .background {
                     ZStack {
                         if isSelected {

--- a/Type4Me/UI/Settings/SettingsCardHelpers.swift
+++ b/Type4Me/UI/Settings/SettingsCardHelpers.swift
@@ -928,7 +928,10 @@ struct SettingsInlineSegmentedPicker: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(SettingsSegmentedButtonStyle())
-                .help(option.label)
+                .settingsTooltip(
+                    option.label,
+                    isEnabled: option.icon != nil
+                )
                 .accessibilityLabel(option.label)
                 .accessibilityAddTraits(isSelected ? [.isSelected] : [])
                 .background {

--- a/Type4Me/UI/Settings/SettingsTheme.swift
+++ b/Type4Me/UI/Settings/SettingsTheme.swift
@@ -37,4 +37,12 @@ enum SettingsTheme: String, CaseIterable, Identifiable {
         case .dark: language == .zh ? "深色" : "Dark"
         }
     }
+
+    var iconName: String {
+        switch self {
+        case .system: "circle.lefthalf.filled"
+        case .light: "sun.max.fill"
+        case .dark: "moon.fill"
+        }
+    }
 }

--- a/Type4Me/UI/Settings/SettingsTheme.swift
+++ b/Type4Me/UI/Settings/SettingsTheme.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Settings-window appearance. RecordingTheme remains an independent preference.
+/// Appearance preference for standard Type4Me windows. RecordingTheme remains independent.
 enum SettingsTheme: String, CaseIterable, Identifiable {
     case system
     case light

--- a/Type4MeTests/SettingsThemeTests.swift
+++ b/Type4MeTests/SettingsThemeTests.swift
@@ -28,6 +28,16 @@ final class SettingsThemeTests: XCTestCase {
         XCTAssertEqual(savedValues.map(SettingsTheme.resolve), themes)
     }
 
+    func testThemeIconsAreDefinedAndAvailable() {
+        XCTAssertEqual(SettingsTheme.system.iconName, "circle.lefthalf.filled")
+        XCTAssertEqual(SettingsTheme.light.iconName, "sun.max.fill")
+        XCTAssertEqual(SettingsTheme.dark.iconName, "moon.fill")
+        for theme in SettingsTheme.allCases {
+            XCTAssertNotNil(NSImage(systemSymbolName: theme.iconName, accessibilityDescription: nil),
+                            "Icon symbol for \(theme.rawValue) must exist in system symbols")
+        }
+    }
+
     func testDarkSettingsTextAndSolidButtonContrast() {
         let surfaces = [TF.settingsWindowBackground, TF.settingsBg, TF.settingsCard,
                         TF.settingsCardAlt, TF.settingsSidebar, TF.settingsControl]


### PR DESCRIPTION
## Summary
The floating "Ask Anything" (`SelectionAskPanel`) window previously did not participate in Type4Me's Window Theme preference and instead followed the system appearance independently. This PR makes Window Theme consistently apply to standard Type4Me windows, including Settings and Ask Anything. It also upgrades the Window Appearance segmented picker to follow Apple Design principles with compact iconography and standard option ordering.

## Changes
- **Host boundary theming**: Introduce a private `SelectionAskThemedRoot` in `SelectionAskController.swift` that observes `@AppStorage(SettingsTheme.storageKey)` and applies `.preferredColorScheme(theme.colorScheme)`.
- **Initial panel appearance**: Set `panel.appearance` synchronously during controller initialization before loading the hosting view, ensuring correct colors on initial show without flashing.
- **Live updates & state retention**: Sync `panel.appearance` via a weak panel capture in the `.onChange` callback when `tf_settingsTheme` updates, without resetting the view hierarchy (`.id(...)` is not used), ensuring active conversations, scroll offsets, and selections are preserved.
- **Apple Design icon segmented picker**: Convert the Window Theme segmented control from text to Apple-standard SF Symbol icons (`circle.lefthalf.filled` for Follow System, `sun.max.fill` for Light, `moon.fill` for Dark) in logical order: **Follow System → Light → Dark**. Includes project-standard hover tooltips (`.settingsTooltip`), VoiceOver accessibility labels, and spring pill animations (`response: 0.28, dampingFraction: 0.82`).
- **Isolation & scope**: Window Theme applies to standard Type4Me windows, including Settings and the standalone Ask Anything panel. The floating recording indicator remains intentionally independent and continues to use its own `tf_recordingTheme` preference.
- **Copy refinement**: Update the appearance settings group title to "Window Appearance" (`窗口外观`) and subtitle to "Applies to Type4Me windows. The recording bar has its own theme." (`应用于 Type4Me 窗口；录音浮条主题独立设置。`).

## Validation
- `swift test --filter SettingsThemeTests` passed (6 tests, 0 failures), verifying icon definition, availability, and color contrast.
- `Type4Me Dev.app` packaged and launched via `scripts/dev-run.sh` (Build 283) with designated requirement and codesigning verified.
- Code review completed with 0 findings.