### PR TITLE
Localize TCC permission usage descriptions (English + zh-Hans)

### DIFF
--- a/Type4Me/Resources/en.lproj/InfoPlist.strings
+++ b/Type4Me/Resources/en.lproj/InfoPlist.strings
@@ -1,0 +1,7 @@
+/* Type4Me permission usage descriptions (English) */
+
+"NSMicrophoneUsageDescription" = "Type4Me needs microphone access to capture your voice for transcription.";
+
+"NSSpeechRecognitionUsageDescription" = "Type4Me needs speech recognition access to transcribe your voice into text.";
+
+"NSAppleEventsUsageDescription" = "Type4Me needs accessibility access to inject transcribed text into other apps.";

--- a/Type4Me/Resources/zh-Hans.lproj/InfoPlist.strings
+++ b/Type4Me/Resources/zh-Hans.lproj/InfoPlist.strings
@@ -1,0 +1,7 @@
+/* Type4Me 权限用途说明（简体中文） */
+
+"NSMicrophoneUsageDescription" = "Type4Me 需要访问麦克风以录制语音并将其转换为文本。";
+
+"NSSpeechRecognitionUsageDescription" = "Type4Me 需要语音识别权限以将你的语音转写为文字。";
+
+"NSAppleEventsUsageDescription" = "Type4Me 需要辅助功能权限来注入转写文字到其他应用";

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -29,9 +29,12 @@ APP_BUILD="${APP_BUILD:-1}"
 MIN_SYSTEM_VERSION="${MIN_SYSTEM_VERSION:-14.0}"
 VARIANT="${VARIANT:-cloud}"    # cloud or local
 ARCH="${ARCH:-universal}"      # arm64 or universal
-MICROPHONE_USAGE_DESCRIPTION="${MICROPHONE_USAGE_DESCRIPTION:-Type4Me 需要访问麦克风以录制语音并将其转换为文本。}"
-SPEECH_RECOGNITION_USAGE_DESCRIPTION="${SPEECH_RECOGNITION_USAGE_DESCRIPTION:-Type4Me 需要语音识别权限以将你的语音转写为文字。}"
-APPLE_EVENTS_USAGE_DESCRIPTION="${APPLE_EVENTS_USAGE_DESCRIPTION:-Type4Me 需要辅助功能权限来注入转写文字到其他应用}"
+# Base (development region: en) usage descriptions. zh-Hans overrides live in
+# Type4Me/Resources/zh-Hans.lproj/InfoPlist.strings; macOS shows the TCC prompt
+# in the user's system language.
+MICROPHONE_USAGE_DESCRIPTION="${MICROPHONE_USAGE_DESCRIPTION:-Type4Me needs microphone access to capture your voice for transcription.}"
+SPEECH_RECOGNITION_USAGE_DESCRIPTION="${SPEECH_RECOGNITION_USAGE_DESCRIPTION:-Type4Me needs speech recognition access to transcribe your voice into text.}"
+APPLE_EVENTS_USAGE_DESCRIPTION="${APPLE_EVENTS_USAGE_DESCRIPTION:-Type4Me needs accessibility access to inject transcribed text into other apps.}"
 INFO_PLIST="$APP_PATH/Contents/Info.plist"
 
 ENTITLEMENTS="$PROJECT_DIR/entitlements.plist"
@@ -193,6 +196,14 @@ cp "$PROJECT_DIR/Type4Me/Resources/Sounds/"*.wav "$APP_PATH/Contents/Resources/S
 
 mkdir -p "$APP_PATH/Contents/Resources/Icons"
 cp "$PROJECT_DIR/Type4Me/Resources/Icons/"*.png "$APP_PATH/Contents/Resources/Icons/" 2>/dev/null || true
+
+# Localized Info.plist overrides (TCC permission prompts shown by macOS).
+# Remove first so re-running over an existing bundle does not nest copies.
+for lproj_dir in "$PROJECT_DIR/Type4Me/Resources/"*.lproj; do
+    [ -d "$lproj_dir" ] || continue
+    rm -rf "$APP_PATH/Contents/Resources/$(basename "$lproj_dir")"
+    cp -R "$lproj_dir" "$APP_PATH/Contents/Resources/"
+done
 
 # --- Models and local ASR server (local variant only) ---
 if [ "$VARIANT" = "local" ]; then


### PR DESCRIPTION
## Problem

On a non-Chinese system, the macOS permission prompts show Chinese text, e.g.:

> Type4Me 需要访问麦克风以录制语音并将其转换为文本。

macOS renders the prompt body from the app's `NS*UsageDescription` values, and `scripts/package-app.sh` hardcodes Chinese defaults and regenerates the entire Info.plist at packaging time (the English strings in `Type4Me/Resources/Info.plist` never ship). The app UI is bilingual (`tf_language`), but the TCC strings have no English equivalent — CLAUDE.md marks Chinese and English as first-class product languages for all user-facing copy.

## Fix

- Base Info.plist usage descriptions now default to English (`CFBundleDevelopmentRegion` is already `en`), keeping the existing `*_USAGE_DESCRIPTION` env-var overrides.
- Adds `zh-Hans.lproj/InfoPlist.strings` (and an explicit `en.lproj`) with the three usage descriptions — `NSMicrophoneUsageDescription`, `NSSpeechRecognitionUsageDescription`, `NSAppleEventsUsageDescription`. The Chinese strings are verbatim the previous ones, so Chinese-system users see no change.
- `package-app.sh` copies `Type4Me/Resources/*.lproj` into `Contents/Resources/`, removing the target first so re-running over an existing bundle (the skip-resign path) doesn't nest copies.

macOS then selects the strings by system language: English systems get English prompts, Chinese systems get the same Chinese prompts as before, other languages fall back to English.

## Verification

- `plutil -lint` passes on both `.strings` files
- `bash -n` on the modified script
- Simulated the lproj copy loop twice against a pre-populated bundle: idempotent, no nesting
- Not verified: a full `build-dmg.sh` + notarized install (needs the release signing identity); happy to run it if useful

🤖 Generated with [Claude Code](https://claude.com/claude-code)