### PR TITLE
Fix Gemini hotword echoes on short recordings

### DIFF
--- a/Type4Me/ASR/GeminiASRClient.swift
+++ b/Type4Me/ASR/GeminiASRClient.swift
@@ -115,6 +115,7 @@ actor GeminiASRClient: SpeechRecognizer {
     private var didEmitFinal = false
     private var audioPayloadCount = 0
     private var connectDate: Date?
+    private var sessionHotwords: [String] = []
 
     var events: AsyncStream<RecognitionEvent> {
         if let existing = _events { return existing }
@@ -157,6 +158,7 @@ actor GeminiASRClient: SpeechRecognizer {
         self.didEmitFinal = false
         self.audioPayloadCount = 0
         self.connectDate = Date()
+        self.sessionHotwords = options.hotwords
 
         try await gate.waitUntilOpen(timeout: .seconds(5))
         startReceiveLoop()
@@ -237,6 +239,7 @@ actor GeminiASRClient: SpeechRecognizer {
         didEmitFinal = false
         audioPayloadCount = 0
         connectDate = nil
+        sessionHotwords = []
         logger.info("Gemini disconnected")
     }
 
@@ -299,7 +302,8 @@ actor GeminiASRClient: SpeechRecognizer {
             if let update = try GeminiTranscribeProtocol.makeTranscriptUpdate(
                 from: data,
                 confirmedSegments: confirmedSegments,
-                didEndAudio: didEndAudio
+                didEndAudio: didEndAudio,
+                hotwords: sessionHotwords
             ) {
                 if update.isSetupComplete {
                     Task { await connectionGate?.markSetupComplete() }
@@ -309,7 +313,13 @@ actor GeminiASRClient: SpeechRecognizer {
                 // Dedup before mutating state: applying `confirmedSegments`
                 // first would let an identical repeated final append twice
                 // while the transcript comparison below still saw a change.
-                guard update.transcript != lastTranscript else { return }
+                // An empty sanitized final may be identical to the initial
+                // transcript. It still has to pass through so stopRecording()
+                // receives the completion signal instead of waiting for a
+                // timeout.
+                guard update.transcript != lastTranscript
+                    || (update.transcript.isFinal && didEndAudio)
+                else { return }
                 confirmedSegments = update.confirmedSegments
                 lastTranscript = update.transcript
 

--- a/Type4Me/ASR/Qwen3HotwordLeakSanitizer.swift
+++ b/Type4Me/ASR/Qwen3HotwordLeakSanitizer.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum Qwen3HotwordLeakSanitizer {
+enum ASRHotwordLeakSanitizer {
     private struct PrefixMatch {
         let consumedText: String
         let remainder: String
@@ -29,10 +29,22 @@ enum Qwen3HotwordLeakSanitizer {
         let fallback = fallbackText.trimmingCharacters(in: .whitespacesAndNewlines)
         let (searchText, hadContextLabel) = droppingLeadingContextLabel(from: trimmedText)
         guard let match = bestPrefixMatch(in: searchText, hotwords: cleanedHotwords, hadContextLabel: hadContextLabel),
-              !match.remainder.isEmpty,
               shouldTreatAsLeak(match: match, fallbackText: fallback)
         else {
             return trimmedText
+        }
+
+        // With very short or silent audio, Qwen3 can return the entire hotword
+        // context as the transcription. There is no remainder in this case,
+        // so the normal "hotwords followed by real text" path cannot identify
+        // it. A context label is unambiguously a prompt echo; an unlabeled run
+        // of multiple hotwords is also a strong signal, while a single exact
+        // hotword is still allowed to be a legitimate utterance.
+        if match.remainder.isEmpty {
+            guard match.hadContextLabel || match.wordCount >= 2 else {
+                return trimmedText
+            }
+            return fallback
         }
 
         guard !fallback.isEmpty else { return match.remainder }
@@ -123,6 +135,10 @@ enum Qwen3HotwordLeakSanitizer {
     }
 
     private static func shouldTreatAsLeak(match: PrefixMatch, fallbackText: String) -> Bool {
+        if match.remainder.isEmpty {
+            return match.hadContextLabel || match.wordCount >= 2
+        }
+
         if match.hadContextLabel || match.wordCount >= 2 {
             return true
         }

--- a/Type4Me/ASR/SenseVoiceASRClient.swift
+++ b/Type4Me/ASR/SenseVoiceASRClient.swift
@@ -641,7 +641,7 @@ actor SenseVoiceASRClient: SpeechRecognizer {
             return nil
         }
 
-        let sanitizedText = Qwen3HotwordLeakSanitizer.sanitize(
+        let sanitizedText = ASRHotwordLeakSanitizer.sanitize(
             calibratedText,
             hotwords: calibrationHotwords,
             fallbackText: fallbackText

--- a/Type4Me/ASR/SenseVoiceWSClient.swift
+++ b/Type4Me/ASR/SenseVoiceWSClient.swift
@@ -152,7 +152,7 @@ actor SenseVoiceWSClient: SpeechRecognizer {
         guard let (data, _) = try? await URLSession.shared.data(for: request),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let text = json["text"] as? String, !text.isEmpty else { return nil }
-        let sanitizedText = Qwen3HotwordLeakSanitizer.sanitize(
+        let sanitizedText = ASRHotwordLeakSanitizer.sanitize(
             text,
             hotwords: HotwordStorage.loadEffective()
         )

--- a/Type4Me/Protocol/GeminiTranscribeProtocol.swift
+++ b/Type4Me/Protocol/GeminiTranscribeProtocol.swift
@@ -173,7 +173,8 @@ enum GeminiTranscribeProtocol {
     static func makeTranscriptUpdate(
         from data: Data,
         confirmedSegments: [String],
-        didEndAudio: Bool
+        didEndAudio: Bool,
+        hotwords: [String] = []
     ) throws -> GeminiTranscriptUpdate? {
         guard data.first == UInt8(ascii: "{") else { return nil }
 
@@ -227,9 +228,23 @@ enum GeminiTranscribeProtocol {
         // 1. Finalized input transcription (authoritative segment)
         if let finalText = serverContent.inputTranscription?.text {
             let trimmed = finalText.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { return nil }
+            let sanitized = ASRHotwordLeakSanitizer.sanitize(trimmed, hotwords: hotwords)
+            guard !sanitized.isEmpty else {
+                guard didEndAudio else { return nil }
+                let authoritative = confirmedSegments.joined()
+                return GeminiTranscriptUpdate(
+                    transcript: RecognitionTranscript(
+                        confirmedSegments: confirmedSegments,
+                        partialText: "",
+                        authoritativeText: authoritative,
+                        isFinal: true
+                    ),
+                    confirmedSegments: confirmedSegments,
+                    isSetupComplete: false
+                )
+            }
 
-            let normalized = normalize(segment: trimmed, after: confirmedSegments.joined())
+            let normalized = normalize(segment: sanitized, after: confirmedSegments.joined())
             var updatedConfirmed = confirmedSegments
             updatedConfirmed.append(normalized)
 
@@ -250,10 +265,11 @@ enum GeminiTranscribeProtocol {
         // 2. Interim input transcription (streaming partial)
         if let interimText = serverContent.interimInputTranscription?.text {
             let trimmed = interimText.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { return nil }
+            let sanitized = ASRHotwordLeakSanitizer.sanitize(trimmed, hotwords: hotwords)
+            guard !sanitized.isEmpty else { return nil }
 
             let confirmedJoined = confirmedSegments.joined()
-            let normalizedInterim = normalize(segment: trimmed, after: confirmedJoined)
+            let normalizedInterim = normalize(segment: sanitized, after: confirmedJoined)
 
             let transcript = RecognitionTranscript(
                 confirmedSegments: confirmedSegments,

--- a/Type4MeTests/GeminiTranscribeProtocolTests.swift
+++ b/Type4MeTests/GeminiTranscribeProtocolTests.swift
@@ -126,6 +126,44 @@ final class GeminiTranscribeProtocolTests: XCTestCase {
         XCTAssertFalse(unwrapped.transcript.isFinal)
     }
 
+    func testMakeTranscriptUpdate_dropsPureHotwordInterim() throws {
+        let json = #"{"serverContent": {"interimInputTranscription": {"text": "Type4Me Qwen Deepgram"}}}"#
+        let update = try GeminiTranscribeProtocol.makeTranscriptUpdate(
+            from: Data(json.utf8),
+            confirmedSegments: [],
+            didEndAudio: false,
+            hotwords: ["Type4Me", "Qwen", "Deepgram"]
+        )
+
+        XCTAssertNil(update)
+    }
+
+    func testMakeTranscriptUpdate_dropsPureHotwordFinalAndCompletes() throws {
+        let json = #"{"serverContent": {"inputTranscription": {"text": "Type4Me Qwen Deepgram"}}}"#
+        let update = try XCTUnwrap(try GeminiTranscribeProtocol.makeTranscriptUpdate(
+            from: Data(json.utf8),
+            confirmedSegments: [],
+            didEndAudio: true,
+            hotwords: ["Type4Me", "Qwen", "Deepgram"]
+        ))
+
+        XCTAssertTrue(update.transcript.isFinal)
+        XCTAssertEqual(update.transcript.displayText, "")
+        XCTAssertTrue(update.confirmedSegments.isEmpty)
+    }
+
+    func testMakeTranscriptUpdate_keepsSingleHotwordUtterance() throws {
+        let json = #"{"serverContent": {"interimInputTranscription": {"text": "Qwen"}}}"#
+        let update = try XCTUnwrap(try GeminiTranscribeProtocol.makeTranscriptUpdate(
+            from: Data(json.utf8),
+            confirmedSegments: [],
+            didEndAudio: false,
+            hotwords: ["Qwen"]
+        ))
+
+        XCTAssertEqual(update.transcript.displayText, "Qwen")
+    }
+
     func testMakeTranscriptUpdate_finalTranscriptionBeforeEndAudio() throws {
         let json = #"{"serverContent": {"inputTranscription": {"text": "Hello world"}}}"#
         let update = try GeminiTranscribeProtocol.makeTranscriptUpdate(

--- a/Type4MeTests/Qwen3HotwordLeakSanitizerTests.swift
+++ b/Type4MeTests/Qwen3HotwordLeakSanitizerTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class Qwen3HotwordLeakSanitizerTests: XCTestCase {
     func testStripsSingleChineseHotwordLeakWhenPreviewMatchesTail() {
-        let text = Qwen3HotwordLeakSanitizer.sanitize(
+        let text = ASRHotwordLeakSanitizer.sanitize(
             "一二三四三字",
             hotwords: ["一二三四"],
             fallbackText: "三字"
@@ -13,7 +13,7 @@ final class Qwen3HotwordLeakSanitizerTests: XCTestCase {
     }
 
     func testKeepsFullHotwordUtterance() {
-        let text = Qwen3HotwordLeakSanitizer.sanitize(
+        let text = ASRHotwordLeakSanitizer.sanitize(
             "一二三四",
             hotwords: ["一二三四"],
             fallbackText: "一二三四"
@@ -22,8 +22,45 @@ final class Qwen3HotwordLeakSanitizerTests: XCTestCase {
         XCTAssertEqual(text, "一二三四")
     }
 
+    func testStripsPureHotwordDumpWithoutContextLabel() {
+        let text = ASRHotwordLeakSanitizer.sanitize(
+            "Type4Me Qwen Deepgram",
+            hotwords: ["Type4Me", "Qwen", "Deepgram"]
+        )
+
+        XCTAssertEqual(text, "")
+    }
+
+    func testStripsPureLabeledHotwordDump() {
+        let text = ASRHotwordLeakSanitizer.sanitize(
+            "Vocabulary: Type4Me, Qwen, Deepgram",
+            hotwords: ["Type4Me", "Qwen", "Deepgram"]
+        )
+
+        XCTAssertEqual(text, "")
+    }
+
+    func testUsesFallbackForPureHotwordDump() {
+        let text = ASRHotwordLeakSanitizer.sanitize(
+            "Type4Me Qwen",
+            hotwords: ["Type4Me", "Qwen"],
+            fallbackText: "真实内容"
+        )
+
+        XCTAssertEqual(text, "真实内容")
+    }
+
+    func testKeepsSingleHotwordUtteranceWithoutFallback() {
+        let text = ASRHotwordLeakSanitizer.sanitize(
+            "Qwen",
+            hotwords: ["Qwen"]
+        )
+
+        XCTAssertEqual(text, "Qwen")
+    }
+
     func testKeepsHotwordCorrectionWhenPreviewAlreadyStartsWithHotword() {
-        let text = Qwen3HotwordLeakSanitizer.sanitize(
+        let text = ASRHotwordLeakSanitizer.sanitize(
             "张三今天开会",
             hotwords: ["张三"],
             fallbackText: "张三今天开会"
@@ -33,7 +70,7 @@ final class Qwen3HotwordLeakSanitizerTests: XCTestCase {
     }
 
     func testStripsLabeledHotwordDumpWithoutFallback() {
-        let text = Qwen3HotwordLeakSanitizer.sanitize(
+        let text = ASRHotwordLeakSanitizer.sanitize(
             "Vocabulary: OpenAI, Qwen, hello world",
             hotwords: ["OpenAI", "Qwen"]
         )
@@ -42,7 +79,7 @@ final class Qwen3HotwordLeakSanitizerTests: XCTestCase {
     }
 
     func testFallsBackWhenDumpTailDoesNotMatchPreview() {
-        let text = Qwen3HotwordLeakSanitizer.sanitize(
+        let text = ASRHotwordLeakSanitizer.sanitize(
             "Claude, OpenAI, unrelated",
             hotwords: ["Claude", "OpenAI"],
             fallbackText: "真实内容"
@@ -52,7 +89,7 @@ final class Qwen3HotwordLeakSanitizerTests: XCTestCase {
     }
 
     func testKeepsSingleHotwordPrefixWithoutFallback() {
-        let text = Qwen3HotwordLeakSanitizer.sanitize(
+        let text = ASRHotwordLeakSanitizer.sanitize(
             "一二三四三字",
             hotwords: ["一二三四"]
         )


### PR DESCRIPTION
## Summary
- suppress pure hotword/context echoes from Gemini interim transcription updates
- preserve legitimate single-hotword utterances and use the existing sanitizer for local Qwen3 paths
- allow an empty sanitized Gemini final to complete normally without a timeout

## Verification
- `swift test --filter GeminiTranscribeProtocolTests` (19 passed)
- `swift test --filter Qwen3HotwordLeakSanitizerTests` (10 passed)
- `swift build -c release` passed
